### PR TITLE
fix shared resize observer for SSR frameworks

### DIFF
--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,7 +1,7 @@
 import { debounce } from 'ts-debounce';
 import { TrackEvent } from '../events';
 import { VideoReceiverStats } from '../stats';
-import { intersectionObserver, resizeObserver, ObservableMediaElement } from '../utils';
+import { getIntersectionObserver, getResizeObserver, ObservableMediaElement } from '../utils';
 import { attachToElement, detachTrack, Track } from './Track';
 
 const REACTION_DELAY = 1000;
@@ -76,8 +76,8 @@ export default class RemoteVideoTrack extends Track {
       (element as ObservableMediaElement)
         .handleVisibilityChanged = this.debouncedHandleVisibilityChanged;
 
-      intersectionObserver.observe(element);
-      resizeObserver.observe(element);
+      getIntersectionObserver().observe(element);
+      getResizeObserver().observe(element);
     }
     return element;
   }
@@ -110,8 +110,8 @@ export default class RemoteVideoTrack extends Track {
   }
 
   private stopObservingElement(element: HTMLMediaElement) {
-    intersectionObserver?.unobserve(element);
-    resizeObserver?.unobserve(element);
+    getIntersectionObserver()?.unobserve(element);
+    getResizeObserver()?.unobserve(element);
     this.elementInfos = this.elementInfos.filter((info) => info.element !== element);
   }
 

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -28,8 +28,19 @@ function ioDispatchCallback(entries: IntersectionObserverEntry[]) {
     (entry.target as ObservableMediaElement).handleVisibilityChanged(entry);
   }
 }
-export const resizeObserver = new ResizeObserver(roDispatchCallback);
-export const intersectionObserver = new IntersectionObserver(ioDispatchCallback);
+
+let resizeObserver: ResizeObserver | null = null;
+export const getResizeObserver = () => {
+  if (!resizeObserver) resizeObserver = new ResizeObserver(roDispatchCallback);
+  return resizeObserver;
+};
+
+let intersectionObserver: IntersectionObserver | null = null;
+export const getIntersectionObserver = () => {
+  if (!intersectionObserver) intersectionObserver = new IntersectionObserver(ioDispatchCallback);
+  return intersectionObserver;
+};
+
 export interface ObservableMediaElement extends HTMLMediaElement {
   handleResize: (entry: ResizeObserverEntry) => void;
   handleVisibilityChanged: (entry: IntersectionObserverEntry) => void;


### PR DESCRIPTION
When implementing #78 I unfortunately forgot about SSR frameworks (e.g. nextjs, nuxt, sveltekit).

I only tested now with sveltekit but the client library cannot be imported anymore (without workarounds) as sveltekit analyzes the library within nodejs and the implementation of #78 uses the browser-specific `ResizeObserver` and `IntersectionObserver` and executes them on import -> errors thrown within node.

This PR tries to address this. RO and IO are only instantiated when they are first called, thus circumventing the automatic instantiation on import.