### PR TITLE
add option to keep local tracks running after disconnect

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -236,12 +236,12 @@ class Room extends EventEmitter {
   /**
    * disconnects the room, emits [[RoomEvent.Disconnected]]
    */
-  disconnect = () => {
-    // send leave
+  disconnect(): void;
+  disconnect(stopTracks = true): void {
     this.engine.client.sendLeave();
     this.engine.close();
-    this.handleDisconnect();
-  };
+    this.handleDisconnect(stopTracks);
+  }
 
   /**
    * Set default publish options
@@ -362,7 +362,7 @@ class Room extends EventEmitter {
     );
   }
 
-  private handleDisconnect() {
+  private handleDisconnect(shouldStopTracks = true) {
     if (this.state === RoomState.Disconnected) {
       return;
     }
@@ -371,10 +371,12 @@ class Room extends EventEmitter {
         p.unpublishTrack(pub.trackSid);
       });
     });
-    this.localParticipant.tracks.forEach((pub) => {
-      pub.track?.detach();
-      pub.track?.stop();
-    });
+    if (shouldStopTracks) {
+      this.localParticipant.tracks.forEach((pub) => {
+        pub.track?.detach();
+        pub.track?.stop();
+      });
+    }
     this.participants.clear();
     this.activeSpeakers = [];
     if (this.audioContext) {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -82,8 +82,6 @@ class Room extends EventEmitter {
 
   private audioContext?: AudioContext;
 
-  private disconnectCallbackRef = () => this.disconnect();
-
   /** @internal */
   constructor(client: SignalClient, options?: RoomOptions) {
     super();
@@ -227,7 +225,8 @@ class Room extends EventEmitter {
         clearTimeout(connectTimeout);
 
         // also hook unload event
-        window.addEventListener('beforeunload', this.disconnectCallbackRef);
+        // @ts-ignore
+        window.addEventListener('beforeunload', this.disconnect);
         navigator.mediaDevices.addEventListener('devicechange', this.handleDeviceChange);
 
         resolve(this);
@@ -238,12 +237,12 @@ class Room extends EventEmitter {
   /**
    * disconnects the room, emits [[RoomEvent.Disconnected]]
    */
-  disconnect(stopTracks = true): void {
+  disconnect = (stopTracks = true) => {
     // send leave
     this.engine.client.sendLeave();
     this.engine.close();
     this.handleDisconnect(stopTracks);
-  }
+  };
 
   /**
    * Set default publish options
@@ -385,7 +384,8 @@ class Room extends EventEmitter {
       this.audioContext.close();
       this.audioContext = undefined;
     }
-    window.removeEventListener('beforeunload', this.disconnectCallbackRef);
+    // @ts-ignore
+    window.removeEventListener('beforeunload', this.disconnect);
     navigator.mediaDevices.removeEventListener('devicechange', this.handleDeviceChange);
     this.emit(RoomEvent.Disconnected);
     this.state = RoomState.Disconnected;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -225,8 +225,7 @@ class Room extends EventEmitter {
         clearTimeout(connectTimeout);
 
         // also hook unload event
-        // @ts-ignore
-        window.addEventListener('beforeunload', this.disconnect);
+        window.addEventListener('beforeunload', this.onBeforeUnload);
         navigator.mediaDevices.addEventListener('devicechange', this.handleDeviceChange);
 
         resolve(this);
@@ -242,6 +241,10 @@ class Room extends EventEmitter {
     this.engine.client.sendLeave();
     this.engine.close();
     this.handleDisconnect(stopTracks);
+  };
+
+  private onBeforeUnload = () => {
+    this.disconnect();
   };
 
   /**
@@ -384,8 +387,7 @@ class Room extends EventEmitter {
       this.audioContext.close();
       this.audioContext = undefined;
     }
-    // @ts-ignore
-    window.removeEventListener('beforeunload', this.disconnect);
+    window.removeEventListener('beforeunload', this.onBeforeUnload);
     navigator.mediaDevices.removeEventListener('devicechange', this.handleDeviceChange);
     this.emit(RoomEvent.Disconnected);
     this.state = RoomState.Disconnected;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -238,6 +238,7 @@ class Room extends EventEmitter {
    */
   disconnect(): void;
   disconnect(stopTracks = true): void {
+    // send leave
     this.engine.client.sendLeave();
     this.engine.close();
     this.handleDisconnect(stopTracks);

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -82,6 +82,8 @@ class Room extends EventEmitter {
 
   private audioContext?: AudioContext;
 
+  private disconnectCallbackRef = () => this.disconnect();
+
   /** @internal */
   constructor(client: SignalClient, options?: RoomOptions) {
     super();
@@ -225,7 +227,7 @@ class Room extends EventEmitter {
         clearTimeout(connectTimeout);
 
         // also hook unload event
-        window.addEventListener('beforeunload', this.disconnect);
+        window.addEventListener('beforeunload', this.disconnectCallbackRef);
         navigator.mediaDevices.addEventListener('devicechange', this.handleDeviceChange);
 
         resolve(this);
@@ -236,7 +238,6 @@ class Room extends EventEmitter {
   /**
    * disconnects the room, emits [[RoomEvent.Disconnected]]
    */
-  disconnect(): void;
   disconnect(stopTracks = true): void {
     // send leave
     this.engine.client.sendLeave();
@@ -384,7 +385,7 @@ class Room extends EventEmitter {
       this.audioContext.close();
       this.audioContext = undefined;
     }
-    window.removeEventListener('beforeunload', this.disconnect);
+    window.removeEventListener('beforeunload', this.disconnectCallbackRef);
     navigator.mediaDevices.removeEventListener('devicechange', this.handleDeviceChange);
     this.emit(RoomEvent.Disconnected);
     this.state = RoomState.Disconnected;


### PR DESCRIPTION
currently whenever you disconnect from a room, all local tracks get stopped and detached from their HTMLElements.

This PR adds an option to keep the local tracks running after a disconnect. The implementation introduces `stopTracks` as a way to determine whether the localTracks should be stopped (and detached) or not. Defaults to `stopTracks = true` in order to not change the current behaviour.

Reasoning:
When managing local tracks independently from rooms it is desirable to persist them across room changes.
In a scenario where room switching should happen as smoothly as possible one would not want to attach and reattach local videotracks to html elements.

It's unfortunate that the event handler of `unbeforeunload` complains with the new boolean function property. 
To minimize code changes I added ts-ignore comments before the event handler assignments, because I couldn't think of a cleaner way to handle it.