### PR TITLE
Improved resize auto-management. Reduce visible delay

### DIFF
--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -123,13 +123,13 @@ export default class RemoteTrackPublication extends TrackPublication {
   }
 
   protected handleVisibilityChange = (visible: boolean) => {
-    log.debug(`automanage video visibility, visible=${visible}`);
+    log.debug('automanage video visibility', this.trackSid, `visible=${visible}`);
     this.disabled = !visible;
     this.emitTrackUpdate();
   };
 
   protected handleVideoDimensionsChange = (dimensions: Track.Dimensions) => {
-    log.debug(`automanage video dimensions, ${dimensions.width}x${dimensions.height}`);
+    log.debug('automanage video dimensions', this.trackSid, `${dimensions.width}x${dimensions.height}`);
     this.videoDimensions = dimensions;
     this.emitTrackUpdate();
   };


### PR DESCRIPTION
When multiple elements were attached, debouncer ate all but one update.

Also removed visibility debounce, so we can detect invisible -> visible change much faster
