### PR TITLE
Fix VideoResolution example

### DIFF
--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -144,8 +144,8 @@ export interface CreateAudioTrackOptions extends CreateLocalTrackOptions {
  *
  * ```typescript
  * {
- *   width: { ideal: 960 },
- *   height: { ideal: 540 },
+ *   width: 960,
+ *   height: 540,
  *   frameRate: {
  *     ideal: 30,
  *     max: 60,


### PR DESCRIPTION
Since #54, the resolution cannot contain the "ideal" keyword and should
only include the number.