### PR TITLE
add room metadata handlers

### DIFF
--- a/src/proto/livekit_models.ts
+++ b/src/proto/livekit_models.ts
@@ -50,6 +50,8 @@ export interface Room {
   creationTime: number;
   turnPassword: string;
   enabledCodecs: Codec[];
+  metadata: string;
+  numParticipants: number;
 }
 
 export interface Codec {
@@ -197,6 +199,13 @@ export interface UserPacket {
   destinationSids: string[];
 }
 
+export interface RecordingResult {
+  id: string;
+  error: string;
+  duration: number;
+  location: string;
+}
+
 const baseRoom: object = {
   sid: "",
   name: "",
@@ -204,6 +213,8 @@ const baseRoom: object = {
   maxParticipants: 0,
   creationTime: 0,
   turnPassword: "",
+  metadata: "",
+  numParticipants: 0,
 };
 
 export const Room = {
@@ -228,6 +239,12 @@ export const Room = {
     }
     for (const v of message.enabledCodecs) {
       Codec.encode(v!, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.metadata !== "") {
+      writer.uint32(66).string(message.metadata);
+    }
+    if (message.numParticipants !== 0) {
+      writer.uint32(72).uint32(message.numParticipants);
     }
     return writer;
   },
@@ -260,6 +277,12 @@ export const Room = {
           break;
         case 7:
           message.enabledCodecs.push(Codec.decode(reader, reader.uint32()));
+          break;
+        case 8:
+          message.metadata = reader.string();
+          break;
+        case 9:
+          message.numParticipants = reader.uint32();
           break;
         default:
           reader.skipType(tag & 7);
@@ -310,6 +333,19 @@ export const Room = {
         message.enabledCodecs.push(Codec.fromJSON(e));
       }
     }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = String(object.metadata);
+    } else {
+      message.metadata = "";
+    }
+    if (
+      object.numParticipants !== undefined &&
+      object.numParticipants !== null
+    ) {
+      message.numParticipants = Number(object.numParticipants);
+    } else {
+      message.numParticipants = 0;
+    }
     return message;
   },
 
@@ -332,6 +368,9 @@ export const Room = {
     } else {
       obj.enabledCodecs = [];
     }
+    message.metadata !== undefined && (obj.metadata = message.metadata);
+    message.numParticipants !== undefined &&
+      (obj.numParticipants = message.numParticipants);
     return obj;
   },
 
@@ -375,6 +414,19 @@ export const Room = {
       for (const e of object.enabledCodecs) {
         message.enabledCodecs.push(Codec.fromPartial(e));
       }
+    }
+    if (object.metadata !== undefined && object.metadata !== null) {
+      message.metadata = object.metadata;
+    } else {
+      message.metadata = "";
+    }
+    if (
+      object.numParticipants !== undefined &&
+      object.numParticipants !== null
+    ) {
+      message.numParticipants = object.numParticipants;
+    } else {
+      message.numParticipants = 0;
     }
     return message;
   },
