### PR TITLE
Still emit event even participant is null

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -368,13 +368,11 @@ class Room extends EventEmitter {
   ) => {
     // find the participant
     const participant = this.participants.get(userPacket.participantSid);
-    if (!participant) {
-      return;
-    }
+
     this.emit(RoomEvent.DataReceived, userPacket.payload, participant, kind);
 
     // also emit on the participant
-    participant.emit(ParticipantEvent.DataReceived, userPacket.payload, kind);
+    participant?.emit(ParticipantEvent.DataReceived, userPacket.payload, kind);
   };
 
   private handleAudioPlaybackStarted = () => {


### PR DESCRIPTION
userPacket.participantSid could be null for userPackets set by Server-API.

Would this work as intended or should we check against `userPacket.participantSid` ?