### PR TITLE
LocalParticipant: Set server track mute status based on local track

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -230,17 +230,15 @@ export default class LocalParticipant extends Participant {
   updateInfo(info: ParticipantInfo) {
     super.updateInfo(info);
 
-    // match local track mute status to server
+    // match server track mute status to local
     info.tracks.forEach((ti) => {
       const pub = <LocalTrackPublication> this.tracks.get(ti.sid);
       if (!pub) {
         return;
       }
 
-      if (ti.muted && !pub.isMuted) {
-        pub.mute();
-      } else if (!ti.muted && pub.isMuted) {
-        pub.unmute();
+      if (ti.muted !== pub.isMuted) {
+        this.engine.updateMuteStatus(ti.sid, pub.isMuted);
       }
     });
   }


### PR DESCRIPTION
Instead of changing the local track mute status when the server status
does not match, update the server's status to the local state. This
prevents a local track from getting unmuted without the user's action
when the states do not match.

Fixes #28