### PR TITLE
unsubscribe from track event listeners when unpublishing

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -353,9 +353,7 @@ export default class LocalParticipant extends Participant {
     // handle track actions
     track.on(TrackEvent.Muted, this.onTrackMuted);
     track.on(TrackEvent.Unmuted, this.onTrackUnmuted);
-    track.on(TrackEvent.Ended, () => {
-      this.unpublishTrack(track);
-    });
+    track.on(TrackEvent.Ended, this.onTrackUnpublish);
 
     // create track publication from track
     const req = AddTrackRequest.fromPartial({
@@ -457,6 +455,10 @@ export default class LocalParticipant extends Participant {
       mediaStreamTrack = track;
     } else {
       mediaStreamTrack = track.mediaStreamTrack;
+
+      track.off(TrackEvent.Muted, this.onTrackMuted);
+      track.off(TrackEvent.Unmuted, this.onTrackUnmuted);
+      track.off(TrackEvent.Ended, this.onTrackUnpublish);
     }
 
     if (this.engine.publisher) {
@@ -565,6 +567,10 @@ export default class LocalParticipant extends Participant {
     }
 
     this.engine.updateMuteStatus(track.sid, muted);
+  };
+
+  onTrackUnpublish = (track: LocalTrack) => {
+    this.unpublishTrack(track);
   };
 
   private getPublicationForTrack(


### PR DESCRIPTION
I was reusing `LocalTrack`s across different rooms and ran into a memory leak:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unmuted listeners added. Use emitter.setMaxListeners() to increase limit
    _addListener events.js:211
    addListener events.js:227
    client livekit-client.js:4364
    client livekit-client.js:4185
    client livekit-client.js:4167
    publishTrack livekit-client.js:4328
```

I realized that the event listeners are not unsubscribed when you unpublish a local track. 
I didn't check more closely if there are any other things that should get disposed when unpublishing, that could cause problems when reusing Tracks across rooms, but maybe worth investigating.