@@ -1160,6 +1212,120 @@ export const UserPacket = {
       for (const e of object.destinationSids) {
         message.destinationSids.push(e);
       }
+    }
+    return message;
+  },
+};
+
+const baseRecordingResult: object = {
+  id: "",
+  error: "",
+  duration: 0,
+  location: "",
+};
+
+export const RecordingResult = {
+  encode(
+    message: RecordingResult,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.id !== "") {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.error !== "") {
+      writer.uint32(18).string(message.error);
+    }
+    if (message.duration !== 0) {
+      writer.uint32(24).int64(message.duration);
+    }
+    if (message.location !== "") {
+      writer.uint32(34).string(message.location);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): RecordingResult {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseRecordingResult } as RecordingResult;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.string();
+          break;
+        case 2:
+          message.error = reader.string();
+          break;
+        case 3:
+          message.duration = longToNumber(reader.int64() as Long);
+          break;
+        case 4:
+          message.location = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RecordingResult {
+    const message = { ...baseRecordingResult } as RecordingResult;
+    if (object.id !== undefined && object.id !== null) {
+      message.id = String(object.id);
+    } else {
+      message.id = "";
+    }
+    if (object.error !== undefined && object.error !== null) {
+      message.error = String(object.error);
+    } else {
+      message.error = "";
+    }
+    if (object.duration !== undefined && object.duration !== null) {
+      message.duration = Number(object.duration);
+    } else {
+      message.duration = 0;
+    }
+    if (object.location !== undefined && object.location !== null) {
+      message.location = String(object.location);
+    } else {
+      message.location = "";
+    }
+    return message;
+  },
+
+  toJSON(message: RecordingResult): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    message.error !== undefined && (obj.error = message.error);
+    message.duration !== undefined && (obj.duration = message.duration);
+    message.location !== undefined && (obj.location = message.location);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<RecordingResult>): RecordingResult {
+    const message = { ...baseRecordingResult } as RecordingResult;
+    if (object.id !== undefined && object.id !== null) {
+      message.id = object.id;
+    } else {
+      message.id = "";
+    }
+    if (object.error !== undefined && object.error !== null) {
+      message.error = object.error;
+    } else {
+      message.error = "";
+    }
+    if (object.duration !== undefined && object.duration !== null) {
+      message.duration = object.duration;
+    } else {
+      message.duration = 0;
+    }
+    if (object.location !== undefined && object.location !== null) {
+      message.location = object.location;
+    } else {
+      message.location = "";
     }
     return message;
   },

--- a/src/proto/livekit_rtc.ts
+++ b/src/proto/livekit_rtc.ts
@@ -121,6 +121,8 @@ export interface SignalResponse {
   mute?: MuteTrackRequest | undefined;
   /** indicates changes to speaker status, including when they've gone to not speaking */
   speakersChanged?: SpeakersChanged | undefined;
+  /** sent when metadata of the room has changed */
+  roomUpdate?: RoomUpdate | undefined;
 }
 
 export interface AddTrackRequest {
@@ -201,6 +203,10 @@ export interface ICEServer {
 
 export interface SpeakersChanged {
   speakers: SpeakerInfo[];
+}
+
+export interface RoomUpdate {
+  room?: Room;
 }
 
 const baseSignalRequest: object = {};
@@ -504,6 +510,9 @@ export const SignalResponse = {
         writer.uint32(82).fork()
       ).ldelim();
     }
+    if (message.roomUpdate !== undefined) {
+      RoomUpdate.encode(message.roomUpdate, writer.uint32(90).fork()).ldelim();
+    }
     return writer;
   },
 
@@ -546,6 +555,9 @@ export const SignalResponse = {
             reader,
             reader.uint32()
           );
+          break;
+        case 11:
+          message.roomUpdate = RoomUpdate.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -609,6 +621,11 @@ export const SignalResponse = {
     } else {
       message.speakersChanged = undefined;
     }
+    if (object.roomUpdate !== undefined && object.roomUpdate !== null) {
+      message.roomUpdate = RoomUpdate.fromJSON(object.roomUpdate);
+    } else {
+      message.roomUpdate = undefined;
+    }
     return message;
   },
 
@@ -647,6 +664,10 @@ export const SignalResponse = {
     message.speakersChanged !== undefined &&
       (obj.speakersChanged = message.speakersChanged
         ? SpeakersChanged.toJSON(message.speakersChanged)
+        : undefined);
+    message.roomUpdate !== undefined &&
+      (obj.roomUpdate = message.roomUpdate
+        ? RoomUpdate.toJSON(message.roomUpdate)
         : undefined);
     return obj;
   },
@@ -704,6 +725,11 @@ export const SignalResponse = {
       );
     } else {
       message.speakersChanged = undefined;
+    }
+    if (object.roomUpdate !== undefined && object.roomUpdate !== null) {
+      message.roomUpdate = RoomUpdate.fromPartial(object.roomUpdate);
+    } else {
+      message.roomUpdate = undefined;
     }
     return message;
   },
