### PR TITLE
Automatically manage remote video track layer

### DIFF
--- a/example/sample.ts
+++ b/example/sample.ts
@@ -203,6 +203,7 @@ window.connectToRoom = async (
       rtcConfig,
       audio: shouldPublish,
       video: shouldPublish,
+      autoManageVideo: true,
       publishDefaults: {
         simulcast,
       },

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -48,7 +48,10 @@ export async function connect(
   }
 
   const client = new WSSignalClient();
-  const room = new Room(client, config);
+  const room = new Room(client, {
+    rtcConfig: options.rtcConfig,
+    autoManageVideo: options.autoManageVideo,
+  });
 
   // connect to room
   await room.connect(url, token, {

--- a/src/options.ts
+++ b/src/options.ts
@@ -10,6 +10,17 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
   /** autosubscribe to room tracks upon connect, defaults to true */
   autoSubscribe?: boolean;
 
+  /**
+   * automatically manage quality of subscribed video tracks, subscribe to the
+   * an appropriate resolution based on the size of the video elements that tracks
+   * are attached to.
+   *
+   * also observes the visibility of attached tracks and pauses receiving data
+   * if they are not visible.
+   *
+   */
+  autoManageVideo?: boolean;
+
   /** configures LiveKit internal log level */
   logLevel?: LogLevel;
 

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -242,4 +242,8 @@ export enum TrackEvent {
   AudioPlaybackStarted = 'audioPlaybackStarted',
   /** @internal */
   AudioPlaybackFailed = 'audioPlaybackFailed',
+  /** @internal */
+  VisibilityChanged = 'visibilityChanged',
+  /** @internal */
+  VideoDimensionsChanged = 'videoDimensionsChanged',
 }

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -1,5 +1,5 @@
-import log from '../../logger';
 import { SignalClient } from '../../api/SignalClient';
+import log from '../../logger';
 import { ParticipantInfo } from '../../proto/livekit_models';
 import {
   UpdateSubscription,
@@ -76,6 +76,7 @@ export default class RemoteParticipant extends Participant {
     mediaTrack: MediaStreamTrack,
     sid: Track.SID,
     receiver?: RTCRtpReceiver,
+    autoManageVideo?: boolean,
     triesLeft?: number,
   ) {
     // find the track publication
@@ -106,7 +107,7 @@ export default class RemoteParticipant extends Participant {
 
       if (triesLeft === undefined) triesLeft = 20;
       setTimeout(() => {
-        this.addSubscribedMediaTrack(mediaTrack, sid, receiver, triesLeft! - 1);
+        this.addSubscribedMediaTrack(mediaTrack, sid, receiver, autoManageVideo, triesLeft! - 1);
       }, 150);
       return;
     }
@@ -120,6 +121,7 @@ export default class RemoteParticipant extends Participant {
     }
     track.start();
 
+    publication.autoManageVideo = autoManageVideo;
     publication.setTrack(track);
     // set track name etc
     track.name = publication.trackName;

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -115,13 +115,12 @@ export default class RemoteParticipant extends Participant {
     const isVideo = mediaTrack.kind === 'video';
     let track: RemoteTrack;
     if (isVideo) {
-      track = new RemoteVideoTrack(mediaTrack, sid, receiver);
+      track = new RemoteVideoTrack(mediaTrack, sid, receiver, autoManageVideo);
     } else {
       track = new RemoteAudioTrack(mediaTrack, sid, receiver);
     }
     track.start();
 
-    publication.autoManageVideo = autoManageVideo;
     publication.setTrack(track);
     // set track name etc
     track.name = publication.trackName;

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -1,3 +1,4 @@
+import log from '../../logger';
 import { TrackInfo } from '../../proto/livekit_models';
 import {
   UpdateSubscription,
@@ -5,17 +6,23 @@ import {
   VideoQuality,
 } from '../../proto/livekit_rtc';
 import { TrackEvent } from '../events';
+import { Track } from './Track';
 import TrackPublication from './TrackPublication';
 import { RemoteTrack } from './types';
 
 export default class RemoteTrackPublication extends TrackPublication {
   track?: RemoteTrack;
 
+  /** @internal */
+  autoManageVideo?: boolean;
+
   protected subscribed?: boolean;
 
   protected disabled: boolean = false;
 
-  protected currentVideoQuality: VideoQuality = VideoQuality.HIGH;
+  protected currentVideoQuality?: VideoQuality = VideoQuality.HIGH;
+
+  protected videoDimensions?: Track.Dimensions;
 
   /**
    * Subscribe or unsubscribe to this remote track
@@ -49,7 +56,7 @@ export default class RemoteTrackPublication extends TrackPublication {
    * @param enabled
    */
   setEnabled(enabled: boolean) {
-    if (this.disabled === !enabled) {
+    if (this.autoManageVideo || this.disabled === !enabled) {
       return;
     }
     this.disabled = !enabled;
@@ -65,16 +72,40 @@ export default class RemoteTrackPublication extends TrackPublication {
    * optimize for uninterrupted video
    */
   setVideoQuality(quality: VideoQuality) {
-    if (this.currentVideoQuality === quality) {
+    if (this.autoManageVideo || this.currentVideoQuality === quality) {
       return;
     }
     this.currentVideoQuality = quality;
+    this.videoDimensions = undefined;
 
     this.emitTrackUpdate();
   }
 
-  get videoQuality(): VideoQuality {
+  setVideoDimensions(dimensions: Track.Dimensions) {
+    if (this.autoManageVideo) return;
+    if (this.videoDimensions?.width === dimensions.width
+        && this.videoDimensions?.height === dimensions.height) {
+      return;
+    }
+    this.videoDimensions = dimensions;
+    this.currentVideoQuality = undefined;
+
+    this.emitTrackUpdate();
+  }
+
+  get videoQuality(): VideoQuality | undefined {
     return this.currentVideoQuality;
+  }
+
+  setTrack(track?: Track) {
+    if (this.track) {
+      // unregister listener
+      this.track.off(TrackEvent.VideoDimensionsChanged, this.handleVideoDimensionsChange);
+      this.track.off(TrackEvent.VisibilityChanged, this.handleVisibilityChange);
+    }
+    super.setTrack(track);
+    this.track?.on(TrackEvent.VideoDimensionsChanged, this.handleVideoDimensionsChange);
+    this.track?.on(TrackEvent.VisibilityChanged, this.handleVisibilityChange);
   }
 
   /** @internal */
@@ -84,12 +115,38 @@ export default class RemoteTrackPublication extends TrackPublication {
     this.track?.setMuted(info.muted);
   }
 
+  protected handleVisibilityChange = (visible: boolean) => {
+    if (!this.autoManageVideo) {
+      return;
+    }
+    log.debug(`automanage video visibility, visible=${visible}`);
+    this.disabled = !visible;
+    this.emitTrackUpdate();
+  };
+
+  protected handleVideoDimensionsChange = (dimensions: Track.Dimensions) => {
+    if (!this.autoManageVideo) {
+      return;
+    }
+    log.debug(`automanage video dimensions, ${dimensions.width}x${dimensions.height}`);
+    this.videoDimensions = dimensions;
+    this.emitTrackUpdate();
+  };
+
   protected emitTrackUpdate() {
     const settings: UpdateTrackSettings = UpdateTrackSettings.fromPartial({
       trackSids: [this.trackSid],
       disabled: this.disabled,
-      quality: this.currentVideoQuality,
     });
+    if (this.videoDimensions) {
+      settings.width = this.videoDimensions.width;
+      settings.height = this.videoDimensions.height;
+    } else if (this.currentVideoQuality) {
+      settings.quality = this.currentVideoQuality;
+    } else {
+      // defaults to high quality
+      settings.quality = VideoQuality.HIGH;
+    }
 
     this.emit(TrackEvent.UpdateSettings, settings);
   }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -102,6 +102,7 @@ export default class RemoteVideoTrack extends Track {
 
   private stopObservingElement(element: HTMLMediaElement) {
     this.intersectionObserver.unobserve(element);
+    this.resizeObserver.unobserve(element);
     this.elementInfos = this.elementInfos.filter((info) => info.element !== element);
   }
 

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,6 +1,10 @@
+import { debounce } from 'ts-debounce';
+import log from '../../logger';
 import { TrackEvent } from '../events';
 import { VideoReceiverStats } from '../stats';
 import { attachToElement, detachTrack, Track } from './Track';
+
+const REACTION_DELAY = 1000;
 
 export default class RemoteVideoTrack extends Track {
   /** @internal */
@@ -8,6 +12,16 @@ export default class RemoteVideoTrack extends Track {
 
   // @ts-ignore noUnusedLocals
   private prevStats?: VideoReceiverStats;
+
+  private elementInfos: ElementInfo[] = [];
+
+  private intersectionObserver: IntersectionObserver;
+
+  private resizeObserver: ResizeObserver;
+
+  private lastVisible?: boolean;
+
+  private lastDimensions?: Track.Dimensions;
 
   constructor(
     mediaTrack: MediaStreamTrack,
@@ -18,6 +32,8 @@ export default class RemoteVideoTrack extends Track {
     // override id to parsed ID
     this.sid = sid;
     this.receiver = receiver;
+    this.intersectionObserver = new IntersectionObserver(this.handleVisibilityChanged);
+    this.resizeObserver = new ResizeObserver(debounce(this.handleResize, REACTION_DELAY));
   }
 
   /** @internal */
@@ -37,6 +53,43 @@ export default class RemoteVideoTrack extends Track {
     });
   }
 
+  attach(): HTMLMediaElement;
+  attach(element: HTMLMediaElement): HTMLMediaElement;
+  attach(element?: HTMLMediaElement): HTMLMediaElement {
+    if (!element) {
+      element = super.attach();
+    }
+    super.attach(element);
+
+    this.elementInfos.push({
+      element,
+      visible: true, // default visible
+      width: element.clientWidth,
+      height: element.clientHeight,
+    });
+    this.intersectionObserver.observe(element);
+    this.resizeObserver.observe(element);
+
+    return element;
+  }
+
+  detach(): HTMLMediaElement[];
+  detach(element: HTMLMediaElement): HTMLMediaElement;
+  detach(element?: HTMLMediaElement): HTMLMediaElement | HTMLMediaElement[] {
+    let detachedElements: HTMLMediaElement[] = [];
+    if (element) {
+      detachedElements.push(element);
+      return super.detach(element);
+    }
+    detachedElements = super.detach();
+
+    for (const e of detachedElements) {
+      this.stopObservingElement(e);
+    }
+
+    return detachedElements;
+  }
+
   start() {
     // use `enabled` of track to enable re-use of transceiver
     super.enable();
@@ -46,4 +99,90 @@ export default class RemoteVideoTrack extends Track {
     // use `enabled` of track to enable re-use of transceiver
     super.disable();
   }
+
+  private stopObservingElement(element: HTMLMediaElement) {
+    this.intersectionObserver.unobserve(element);
+    this.elementInfos = this.elementInfos.filter((info) => info.element !== element);
+  }
+
+  private handleVisibilityChanged = (entries: IntersectionObserverEntry[]) => {
+    for (const entry of entries) {
+      const { target, isIntersecting } = entry;
+      const elementInfo = this.elementInfos.find((info) => info.element === target);
+      if (elementInfo) {
+        elementInfo.visible = isIntersecting;
+        elementInfo.visibilityChangedAt = Date.now();
+      }
+    }
+    this.updateVisibility();
+  };
+
+  private handleResize = (entries: ResizeObserverEntry[]) => {
+    for (const entry of entries) {
+      const { target, contentRect } = entry;
+      const elementInfo = this.elementInfos.find((info) => info.element === target);
+      if (elementInfo) {
+        elementInfo.width = contentRect.width;
+        elementInfo.height = contentRect.height;
+        log.debug(
+          `RemoteVideoTrack ${this.sid} resized to ${elementInfo.width}x${elementInfo.height}`,
+        );
+      }
+    }
+    this.updateDimensions();
+  };
+
+  private updateVisibility() {
+    const lastVisibilityChange = this.elementInfos.reduce(
+      (prev, info) => Math.max(prev, info.visibilityChangedAt || 0),
+      0,
+    );
+    const isVisible = this.elementInfos.some((info) => info.visible);
+
+    if (this.lastVisible === isVisible) {
+      return;
+    }
+
+    if (!isVisible && Date.now() - lastVisibilityChange < REACTION_DELAY) {
+      // delay hidden events
+      setTimeout(() => {
+        this.updateVisibility();
+      }, Date.now() - lastVisibilityChange);
+      return;
+    }
+
+    this.lastVisible = isVisible;
+    this.emit(TrackEvent.VisibilityChanged, isVisible, this);
+  }
+
+  private updateDimensions() {
+    let maxWidth = 0;
+    let maxHeight = 0;
+    for (const info of this.elementInfos) {
+      if (info.visible) {
+        if (info.width + info.height > maxWidth + maxHeight) {
+          maxWidth = info.width;
+          maxHeight = info.height;
+        }
+      }
+    }
+
+    if (this.lastDimensions?.width === maxWidth && this.lastDimensions?.height === maxHeight) {
+      return;
+    }
+
+    this.lastDimensions = {
+      width: maxWidth,
+      height: maxHeight,
+    };
+    this.emit(TrackEvent.VideoDimensionsChanged, this.lastDimensions, this);
+  }
+}
+
+interface ElementInfo {
+  element: HTMLMediaElement;
+  width: number;
+  height: number;
+  visible: boolean;
+  visibilityChangedAt?: number;
 }

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -32,7 +32,14 @@ export class Track extends EventEmitter {
     this.source = Track.Source.Unknown;
   }
 
+  /**
+   * creates a new HTMLAudioElement or HTMLVideoElement, attaches to it, and returns it
+   */
   attach(): HTMLMediaElement;
+
+  /**
+   * attaches track to an existing HTMLAudioElement or HTMLVideoElement
+   */
   attach(element: HTMLMediaElement): HTMLMediaElement;
   attach(element?: HTMLMediaElement): HTMLMediaElement {
     let elementType = 'audio';
@@ -83,7 +90,15 @@ export class Track extends EventEmitter {
     return element;
   }
 
+  /**
+   * Detaches from all attached elements
+   */
   detach(): HTMLMediaElement[];
+
+  /**
+   * Detach from a single element
+   * @param element
+   */
   detach(element: HTMLMediaElement): HTMLMediaElement;
   detach(element?: HTMLMediaElement): HTMLMediaElement | HTMLMediaElement[] {
     // detach from a single element


### PR DESCRIPTION
Opt-in feature for now. When enabled, the client will automatically request an appropriately sized layer that matches the attached video elements. It'll also pause the stream when the object becomes invisible, without requiring explicit management from client apps.