### PR TITLE
set metadata on room connect

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -253,6 +253,7 @@ class Room extends EventEmitter {
 
       this.name = joinResponse.room!.name;
       this.sid = joinResponse.room!.sid;
+      this.metadata = joinResponse.room!.metadata;
     } catch (err) {
       this.engine.close();
       throw err;


### PR DESCRIPTION
seems like this was missing and lead to metadata always being undefined when connecting.