### PR TITLE
Do not downgrade layers too early

### DIFF
--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -160,8 +160,8 @@ export default class LocalVideoTrack extends LocalTrack {
       return;
     }
 
-    this.lastExplicitQualityChange = new Date().getTime();
     this.lastQualityChange = new Date().getTime();
+    this.lastExplicitQualityChange = new Date().getTime();
 
     this.signalClient?.sendSetSimulcastLayers(this.sid, layers);
 


### PR DESCRIPTION
## Problem
On my slow machine, about half the time the "f" layer does not even start before the
monitor code swoops in and downgrades quality.

It is puzzling as to why it is not started. Activity Monitor shows 75% idle even when all
layers are encoding. And the server is running on the same machine. So, bandwidth
should not be an issue.

Anyhow, once downgraded, we wait the 60 seconds before enabling the "f" layer
which is quite a while for high quality video to be sent out.

## Fix
Check if the best encoder has been active (by checking `framesSent !== 0`) before
downgrading. With this change, the "f" layer starts about 15 - 20 seconds into the
session rather the 60+ seconds because of downgrading too early. 15 - 20 seconds is
not great either, but at least it is not as bad.

## To think about
What if even "h" was too much and we need to downgrade to "q"? By waiting for "f"
to start, we will never get to that. Maybe, we need to check the currently active (or
at some point active) best encoding and see if that is suffering. Or maybe, letting the
browser handle it is okay as "h" suffering is probably a sign that the machine is going
to perform poorly even for the most basic cases.

## Testing
Ensure that "f" layer is not clobbered before it has a chance to start.

