### PR TITLE
override track name if set via options

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -182,6 +182,9 @@ export default class LocalParticipant extends Participant {
     if (opts.source) {
       track.source = opts.source;
     }
+    if (opts.name) {
+      track.name = opts.name;
+    }
 
     // handle track actions
     track.on(TrackEvent.Muted, this.onTrackMuted);


### PR DESCRIPTION
Right now setting the `name` property in the track publish option like 
```ts
	await this.currentRoom.localParticipant.publishTrack(audioTrack, {
					name: `my-microphone`
				});
```

doesn't have any effect if the track is not an instance of `MediaStreamTrack`.
This PR overrides the track name if it is set explicitly via options also for a `LocalTrack` type.