### PR TITLE
Restore createLocalTracks method for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ You can use the helper `MediaDeviceFailure.getFailure(error)` to determine speci
 
 These distinctions enables you to provide more specific messaging to the user.
 
-You could also retrieve the last error with `getLastAudioCreateError` and `getLastVideoCreateError`.
+You could also retrieve the last error with `LocalParticipant.lastCameraError` and `LocalParticipant.lastMicrophoneError`.
 
 ### Audio playback
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './connect';
 export * from './options';
 export * from './room/errors';
 export * from './room/events';
+export * from './room/track/create';
 export * from './room/track/options';
 export * from './room/track/Track';
 export * from './room/track/types';

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -15,15 +15,8 @@ import LocalParticipant from './participant/LocalParticipant';
 import Participant, { ConnectionQuality } from './participant/Participant';
 import RemoteParticipant from './participant/RemoteParticipant';
 import RTCEngine, { maxICEConnectTimeout } from './RTCEngine';
+import { audioDefaults, publishDefaults, videoDefaults } from './track/defaults';
 import LocalTrackPublication from './track/LocalTrackPublication';
-import {
-  AudioCaptureOptions,
-  AudioPresets,
-  ScreenSharePresets,
-  TrackPublishDefaults,
-  VideoCaptureOptions,
-  VideoPresets,
-} from './track/options';
 import RemoteTrackPublication from './track/RemoteTrackPublication';
 import { Track } from './track/Track';
 import TrackPublication from './track/TrackPublication';
@@ -35,25 +28,6 @@ export enum RoomState {
   Connected = 'connected',
   Reconnecting = 'reconnecting',
 }
