### PR TITLE
feat: added connection status feature

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -39,7 +39,6 @@ export async function connect(
   options.logLevel ||= LogLevel.info;
   if (options.audio === undefined) options.audio = false;
   if (options.video === undefined) options.video = false;
-  if (options.enableConnectionMonitor === undefined) options.enableConnectionMonitor = false;
 
   log.setLevel(options.logLevel);
 
@@ -49,7 +48,7 @@ export async function connect(
   }
 
   const client = new WSSignalClient();
-  const room = new Room(client, config, options.enableConnectionMonitor);
+  const room = new Room(client, config, options.connectionMonitor);
 
   // connect to room
   await room.connect(url, token, {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -39,6 +39,7 @@ export async function connect(
   options.logLevel ||= LogLevel.info;
   if (options.audio === undefined) options.audio = false;
   if (options.video === undefined) options.video = false;
+  if (options.enableConnectionMonitor === undefined) options.enableConnectionMonitor = false;
 
   log.setLevel(options.logLevel);
 
@@ -48,7 +49,7 @@ export async function connect(
   }
 
   const client = new WSSignalClient();
-  const room = new Room(client, config);
+  const room = new Room(client, config, options.enableConnectionMonitor);
 
   // connect to room
   await room.connect(url, token, {

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,7 @@
 import {
   CreateLocalTracksOptions, TrackCaptureDefaults, TrackPublishDefaults,
 } from './room/track/options';
+import { ConnectionMonitorOption } from './room/stats';
 
 /**
  * if video or audio tracks are created as part of [[connect]], it'll automatically
@@ -50,7 +51,7 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
   /**
    * Option to enable connection monitor based on webrtc stats
    */
-  enableConnectionMonitor?: boolean;
+  connectionMonitor?: ConnectionMonitorOption;
 }
 
 export enum LogLevel {

--- a/src/options.ts
+++ b/src/options.ts
@@ -46,6 +46,11 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
    * default options to use when publishing tracks
    */
   publishDefaults?: TrackPublishDefaults;
+
+  /**
+   * Option to enable connection monitor based on webrtc stats
+   */
+  enableConnectionMonitor?: boolean;
 }
 
 export enum LogLevel {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -18,13 +18,14 @@ import LocalParticipant from './participant/LocalParticipant';
 import Participant from './participant/Participant';
 import RemoteParticipant from './participant/RemoteParticipant';
 import RTCEngine, { maxICEConnectTimeout } from './RTCEngine';
+import { monitorFrequency, ConnectionStatus } from './stats';
 import LocalTrackPublication from './track/LocalTrackPublication';
 import { TrackCaptureDefaults, TrackPublishDefaults } from './track/options';
 import RemoteTrackPublication from './track/RemoteTrackPublication';
 import { Track } from './track/Track';
 import TrackPublication from './track/TrackPublication';
 import { RemoteTrack } from './track/types';
-import { unpackStreamId } from './utils';
+import { getConnectionStatus, unpackStreamId } from './utils';
 
 export enum RoomState {
   Disconnected = 'disconnected',
@@ -72,8 +73,10 @@ class Room extends EventEmitter {
 
   private audioContext?: AudioContext;
 
+  private connectionMonitorInterval: any = undefined;
+
   /** @internal */
-  constructor(client: SignalClient, config?: RTCConfiguration) {
+  constructor(client: SignalClient, config?: RTCConfiguration, enableConnectionMonitor: boolean = false) {
     super();
     this.participants = new Map();
     this.engine = new RTCEngine(client, config);
@@ -116,16 +119,20 @@ class Room extends EventEmitter {
       this.state = RoomState.Connected;
       this.emit(RoomEvent.Reconnected);
     });
+
+    if(enableConnectionMonitor){
+      this.startConnectionMonitoring();
+    }
   }
 
   /**
-   * getLocalDevices abstracts navigator.mediaDevices.enumerateDevices.
-   * In particular, it handles Chrome's unique behavior of creating `default`
-   * devices. When encountered, it'll be removed from the list of devices.
-   * The actual default device will be placed at top.
-   * @param kind
-   * @returns a list of available local devices
-   */
+ * getLocalDevices abstracts navigator.mediaDevices.enumerateDevices.
+ * In particular, it handles Chrome's unique behavior of creating `default`
+ * devices. When encountered, it'll be removed from the list of devices.
+ * The actual default device will be placed at top.
+ * @param kind
+ * @returns a list of available local devices
+ */
   static getLocalDevices(kind: MediaDeviceKind): Promise<MediaDeviceInfo[]> {
     return DeviceManager.getInstance().getDevices(kind);
   }
@@ -225,7 +232,126 @@ class Room extends EventEmitter {
     this.engine.client.sendLeave();
     this.engine.close();
     this.handleDisconnect();
+
+    if(this.connectionMonitorInterval !== undefined){
+      clearInterval(this.connectionMonitorInterval);
+    }
   };
+
+  /**
+   * Start connection monitoring based on inbound-rtp and outbound-rtp
+   */
+
+  startConnectionMonitoring = async () => {
+
+    let previousAudioDataFromPublisher: RTCStatsReport, previousVideoDataFromPublisher: RTCStatsReport, previousAudioDataFromSubscriber: RTCStatsReport, previousVideoDataFromSubscriber: RTCStatsReport;
+
+    this.connectionMonitorInterval = setInterval(async () => {
+
+      let status: ConnectionStatus = {
+        "audio": {
+          outbound: 0,
+          inbound: 0,
+          jitter: 0,
+          packetsLost: 0,
+        },
+        "video": {
+          outbound: 0,
+          inbound: 0,
+          jitter: 0,
+          packetsLost: 0,
+        }
+      };
+
+      let currentAudioData: any = {
+        kind: "audio",
+        type: "outbound-rtp",
+        hasData: false
+      };
+
+      let currentVideoData: any = {
+        kind: "video",
+        type: "outbound-rtp",
+        hasData: false
+      };
+
+      let fromPublisher = await this.engine.publisher?.pc.getStats();
+
+      fromPublisher?.forEach((report: any) => {
+        if (report.kind === "audio" && report.type === "outbound-rtp" ) {
+          currentAudioData[report.id] = report;
+          currentAudioData.hasData = true;
+        }
+        if (report.kind === "video" && report.type === "outbound-rtp") {
+          currentVideoData[report.id] = report;
+          currentVideoData.hasData = true;
+        }
+      });
+
+      if (currentAudioData.hasData) {
+        let result = await getConnectionStatus(currentAudioData, previousAudioDataFromPublisher);
+        status.audio.outbound = result.audio.outbound;
+
+        previousAudioDataFromPublisher = currentAudioData;
+      }
+
+      if (currentVideoData.hasData) {
+        let result = await getConnectionStatus(currentVideoData, previousVideoDataFromPublisher);
+        status.video.outbound = result.video.outbound;
+
+        previousVideoDataFromPublisher = currentVideoData;
+      }
+
+      currentAudioData = {
+        kind: "audio",
+        type: "inbound-rtp",
+        hasData: false
+      };
+
+      currentVideoData = {
+        kind: "video",
+        type: "inbound-rtp",
+        hasData: false
+      };
+
+      let fromSubscriber = await this.engine.subscriber?.pc.getStats();
+
+      fromSubscriber?.forEach((report: any) => {
+        if (report.kind === "audio" && report.type === "inbound-rtp") {
+          currentAudioData[report.id] = report;
+          currentAudioData.hasData = true;
+        }
+
+        if (report.kind === "video" && report.type === "inbound-rtp") {
+          currentVideoData[report.id] = report;
+          currentVideoData.hasData = true;
+        }
+      });
+
+      if (currentAudioData.hasData) {
+        let result = await getConnectionStatus(currentAudioData, previousAudioDataFromSubscriber);
+        
+        status.audio.inbound = result.audio.inbound;
+        status.audio.jitter = result.audio.jitter;
+        status.audio.packetsLost = result.audio.packetsLost;
+
+        previousAudioDataFromSubscriber = currentAudioData;
+      }
+
+      if (currentVideoData.hasData) {
+        let result = await getConnectionStatus(currentVideoData, previousVideoDataFromSubscriber);
+        
+        status.video.inbound = result.video.inbound;
+        status.video.jitter = result.video.jitter;
+        status.video.packetsLost = result.video.packetsLost;
+
+        previousVideoDataFromSubscriber = currentVideoData;
+      }
+
+      this.emit(RoomEvent.ConnectionStatus, status);
+
+    }, monitorFrequency);
+  }
 
   /**
    * Set default publish options

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -76,7 +76,8 @@ class Room extends EventEmitter {
   private connectionMonitorInterval: any = undefined;
 
   /** @internal */
-  constructor(client: SignalClient, config?: RTCConfiguration, enableConnectionMonitor: boolean = false) {
+  constructor(client: SignalClient, config?: RTCConfiguration,
+    enableConnectionMonitor: boolean = false) {
     super();
     this.participants = new Map();
     this.engine = new RTCEngine(client, config);
@@ -120,7 +121,7 @@ class Room extends EventEmitter {
       this.emit(RoomEvent.Reconnected);
     });
 
-    if(enableConnectionMonitor){
+    if (enableConnectionMonitor) {
       this.startConnectionMonitoring();
     }
   }
@@ -233,7 +234,7 @@ class Room extends EventEmitter {
     this.engine.close();
     this.handleDisconnect();
 
-    if(this.connectionMonitorInterval !== undefined){
+    if (this.connectionMonitorInterval !== undefined) {
       clearInterval(this.connectionMonitorInterval);
     }
   };
@@ -243,94 +244,94 @@ class Room extends EventEmitter {
    */
 
   startConnectionMonitoring = async () => {
-
-    let previousAudioDataFromPublisher: RTCStatsReport, previousVideoDataFromPublisher: RTCStatsReport, previousAudioDataFromSubscriber: RTCStatsReport, previousVideoDataFromSubscriber: RTCStatsReport;
+    let previousAudioDataFromPublisher: RTCStatsReport;
+    let previousVideoDataFromPublisher: RTCStatsReport;
+    let previousAudioDataFromSubscriber: RTCStatsReport;
+    let previousVideoDataFromSubscriber: RTCStatsReport;
 
     this.connectionMonitorInterval = setInterval(async () => {
-
-      let status: ConnectionStatus = {
-        "audio": {
+      const status: ConnectionStatus = {
+        audio: {
           outbound: 0,
           inbound: 0,
           jitter: 0,
           packetsLost: 0,
         },
-        "video": {
+        video: {
           outbound: 0,
           inbound: 0,
           jitter: 0,
           packetsLost: 0,
-        }
+        },
       };
 
       let currentAudioData: any = {
-        kind: "audio",
-        type: "outbound-rtp",
-        hasData: false
+        kind: 'audio',
+        type: 'outbound-rtp',
+        hasData: false,
       };
 
       let currentVideoData: any = {
-        kind: "video",
-        type: "outbound-rtp",
-        hasData: false
+        kind: 'video',
+        type: 'outbound-rtp',
+        hasData: false,
       };
 
-      let fromPublisher = await this.engine.publisher?.pc.getStats();
+      const fromPublisher = await this.engine.publisher?.pc.getStats();
 
       fromPublisher?.forEach((report: any) => {
-        if (report.kind === "audio" && report.type === "outbound-rtp" ) {
+        if (report.kind === 'audio' && report.type === 'outbound-rtp') {
           currentAudioData[report.id] = report;
           currentAudioData.hasData = true;
         }
-        if (report.kind === "video" && report.type === "outbound-rtp") {
+        if (report.kind === 'video' && report.type === 'outbound-rtp') {
           currentVideoData[report.id] = report;
           currentVideoData.hasData = true;
         }
       });
 
       if (currentAudioData.hasData) {
-        let result = await getConnectionStatus(currentAudioData, previousAudioDataFromPublisher);
+        const result = await getConnectionStatus(currentAudioData, previousAudioDataFromPublisher);
         status.audio.outbound = result.audio.outbound;
 
         previousAudioDataFromPublisher = currentAudioData;
       }
 
       if (currentVideoData.hasData) {
-        let result = await getConnectionStatus(currentVideoData, previousVideoDataFromPublisher);
+        const result = await getConnectionStatus(currentVideoData, previousVideoDataFromPublisher);
         status.video.outbound = result.video.outbound;
 
         previousVideoDataFromPublisher = currentVideoData;
       }
 
       currentAudioData = {
-        kind: "audio",
-        type: "inbound-rtp",
-        hasData: false
+        kind: 'audio',
+        type: 'inbound-rtp',
+        hasData: false,
       };
 
       currentVideoData = {
-        kind: "video",
-        type: "inbound-rtp",
-        hasData: false
+        kind: 'video',
+        type: 'inbound-rtp',
+        hasData: false,
       };
 
-      let fromSubscriber = await this.engine.subscriber?.pc.getStats();
+      const fromSubscriber = await this.engine.subscriber?.pc.getStats();
 
       fromSubscriber?.forEach((report: any) => {
-        if (report.kind === "audio" && report.type === "inbound-rtp") {
+        if (report.kind === 'audio' && report.type === 'inbound-rtp') {
           currentAudioData[report.id] = report;
           currentAudioData.hasData = true;
         }
 
-        if (report.kind === "video" && report.type === "inbound-rtp") {
+        if (report.kind === 'video' && report.type === 'inbound-rtp') {
           currentVideoData[report.id] = report;
           currentVideoData.hasData = true;
         }
       });
 
       if (currentAudioData.hasData) {
-        let result = await getConnectionStatus(currentAudioData, previousAudioDataFromSubscriber);
-        
+        const result = await getConnectionStatus(currentAudioData, previousAudioDataFromSubscriber);
         status.audio.inbound = result.audio.inbound;
         status.audio.jitter = result.audio.jitter;
         status.audio.packetsLost = result.audio.packetsLost;
@@ -339,19 +340,16 @@ class Room extends EventEmitter {
       }
 
       if (currentVideoData.hasData) {
-        let result = await getConnectionStatus(currentVideoData, previousVideoDataFromSubscriber);
-        
+        const result = await getConnectionStatus(currentVideoData, previousVideoDataFromSubscriber);
         status.video.inbound = result.video.inbound;
         status.video.jitter = result.video.jitter;
         status.video.packetsLost = result.video.packetsLost;
 
         previousVideoDataFromSubscriber = currentVideoData;
       }
-
       this.emit(RoomEvent.ConnectionStatus, status);
-
     }, monitorFrequency);
-  }
+  };
 
   /**
    * Set default publish options

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -233,10 +233,6 @@ class Room extends EventEmitter {
     this.engine.client.sendLeave();
     this.engine.close();
     this.handleDisconnect();
-
-    if (this.connectionMonitorInterval !== undefined) {
-      clearInterval(this.connectionMonitorInterval);
-    }
   };
 
   /**
@@ -276,6 +272,11 @@ class Room extends EventEmitter {
         type: 'outbound-rtp',
         hasData: false,
       };
+
+      if (this.engine.subscriber?.pc.connectionState === 'disconnected') {
+        clearInterval(this.connectionMonitorInterval);
+        return;
+      }
 
       const fromPublisher = await this.engine.publisher?.pc.getStats();
 

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -185,7 +185,8 @@ export enum RoomEvent {
 
   /**
    * Get webrtc-stats for video and audio
-   * This will send stats periodically based on monitorFrequency value
+   * This will send stats periodically based on frequency value
+   * by default monitorFrequency value
    * outbound indicates upload and inbound indicates download
    * args: (stats: ConnectionStatus)
    */

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -182,6 +182,15 @@ export enum RoomEvent {
    * args: (error: Error)
    */
   MediaDevicesError = 'mediaDevicesError',
+
+  /**
+   * Get webrtc-stats for video and audio
+   * This will send stats periodically based on monitorFrequency value
+   * outbound indicates upload and inbound indicates download
+   * args: (stats: ConnectionStatus)
+   */
+
+  ConnectionStatus = 'connectionStatus',
 }
 
 export enum ParticipantEvent {

--- a/src/room/stats.ts
+++ b/src/room/stats.ts
@@ -82,18 +82,17 @@ export interface VideoReceiverStats extends ReceiverStats {
 }
 
 export interface ConnectionStatus {
-  "audio": {
+  'audio': {
 
     outbound: number,
 
     inbound: number,
 
     jitter: number,
-    
+
     packetsLost: number,
-    
   },
-  "video": {
+  'video': {
 
     outbound: number,
 
@@ -102,6 +101,5 @@ export interface ConnectionStatus {
     jitter: number,
 
     packetsLost: number,
-
   }
 }

--- a/src/room/stats.ts
+++ b/src/room/stats.ts
@@ -81,6 +81,13 @@ export interface VideoReceiverStats extends ReceiverStats {
   nackCount: number;
 }
 
+export interface ConnectionMonitorOption {
+  enabled: boolean,
+
+  /** frequency value in milliseconds. 1 second = 1000 milliseconds  */
+  frequency?: number,
+}
+
 export interface ConnectionStatus {
   'audio': {
 

--- a/src/room/stats.ts
+++ b/src/room/stats.ts
@@ -80,3 +80,28 @@ export interface VideoReceiverStats extends ReceiverStats {
 
   nackCount: number;
 }
+
+export interface ConnectionStatus {
+  "audio": {
+
+    outbound: number,
+
+    inbound: number,
+
+    jitter: number,
+    
+    packetsLost: number,
+    
+  },
+  "video": {
+
+    outbound: number,
+
+    inbound: number,
+
+    jitter: number,
+
+    packetsLost: number,
+
+  }
+}

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -1,4 +1,4 @@
-import { ConnectionStatus } from "./stats";
+import { ConnectionStatus } from './stats';
 
 const separator = '|';
 
@@ -20,47 +20,39 @@ export async function sleep(duration: number): Promise<void> {
 }
 
 export async function getConnectionStatus(currentData: any, previousData: any) {
-
-  let result: ConnectionStatus = {
-    "audio": {
+  const result: ConnectionStatus = {
+    audio: {
       outbound: 0,
       inbound: 0,
       jitter: 0,
       packetsLost: 0,
     },
-    "video": {
+    video: {
       outbound: 0,
       inbound: 0,
       jitter: 0,
       packetsLost: 0,
-    }
+    },
   };
 
-  const kind = currentData.kind, type = currentData.type;
+  const { kind, type } = currentData;
   delete currentData.kind;
   delete currentData.type;
   delete currentData.hasData;
 
-  if (kind === "audio" && type === "outbound-rtp") {
-
-    let audioStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+  if (kind === 'audio' && type === 'outbound-rtp') {
+    const audioStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
     result.audio.outbound = audioStat.outbound;
-    
-  } else if (kind === "audio" && type === "inbound-rtp") {
-
-    let audioStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+  } else if (kind === 'audio' && type === 'inbound-rtp') {
+    const audioStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
     result.audio.inbound = audioStat.inbound;
     result.audio.jitter = audioStat.jitter;
     result.audio.packetsLost = audioStat.packetsLost;
-
-  } else if (kind === "video" && type === "outbound-rtp") {
-
-    let videoStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+  } else if (kind === 'video' && type === 'outbound-rtp') {
+    const videoStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
     result.video.outbound = videoStat.outbound;
-
-  } else if (kind === "video" && type === "inbound-rtp") {
-
-    let videoStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+  } else if (kind === 'video' && type === 'inbound-rtp') {
+    const videoStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
     result.video.inbound = videoStat.inbound;
     result.video.jitter = videoStat.jitter;
     result.video.packetsLost = videoStat.packetsLost;
@@ -70,12 +62,11 @@ export async function getConnectionStatus(currentData: any, previousData: any) {
 }
 
 export async function calculateBitsPerSecondFromMultipleData(currentData: any, previousData: any) {
-
   const result = {
     inbound: 0,
     outbound: 0,
     jitter: 0,
-    packetsLost: 0
+    packetsLost: 0,
   };
 
   if (!previousData && currentData) {
@@ -86,8 +77,7 @@ export async function calculateBitsPerSecondFromMultipleData(currentData: any, p
   if (!currentData || !previousData) return result;
 
   Object.keys(currentData).forEach((peerId) => {
-    if (previousData[peerId] && (currentData[peerId].type === "outbound-rtp" || currentData[peerId].type === "inbound-rtp")) {
-
+    if (previousData[peerId] && (currentData[peerId].type === 'outbound-rtp' || currentData[peerId].type === 'inbound-rtp')) {
       const {
         outbound: peerOutbound,
         inbound: peerInbound,
@@ -98,37 +88,33 @@ export async function calculateBitsPerSecondFromMultipleData(currentData: any, p
       result.inbound += peerInbound;
     }
 
-    if (currentData[peerId].type === "inbound-rtp") {
+    if (currentData[peerId].type === 'inbound-rtp') {
       result.jitter = currentData[peerId].jitter;
       result.packetsLost = currentData[peerId].packetsLost;
     }
-
   });
-
   return result;
 }
 
 export function calculateBitsPerSecond(currentData: any, previousData: any) {
-
   const result = {
     inbound: 0,
-    outbound: 0
+    outbound: 0,
   };
 
   if (!currentData || !previousData) return result;
 
-  const currentOutboundData = currentData.type === "outbound-rtp" ? currentData : null;
-  const previousOutboundData = previousData.type === "outbound-rtp" ? previousData : null;
+  const currentOutboundData = currentData.type === 'outbound-rtp' ? currentData : null;
+  const previousOutboundData = previousData.type === 'outbound-rtp' ? previousData : null;
 
-  const currentInboundData = currentData.type === "inbound-rtp" ? currentData : null;
-  const previousInboundData = previousData.type === "inbound-rtp" ? previousData : null;
+  const currentInboundData = currentData.type === 'inbound-rtp' ? currentData : null;
+  const previousInboundData = previousData.type === 'inbound-rtp' ? previousData : null;
 
   if (currentOutboundData && previousOutboundData) {
     const {
       bytesSent: outboundBytesSent,
       timestamp: outboundTimestamp,
     } = currentOutboundData;
-
 
     let {
       headerBytesSent: outboundHeaderBytesSent,
@@ -188,4 +174,4 @@ export function calculateBitsPerSecond(currentData: any, previousData: any) {
   }
 
   return result;
-};
+}

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -1,3 +1,5 @@
+import { ConnectionStatus } from "./stats";
+
 const separator = '|';
 
 export function unpackStreamId(packed: string): string[] {
@@ -16,3 +18,174 @@ export function useLegacyAPI(): boolean {
 export async function sleep(duration: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, duration));
 }
+
+export async function getConnectionStatus(currentData: any, previousData: any) {
+
+  let result: ConnectionStatus = {
+    "audio": {
+      outbound: 0,
+      inbound: 0,
+      jitter: 0,
+      packetsLost: 0,
+    },
+    "video": {
+      outbound: 0,
+      inbound: 0,
+      jitter: 0,
+      packetsLost: 0,
+    }
+  };
+
+  const kind = currentData.kind, type = currentData.type;
+  delete currentData.kind;
+  delete currentData.type;
+  delete currentData.hasData;
+
+  if (kind === "audio" && type === "outbound-rtp") {
+
+    let audioStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+    result.audio.outbound = audioStat.outbound;
+    
+  } else if (kind === "audio" && type === "inbound-rtp") {
+
+    let audioStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+    result.audio.inbound = audioStat.inbound;
+    result.audio.jitter = audioStat.jitter;
+    result.audio.packetsLost = audioStat.packetsLost;
+
+  } else if (kind === "video" && type === "outbound-rtp") {
+
+    let videoStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+    result.video.outbound = videoStat.outbound;
+
+  } else if (kind === "video" && type === "inbound-rtp") {
+
+    let videoStat = await calculateBitsPerSecondFromMultipleData(currentData, previousData);
+    result.video.inbound = videoStat.inbound;
+    result.video.jitter = videoStat.jitter;
+    result.video.packetsLost = videoStat.packetsLost;
+  }
+
+  return result;
+}
+
+export async function calculateBitsPerSecondFromMultipleData(currentData: any, previousData: any) {
+
+  const result = {
+    inbound: 0,
+    outbound: 0,
+    jitter: 0,
+    packetsLost: 0
+  };
+
+  if (!previousData && currentData) {
+    previousData = currentData;
+    return result;
+  }
+
+  if (!currentData || !previousData) return result;
+
+  Object.keys(currentData).forEach((peerId) => {
+    if (previousData[peerId] && (currentData[peerId].type === "outbound-rtp" || currentData[peerId].type === "inbound-rtp")) {
+
+      const {
+        outbound: peerOutbound,
+        inbound: peerInbound,
+
+      } = calculateBitsPerSecond(currentData[peerId], previousData[peerId]);
+
+      result.outbound += peerOutbound;
+      result.inbound += peerInbound;
+    }
+
+    if (currentData[peerId].type === "inbound-rtp") {
+      result.jitter = currentData[peerId].jitter;
+      result.packetsLost = currentData[peerId].packetsLost;
+    }
+
+  });
+
+  return result;
+}
+
+export function calculateBitsPerSecond(currentData: any, previousData: any) {
+
+  const result = {
+    inbound: 0,
+    outbound: 0
+  };
+
+  if (!currentData || !previousData) return result;
+
+  const currentOutboundData = currentData.type === "outbound-rtp" ? currentData : null;
+  const previousOutboundData = previousData.type === "outbound-rtp" ? previousData : null;
+
+  const currentInboundData = currentData.type === "inbound-rtp" ? currentData : null;
+  const previousInboundData = previousData.type === "inbound-rtp" ? previousData : null;
+
+  if (currentOutboundData && previousOutboundData) {
+    const {
+      bytesSent: outboundBytesSent,
+      timestamp: outboundTimestamp,
+    } = currentOutboundData;
+
+
+    let {
+      headerBytesSent: outboundHeaderBytesSent,
+    } = currentOutboundData;
+
+    if (!outboundHeaderBytesSent) outboundHeaderBytesSent = 0;
+
+    const {
+      bytesSent: previousOutboundBytesSent,
+      timestamp: previousOutboundTimestamp,
+    } = previousOutboundData;
+
+    let {
+      headerBytesSent: previousOutboundHeaderBytesSent,
+    } = previousOutboundData;
+
+    if (!previousOutboundHeaderBytesSent) previousOutboundHeaderBytesSent = 0;
+
+    const outboundBytesPerSecond = (outboundBytesSent + outboundHeaderBytesSent
+      - previousOutboundBytesSent - previousOutboundHeaderBytesSent)
+      / (outboundTimestamp - previousOutboundTimestamp);
+
+    result.outbound = Math.round((outboundBytesPerSecond * 8 * 1000) / 1024);
+  }
+
+  if (currentInboundData && previousInboundData) {
+    const {
+      bytesReceived: inboundBytesReceived,
+      timestamp: inboundTimestamp,
+    } = currentInboundData;
+
+    let {
+      headerBytesReceived: inboundHeaderBytesReceived,
+    } = currentInboundData;
+
+    if (!inboundHeaderBytesReceived) inboundHeaderBytesReceived = 0;
+
+    const {
+      bytesReceived: previousInboundBytesReceived,
+      timestamp: previousInboundTimestamp,
+    } = previousInboundData;
+
+    let {
+      headerBytesReceived: previousInboundHeaderBytesReceived,
+    } = previousInboundData;
+
+    if (!previousInboundHeaderBytesReceived) {
+      previousInboundHeaderBytesReceived = 0;
+    }
+
+    const inboundBytesPerSecond = (inboundBytesReceived
+      + inboundHeaderBytesReceived - previousInboundBytesReceived
+      - previousInboundHeaderBytesReceived) / (inboundTimestamp
+        - previousInboundTimestamp);
+
+    result.inbound = Math.round((inboundBytesPerSecond * 8 * 1000) / 1024);
+  }
+
+  return result;
+};


### PR DESCRIPTION
Connection status monitor based on webrtc stats (inbound-rtp and outbound-rtp). I've followed from [bigbluebutton-connection-status](https://github.com/bigbluebutton/bigbluebutton/blob/706d9a1c5a5e9b43199eb01b5dc43b179aaf49d8/bigbluebutton-html5/imports/ui/components/connection-status/service.js#L461). I've tested from firefox & chrome. Both worked as expected. User can get outbound (upload) and inbound (download) rates (kbps), jitter and packetsLost 

Close #59 