### PR TITLE
add screenshareaudio track source

### DIFF
--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -82,13 +82,16 @@ export default class Participant extends EventEmitter {
         return pub;
       }
       if (pub.source === Track.Source.Unknown) {
-        if (source === Track.Source.Microphone && pub.kind === Track.Kind.Audio) {
+        if (source === Track.Source.Microphone && pub.kind === Track.Kind.Audio && pub.trackName !== 'screen') {
           return pub;
         }
         if (source === Track.Source.Camera && pub.kind === Track.Kind.Video && pub.trackName !== 'screen') {
           return pub;
         }
         if (source === Track.Source.ScreenShare && pub.kind === Track.Kind.Video && pub.trackName === 'screen') {
+          return pub;
+        }
+        if (source === Track.Source.ScreenShareAudio && pub.kind === Track.Kind.Audio && pub.trackName === 'screen') {
           return pub;
         }
       }

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -142,7 +142,9 @@ export async function createLocalScreenTracks(
   screenVideo.source = Track.Source.ScreenShare;
   const localTracks: Array<LocalTrack> = [screenVideo];
   if (stream.getAudioTracks().length > 0) {
-    localTracks.push(new LocalAudioTrack(stream.getAudioTracks()[0], options.name));
+    const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0], options.name);
+    screenAudio.source = Track.Source.ScreenShareAudio;
+    localTracks.push(screenAudio);
   }
   return localTracks;
 }


### PR DESCRIPTION
Right now screen share audio has an "unknown" source type set. 
I found myself needing to know specifically if it is audio from a screen share, thus this PR.