### PR TITLE
use shared observers for auto managed video

### DIFF
--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -72,9 +72,9 @@ export default class RemoteVideoTrack extends Track {
       });
 
       (element as ObservableMediaElement)
-        .handleResize = debounce(this.handleResize, REACTION_DELAY);
+        .handleResize = this.debouncedHandleResize;
       (element as ObservableMediaElement)
-        .handleVisibilityChanged = debounce(this.handleVisibilityChanged, REACTION_DELAY);
+        .handleVisibilityChanged = this.debouncedHandleVisibilityChanged;
 
       intersectionObserver.observe(element);
       resizeObserver.observe(element);
@@ -125,6 +125,10 @@ export default class RemoteVideoTrack extends Track {
     this.updateVisibility();
   };
 
+  private readonly debouncedHandleVisibilityChanged = debounce(
+    this.handleVisibilityChanged, REACTION_DELAY,
+  );
+
   private handleResize = (entry: ResizeObserverEntry) => {
     const { target, contentRect } = entry;
     const elementInfo = this.elementInfos.find((info) => info.element === target);
@@ -134,6 +138,8 @@ export default class RemoteVideoTrack extends Track {
     }
     this.updateDimensions();
   };
+
+  private readonly debouncedHandleResize = debounce(this.handleResize, REACTION_DELAY);
 
   private updateVisibility() {
     const lastVisibilityChange = this.elementInfos.reduce(

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,6 +1,7 @@
 import { debounce } from 'ts-debounce';
 import { TrackEvent } from '../events';
 import { VideoReceiverStats } from '../stats';
+import { intersectionObserver, resizeObserver, ObservableMediaElement } from '../utils';
 import { attachToElement, detachTrack, Track } from './Track';
 
 const REACTION_DELAY = 1000;
@@ -13,10 +14,6 @@ export default class RemoteVideoTrack extends Track {
   private prevStats?: VideoReceiverStats;
 
   private elementInfos: ElementInfo[] = [];
-
-  private intersectionObserver?: IntersectionObserver;
-
-  private resizeObserver?: ResizeObserver;
 
   private autoManaged?: boolean;
 
@@ -35,10 +32,6 @@ export default class RemoteVideoTrack extends Track {
     this.sid = sid;
     this.receiver = receiver;
     this.autoManaged = autoManaged;
-    if (this.isAutoManaged) {
-      this.intersectionObserver = new IntersectionObserver(this.handleVisibilityChanged);
-      this.resizeObserver = new ResizeObserver(debounce(this.handleResize, REACTION_DELAY));
-    }
   }
 
   get isAutoManaged(): boolean {
@@ -70,15 +63,21 @@ export default class RemoteVideoTrack extends Track {
     }
     super.attach(element);
 
-    if (this.intersectionObserver && this.resizeObserver) {
+    if (this.autoManaged) {
       this.elementInfos.push({
         element,
         visible: true, // default visible
         width: element.clientWidth,
         height: element.clientHeight,
       });
-      this.intersectionObserver.observe(element);
-      this.resizeObserver.observe(element);
+
+      (element as ObservableMediaElement)
+        .handleResize = debounce(this.handleResize, REACTION_DELAY);
+      (element as ObservableMediaElement)
+        .handleVisibilityChanged = debounce(this.handleVisibilityChanged, REACTION_DELAY);
+
+      intersectionObserver.observe(element);
+      resizeObserver.observe(element);
     }
     return element;
   }
@@ -111,35 +110,27 @@ export default class RemoteVideoTrack extends Track {
   }
 
   private stopObservingElement(element: HTMLMediaElement) {
-    if (this.intersectionObserver) {
-      this.intersectionObserver.unobserve(element);
-    }
-    if (this.resizeObserver) {
-      this.resizeObserver.unobserve(element);
-    }
+    intersectionObserver?.unobserve(element);
+    resizeObserver?.unobserve(element);
     this.elementInfos = this.elementInfos.filter((info) => info.element !== element);
   }
 
-  private handleVisibilityChanged = (entries: IntersectionObserverEntry[]) => {
-    for (const entry of entries) {
-      const { target, isIntersecting } = entry;
-      const elementInfo = this.elementInfos.find((info) => info.element === target);
-      if (elementInfo) {
-        elementInfo.visible = isIntersecting;
-        elementInfo.visibilityChangedAt = Date.now();
-      }
+  private handleVisibilityChanged = (entry: IntersectionObserverEntry) => {
+    const { target, isIntersecting } = entry;
+    const elementInfo = this.elementInfos.find((info) => info.element === target);
+    if (elementInfo) {
+      elementInfo.visible = isIntersecting;
+      elementInfo.visibilityChangedAt = Date.now();
     }
     this.updateVisibility();
   };
 
-  private handleResize = (entries: ResizeObserverEntry[]) => {
-    for (const entry of entries) {
-      const { target, contentRect } = entry;
-      const elementInfo = this.elementInfos.find((info) => info.element === target);
-      if (elementInfo) {
-        elementInfo.width = contentRect.width;
-        elementInfo.height = contentRect.height;
-      }
+  private handleResize = (entry: ResizeObserverEntry) => {
+    const { target, contentRect } = entry;
+    const elementInfo = this.elementInfos.find((info) => info.element === target);
+    if (elementInfo) {
+      elementInfo.width = contentRect.width;
+      elementInfo.height = contentRect.height;
     }
     this.updateDimensions();
   };

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -16,3 +16,21 @@ export function useLegacyAPI(): boolean {
 export async function sleep(duration: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, duration));
 }
+
+function roDispatchCallback(entries: ResizeObserverEntry[]) {
+  for (const entry of entries) {
+    (entry.target as ObservableMediaElement).handleResize(entry);
+  }
+}
+
+function ioDispatchCallback(entries: IntersectionObserverEntry[]) {
+  for (const entry of entries) {
+    (entry.target as ObservableMediaElement).handleVisibilityChanged(entry);
+  }
+}
+export const resizeObserver = new ResizeObserver(roDispatchCallback);
+export const intersectionObserver = new IntersectionObserver(ioDispatchCallback);
+export interface ObservableMediaElement extends HTMLMediaElement {
+  handleResize: (entry: ResizeObserverEntry) => void;
+  handleVisibilityChanged: (entry: IntersectionObserverEntry) => void;
+}


### PR DESCRIPTION
an attempt at using shared observers. 
One downside is that one InteractionObserver and one ResizeObserver will be created even if autoManageVideo is false.
but at least they will never observe any elements in that case, so the impact should be negligible.

not sure about where to put the `ObservableMediaElement` interface. Putting it into `types` resulted in a dependency loop.

reference for implementation: https://groups.google.com/a/chromium.org/g/blink-dev/c/z6ienONUb5A/m/F5-VcUZtBAAJ