### PR TITLE
Set src to empty after detach

### DIFF
--- a/example/sample.ts
+++ b/example/sample.ts
@@ -258,6 +258,7 @@ window.toggleVideo = async () => {
   if (videoTrack) {
     appendLog('turning video off');
     currentRoom.localParticipant.unpublishTrack(videoTrack);
+    videoTrack.detach();
     videoTrack = undefined;
     const video = getMyVideo();
     if (video) video.remove();

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -249,6 +249,7 @@ class Room extends EventEmitter {
     this.emit(RoomEvent.ParticipantDisconnected, participant);
   }
 
+  // updates are sent only when there's a change to speaker ordering
   private handleSpeakerUpdate = (speakers: SpeakerInfo[]) => {
     const activeSpeakers: Participant[] = [];
     const seenSids: any = {};

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -116,6 +116,8 @@ function detachTrack(
   if (element.srcObject instanceof MediaStream) {
     const mediaStream = element.srcObject;
     mediaStream.removeTrack(track);
+    element.srcObject = null;
+    element.src = '';
   }
 }
 

--- a/src/room/track/TrackPublication.ts
+++ b/src/room/track/TrackPublication.ts
@@ -51,6 +51,10 @@ export default class TrackPublication extends EventEmitter {
     return this.metadataMuted;
   }
 
+  get isEnabled(): boolean {
+    return true;
+  }
+
   get isSubscribed(): boolean {
     return this.track !== undefined;
   }


### PR DESCRIPTION
In order to clean up Chrome's media players, srcObj/src needed to be set to empty. This will help keep memory usage down as well as avoid breakage when chrome [implements media player limits](https://chromium-review.googlesource.com/c/chromium/src/+/2816118) (again).