### PR TITLE
wait until DataChannel is ready to send message

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -392,8 +392,14 @@ export default class RTCEngine extends EventEmitter {
     await this.ensurePublisherConnected();
 
     if (kind === DataPacket_Kind.LOSSY && this.lossyDC) {
+      if (this.lossyDC.readyState === 'connecting') {
+        await sleep(1000);
+      }
       this.lossyDC.send(msg);
     } else if (kind === DataPacket_Kind.RELIABLE && this.reliableDC) {
+      if (this.reliableDC.readyState === 'connecting') {
+        await sleep(1000);
+      }
       this.reliableDC.send(msg);
     }
   }


### PR DESCRIPTION
We'll check if status is `connecting`. In that case wait 1 second before sending message. 

Fixed: https://github.com/livekit/livekit-server/issues/144