### PR TITLE
Use only h264 codec with profile-level-id=42e01f

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -345,11 +345,11 @@ export default class LocalParticipant extends Participant {
 
       // for h264 codecs that have sdpFmtpLine available, use only if the
       // profile-level-id is 42e01f for cross-browser compatibility
-      if (videoCodec === "h264" && c.sdpFmtpLine) {
-        return matchesVideoCodec && c.sdpFmtpLine.includes("profile-level-id=42e01f");
+      if (videoCodec === 'h264' && c.sdpFmtpLine) {
+        return matchesVideoCodec && c.sdpFmtpLine.includes('profile-level-id=42e01f');
       }
 
-      return matchesVideoCodec || codec === "audio/opus";
+      return matchesVideoCodec || codec === 'audio/opus';
     });
     if (selected && 'setCodecPreferences' in transceiver) {
       transceiver.setCodecPreferences([selected]);

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -339,10 +339,18 @@ export default class LocalParticipant extends Participant {
     }
     const cap = RTCRtpSender.getCapabilities(kind);
     if (!cap) return;
-    const selected = cap.codecs.find(
-      (c) => c.mimeType.toLowerCase() === `video/${videoCodec}`
-        || c.mimeType.toLowerCase() === 'audio/opus',
-    );
+    const selected = cap.codecs.find((c) => {
+      const codec = c.mimeType.toLowerCase();
+      const matchesVideoCodec = codec === `video/${videoCodec}`;
+
+      // for h264 codecs that have sdpFmtpLine available, use only if the
+      // profile-level-id is 42e01f for cross-browser compatibility
+      if (videoCodec === "h264" && c.sdpFmtpLine) {
+        return matchesVideoCodec && c.sdpFmtpLine.includes("profile-level-id=42e01f");
+      }
+
+      return matchesVideoCodec || codec === "audio/opus";
+    });
     if (selected && 'setCodecPreferences' in transceiver) {
       transceiver.setCodecPreferences([selected]);
     }


### PR DESCRIPTION
Improves cross-browser support for h264 simulcast by selecting the `42e01f` profile level id if `sdpFmtpLine` is available to check. The final return statement is the same behavior as before. #25