@@ -1920,6 +1946,65 @@ export const SpeakersChanged = {
       for (const e of object.speakers) {
         message.speakers.push(SpeakerInfo.fromPartial(e));
       }
+    }
+    return message;
+  },
+};
+
+const baseRoomUpdate: object = {};
+
+export const RoomUpdate = {
+  encode(
+    message: RoomUpdate,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.room !== undefined) {
+      Room.encode(message.room, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): RoomUpdate {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = { ...baseRoomUpdate } as RoomUpdate;
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.room = Room.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): RoomUpdate {
+    const message = { ...baseRoomUpdate } as RoomUpdate;
+    if (object.room !== undefined && object.room !== null) {
+      message.room = Room.fromJSON(object.room);
+    } else {
+      message.room = undefined;
+    }
+    return message;
+  },
+
+  toJSON(message: RoomUpdate): unknown {
+    const obj: any = {};
+    message.room !== undefined &&
+      (obj.room = message.room ? Room.toJSON(message.room) : undefined);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<RoomUpdate>): RoomUpdate {
+    const message = { ...baseRoomUpdate } as RoomUpdate;
+    if (object.room !== undefined && object.room !== null) {
+      message.room = Room.fromPartial(object.room);
+    } else {
+      message.room = undefined;
     }
     return message;
   },

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -58,6 +58,9 @@ class Room extends EventEmitter {
   /** the current participant */
   localParticipant!: LocalParticipant;
 
+  /** room metadata */
+  metadata: string | undefined = undefined;
+
   private audioEnabled = true;
 
   private audioContext?: AudioContext;
@@ -92,6 +95,7 @@ class Room extends EventEmitter {
       },
     );
 
+    this.engine.on(EngineEvent.RoomUpdate, this.handleRoomUpdate);
     this.engine.on(EngineEvent.ActiveSpeakersUpdate, this.handleActiveSpeakersUpdate);
     this.engine.on(EngineEvent.SpeakersChanged, this.handleSpeakersChanged);
     this.engine.on(EngineEvent.DataPacketReceived, this.handleDataPacket);
@@ -398,6 +402,11 @@ class Room extends EventEmitter {
     this.audioEnabled = false;
     this.emit(RoomEvent.AudioPlaybackStatusChanged, false);
   };
+
+  private handleRoomUpdate = (r: Room) => {
+    this.metadata = r.metadata;
+    this.emit(RoomEvent.RoomMetadataChanged, r.metadata);
+  }
 
   private acquireAudioContext() {
     if (this.audioContext) {

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -113,6 +113,16 @@ export enum RoomEvent {
   MetadataChanged = 'metadataChanged',
 
   /**
+   * Room metadata is a simple way for app-specific state to be pushed to
+   * all users.
+   * When RoomService.UpdateRoomMetadata is called to change a room's state,
+   * *all*  participants in the room will fire this event.
+   *
+   * args: (string)
+   */
+   RoomMetadataChanged = 'roomMetadataChanged',
+
+  /**
    * Data received from another participant.
    * Data packets provides the ability to use LiveKit to send/receive arbitrary payloads.
    * All participants in the room will receive the messages sent to the room.
@@ -149,6 +159,7 @@ export enum EngineEvent {
   SpeakersChanged = 'speakersChanged',
   DataPacketReceived = 'dataPacketReceived',
   RemoteMuteChanged = 'remoteMuteChanged',
+  RoomUpdate = 'roomUpdate',
 }
 
 export enum TrackEvent {


### PR DESCRIPTION
side note: the proto files are based on the main branch of the protocol repository, wasn't sure if that's appropriate.

also I'm (again) not sure about when and when not to differentiate between `RoomUpdate` and `RoomMetadataUpdate`.

On the `RoomEvent` enum there is currently `metadataChanged` as an event reserved for participant metadata updates. Does it make sense to change the naming there to something more specific while at it?
