### PR TITLE
Use subscriber connection as primary

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "events": "^3.3.0",
     "loglevel": "^1.7.1",
     "protobufjs": "^6.10.2",
+    "ts-debounce": "^3.0.0",
     "webrtc-adapter": "^7.7.1"
   },
   "devDependencies": {

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -151,7 +151,7 @@ export class WSSignalClient {
               reject(new ConnectionError('Internal error'));
             }
           } catch (e) {
-            reject(new ConnectionError(e));
+            reject(new ConnectionError('server was not reachable'));
           }
           return;
         }

--- a/src/proto/livekit_rtc.ts
+++ b/src/proto/livekit_rtc.ts
@@ -155,6 +155,8 @@ export interface JoinResponse {
   otherParticipants: ParticipantInfo[];
   serverVersion: string;
   iceServers: ICEServer[];
+  /** use subscriber as the primary PeerConnection */
+  subscriberPrimary: boolean;
 }
 
 export interface TrackPublishedResponse {
@@ -1083,7 +1085,10 @@ export const SetSimulcastLayers = {
   },
 };
 
-const baseJoinResponse: object = { serverVersion: "" };
+const baseJoinResponse: object = {
+  serverVersion: "",
+  subscriberPrimary: false,
+};
 
 export const JoinResponse = {
   encode(
@@ -1107,6 +1112,9 @@ export const JoinResponse = {
     }
     for (const v of message.iceServers) {
       ICEServer.encode(v!, writer.uint32(42).fork()).ldelim();
+    }
+    if (message.subscriberPrimary === true) {
+      writer.uint32(48).bool(message.subscriberPrimary);
     }
     return writer;
   },
@@ -1136,6 +1144,9 @@ export const JoinResponse = {
           break;
         case 5:
           message.iceServers.push(ICEServer.decode(reader, reader.uint32()));
+          break;
+        case 6:
+          message.subscriberPrimary = reader.bool();
           break;
         default:
           reader.skipType(tag & 7);
@@ -1177,6 +1188,14 @@ export const JoinResponse = {
         message.iceServers.push(ICEServer.fromJSON(e));
       }
     }
+    if (
+      object.subscriberPrimary !== undefined &&
+      object.subscriberPrimary !== null
+    ) {
+      message.subscriberPrimary = Boolean(object.subscriberPrimary);
+    } else {
+      message.subscriberPrimary = false;
+    }
     return message;
   },
 
@@ -1204,6 +1223,8 @@ export const JoinResponse = {
     } else {
       obj.iceServers = [];
     }
+    message.subscriberPrimary !== undefined &&
+      (obj.subscriberPrimary = message.subscriberPrimary);
     return obj;
   },
 
@@ -1238,6 +1259,14 @@ export const JoinResponse = {
       for (const e of object.iceServers) {
         message.iceServers.push(ICEServer.fromPartial(e));
       }
+    }
+    if (
+      object.subscriberPrimary !== undefined &&
+      object.subscriberPrimary !== null
+    ) {
+      message.subscriberPrimary = object.subscriberPrimary;
+    } else {
+      message.subscriberPrimary = false;
     }
     return message;
   },

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -1,9 +1,17 @@
+import log from 'loglevel';
+import { debounce } from 'ts-debounce';
+
+/** @internal */
 export default class PCTransport {
   pc: RTCPeerConnection;
 
   pendingCandidates: RTCIceCandidateInit[] = [];
 
   restartingIce: boolean = false;
+
+  renegotiate: boolean = false;
+
+  onOffer?: (offer: RTCSessionDescriptionInit) => void;
 
   constructor(config?: RTCConfiguration) {
     this.pc = new RTCPeerConnection(config);
@@ -24,6 +32,45 @@ export default class PCTransport {
     });
     this.pendingCandidates = [];
     this.restartingIce = false;
+
+    if (this.renegotiate) {
+      this.renegotiate = false;
+      this.createAndSendOffer();
+    }
+  }
+
+  // debounced negotiate interface
+  negotiate = debounce(() => { this.createAndSendOffer(); }, 100);
+
+  async createAndSendOffer(options?: RTCOfferOptions) {
+    if (this.onOffer === undefined) {
+      return;
+    }
+
+    if (options?.iceRestart) {
+      log.debug('restarting ICE');
+      this.restartingIce = true;
+    }
+
+    if (this.pc.signalingState === 'have-local-offer') {
+      // we're waiting for the peer to accept our offer, so we'll just wait
+      // the only exception to this is when ICE restart is needed
+      const currentSD = this.pc.remoteDescription;
+      if (options?.iceRestart && currentSD) {
+        // TODO: handle when ICE restart is needed but we don't have a remote description
+        // the best thing to do is to recreate the peerconnection
+        await this.pc.setRemoteDescription(currentSD);
+      } else {
+        this.renegotiate = true;
+        return;
+      }
+    }
+
+    // actually negotiate
+    log.debug('starting to negotiate');
+    const offer = await this.pc.createOffer(options);
+    await this.pc.setLocalDescription(offer);
+    this.onOffer(offer);
   }
 
   close() {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -12,7 +12,7 @@ import {
 import LocalParticipant from './participant/LocalParticipant';
 import Participant from './participant/Participant';
 import RemoteParticipant from './participant/RemoteParticipant';
-import RTCEngine from './RTCEngine';
+import RTCEngine, { maxICEConnectTimeout } from './RTCEngine';
 import RemoteTrackPublication from './track/RemoteTrackPublication';
 import { Track } from './track/Track';
 import TrackPublication from './track/TrackPublication';
@@ -157,7 +157,7 @@ class Room extends EventEmitter {
         // timeout
         this.engine.close();
         reject(new ConnectionError('could not connect after timeout'));
-      }, 5 * 1000);
+      }, maxICEConnectTimeout);
 
       this.engine.once(EngineEvent.Connected, () => {
         clearTimeout(connectTimeout);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const version = '0.12.0';
-export const protocolVersion = 2;
+export const protocolVersion = 3;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4265,6 +4265,11 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
+ts-debounce@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ts-debounce/-/ts-debounce-3.0.0.tgz#9beedf59c04de3b5bef8ff28bd6885624df357be"
+  integrity sha512-7jiRWgN4/8IdvCxbIwnwg2W0bbYFBH6BxFqBjMKk442t7+liF2Z1H6AUCcl8e/pD93GjPru+axeiJwFmRww1WQ==
+
 ts-loader@^8.1.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.3.0.tgz#83360496d6f8004fab35825279132c93412edf33"


### PR DESCRIPTION
Implements client protocol version 3 - subscriber primary peer connections. Designed to reduce publisher connection load when the client is in read-only mode.

* rely on subscriber connection as the primary PeerConnection
* backwards compatible with previous server versions (and uses publisher as primary)
* receive data messages on subscriber PC