### PR TITLE
keep order of user provided capture constraints

### DIFF
--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -16,18 +16,24 @@ export function mergeDefaultOptions(
 
   // use defaults
   if (opts.audio) {
-    opts.audio = {
-      ...audioDefaults,
-      ...opts.audio,
-    };
+    mergeObjectWithoutOverwriting(opts.audio as Record<string, unknown>,
+      audioDefaults as Record<string, unknown>);
   }
   if (opts.video) {
-    opts.video = {
-      ...videoDefaults,
-      ...opts.video,
-    };
+    mergeObjectWithoutOverwriting(opts.video as Record<string, unknown>,
+      videoDefaults as Record<string, unknown>);
   }
   return opts;
+}
+
+function mergeObjectWithoutOverwriting(
+  mainObject: Record<string, unknown>,
+  objectToMerge: Record<string, unknown>,
+): Record<string, unknown> {
+  Object.keys(objectToMerge).forEach((key) => {
+    if (!mainObject[key]) mainObject[key] = objectToMerge[key];
+  });
+  return mainObject;
 }
 
 export function constraintsForOptions(options: CreateLocalTracksOptions): MediaStreamConstraints {


### PR DESCRIPTION
when reading through #91, I realised that the order of properties was already being overriden by the defaults-order previously in the merge function. 
This change merges defaults and user provided options in  a way that keeps the property order of the `mainObject` and adds all properties of `objectToMerge` that are not present on the `mainObject`.

function adapted to TS from this answer https://stackoverflow.com/a/66525560

edit: target-branch of this PR is the branch of #91 