-
-const publishDefaults: TrackPublishDefaults = {
-  audioBitrate: AudioPresets.speech.maxBitrate,
-  dtx: true,
-  simulcast: true,
-  screenShareEncoding: ScreenSharePresets.hd_15.encoding,
-  stopMicTrackOnMute: false,
-};
-
-const audioDefaults: AudioCaptureOptions = {
-  autoGainControl: true,
-  channelCount: 1,
-  echoCancellation: true,
-  noiseSuppression: true,
-};
-
-const videoDefaults: VideoCaptureOptions = {
-  resolution: VideoPresets.qhd.resolution,
-};
 
 /**
  * In LiveKit, a room is the logical grouping for a list of participants.

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -1,0 +1,115 @@
+import { TrackInvalidError } from '../errors';
+import { mediaTrackToLocalTrack } from '../participant/publishUtils';
+import { audioDefaults, videoDefaults } from './defaults';
+import LocalAudioTrack from './LocalAudioTrack';
+import LocalTrack from './LocalTrack';
+import LocalVideoTrack from './LocalVideoTrack';
+import {
+  AudioCaptureOptions, CreateLocalTracksOptions, ScreenShareCaptureOptions,
+  VideoCaptureOptions, VideoPresets,
+} from './options';
+import { Track } from './Track';
+import { constraintsForOptions, mergeDefaultOptions } from './utils';
+
+/**
+ * Creates a local video and audio track at the same time. When acquiring both
+ * audio and video tracks together, it'll display a single permission prompt to
+ * the user instead of two separate ones.
+ * @param options
+ */
+export async function createLocalTracks(
+  options?: CreateLocalTracksOptions,
+): Promise<Array<LocalTrack>> {
+  const opts = mergeDefaultOptions(options, audioDefaults, videoDefaults);
+  const constraints = constraintsForOptions(opts);
+  const stream = await navigator.mediaDevices.getUserMedia(
+    constraints,
+  );
+  return stream.getTracks().map((mediaStreamTrack) => {
+    const isAudio = mediaStreamTrack.kind === 'audio';
+    let trackOptions = isAudio ? options!.audio : options!.video;
+    if (typeof trackOptions === 'boolean' || !trackOptions) {
+      trackOptions = {};
+    }
+    let trackConstraints: MediaTrackConstraints | undefined;
+    const conOrBool = isAudio ? constraints.audio : constraints.video;
+    if (typeof conOrBool !== 'boolean') {
+      trackConstraints = conOrBool;
+    }
+    const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints);
+    if (track.kind === Track.Kind.Video) {
+      track.source = Track.Source.Camera;
+    } else if (track.kind === Track.Kind.Audio) {
+      track.source = Track.Source.Microphone;
+    }
+    return track;
+  });
+}
+
+/**
+ * Creates a [[LocalVideoTrack]] with getUserMedia()
+ * @param options
+ */
+export async function createLocalVideoTrack(
+  options?: VideoCaptureOptions,
+): Promise<LocalVideoTrack> {
+  const tracks = await createLocalTracks({
+    audio: false,
+    video: options,
+  });
+  return <LocalVideoTrack>tracks[0];
+}
+
+export async function createLocalAudioTrack(
+  options?: AudioCaptureOptions,
+): Promise<LocalAudioTrack> {
+  const tracks = await createLocalTracks({
+    audio: options,
+    video: false,
+  });
+  return <LocalAudioTrack>tracks[0];
+}
+
+/**
+ * Creates a screen capture tracks with getDisplayMedia().
+ * A LocalVideoTrack is always created and returned.
+ * If { audio: true }, and the browser supports audio capture, a LocalAudioTrack is also created.
+ */
+export async function createLocalScreenTracks(
+  options?: ScreenShareCaptureOptions,
+): Promise<Array<LocalTrack>> {
+  if (options === undefined) {
+    options = {};
+  }
+  if (options.resolution === undefined) {
+    options.resolution = VideoPresets.fhd.resolution;
+  }
+
+  let videoConstraints: MediaTrackConstraints | boolean = true;
+  if (options.resolution) {
+    videoConstraints = {
+      width: options.resolution.width,
+      height: options.resolution.height,
+    };
+  }
+  // typescript definition is missing getDisplayMedia: https://github.com/microsoft/TypeScript/issues/33232
+  // @ts-ignore
+  const stream: MediaStream = await navigator.mediaDevices.getDisplayMedia({
+    audio: options.audio ?? false,
+    video: videoConstraints,
+  });
+
+  const tracks = stream.getVideoTracks();
+  if (tracks.length === 0) {
+    throw new TrackInvalidError('no video track found');
+  }
+  const screenVideo = new LocalVideoTrack(tracks[0]);
+  screenVideo.source = Track.Source.ScreenShare;
+  const localTracks: Array<LocalTrack> = [screenVideo];
+  if (stream.getAudioTracks().length > 0) {
+    const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0]);
+    screenAudio.source = Track.Source.ScreenShareAudio;
+    localTracks.push(screenAudio);
+  }
+  return localTracks;
+}

--- a/src/room/track/defaults.ts
+++ b/src/room/track/defaults.ts
@@ -1,0 +1,23 @@
+import {
+  AudioCaptureOptions, AudioPresets, ScreenSharePresets,
+  TrackPublishDefaults, VideoCaptureOptions, VideoPresets,
+} from './options';
+
+export const publishDefaults: TrackPublishDefaults = {
+  audioBitrate: AudioPresets.speech.maxBitrate,
+  dtx: true,
+  simulcast: true,
+  screenShareEncoding: ScreenSharePresets.hd_15.encoding,
+  stopMicTrackOnMute: false,
+};
+
+export const audioDefaults: AudioCaptureOptions = {
+  autoGainControl: true,
+  channelCount: 1,
+  echoCancellation: true,
+  noiseSuppression: true,
+};
+
+export const videoDefaults: VideoCaptureOptions = {
+  resolution: VideoPresets.qhd.resolution,
+};


### PR DESCRIPTION
Folks reported using `createLocalTracks` to create "preview" tracks prior to the user connecting to a room. This is a valid use case that we broke by removing these top level functions previously. Re-introducing them back for backwards compatibility and to satisfy the preview use case.