### PR TITLE
Async mute/unmute to ensure track restart is complete

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -117,7 +117,7 @@ export default class LocalParticipant extends Participant {
     const track = this.getTrack(source);
     if (enabled) {
       if (track) {
-        track.unmute();
+        await track.unmute();
       } else {
         let localTrack: LocalTrack | undefined;
         switch (source) {
@@ -141,7 +141,7 @@ export default class LocalParticipant extends Participant {
       if (source === Track.Source.ScreenShare) {
         this.unpublishTrack(track.track);
       } else {
-        track.mute();
+        await track.mute();
       }
     }
   }

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -24,6 +24,23 @@ export default class LocalAudioTrack extends LocalTrack {
     }
   }
 
+  async mute(): Promise<LocalAudioTrack> {
+    if (this.source === Track.Source.Microphone) {
+      // also stop the track, so that camera indicator is turned off
+      this.mediaStreamTrack.stop();
+    }
+    await super.mute();
+    return this;
+  }
+
+  async unmute(): Promise<LocalAudioTrack> {
+    if (this.source === Track.Source.Microphone) {
+      await this.restartTrack();
+    }
+    await super.unmute();
+    return this;
+  }
+
   async restartTrack(options?: CreateAudioTrackOptions) {
     let constraints: MediaTrackConstraints | undefined;
     if (options) {

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -100,12 +100,12 @@ export default class LocalTrack extends Track {
     return DeviceManager.getInstance().normalizeDeviceId(kind, deviceId, groupId);
   }
 
-  mute(): LocalTrack {
+  async mute(): Promise<LocalTrack> {
     this.setTrackMuted(true);
     return this;
   }
 
-  unmute(): LocalTrack {
+  async unmute(): Promise<LocalTrack> {
     this.setTrackMuted(false);
     return this;
   }

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -33,14 +33,14 @@ export default class LocalTrackPublication extends TrackPublication {
   /**
    * Mute the track associated with this publication
    */
-  mute() {
-    this.track?.mute();
+  async mute() {
+    return this.track?.mute();
   }
 
   /**
    * Unmute track associated with this publication
    */
-  unmute() {
-    this.track?.unmute();
+  async unmute() {
+    return this.track?.unmute();
   }
 }

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -62,19 +62,21 @@ export default class LocalVideoTrack extends LocalTrack {
     super.stop();
   }
 
-  mute(): LocalTrack {
+  async mute(): Promise<LocalVideoTrack> {
     if (this.source === Track.Source.Camera) {
       // also stop the track, so that camera indicator is turned off
       this.mediaStreamTrack.stop();
     }
-    return super.mute();
+    await super.mute();
+    return this;
   }
 
-  unmute(): LocalTrack {
+  async unmute(): Promise<LocalVideoTrack> {
     if (this.source === Track.Source.Camera) {
-      this.restartTrack();
+      await this.restartTrack();
     }
-    return super.unmute();
+    await super.unmute();
+    return this;
   }
 
   async getSenderStats(): Promise<VideoSenderStats[]> {


### PR DESCRIPTION
For apps that are need to know when unmute is complete (in order to update track state), we would need to return a Promise to ensure they could know when the update is complete