### PR TITLE
Expose track-level upstream & downstream stats

### DIFF
--- a/example/sample.ts
+++ b/example/sample.ts
@@ -1,9 +1,11 @@
 import {
   DataPacket_Kind, LocalParticipant,
+  LocalTrack,
   MediaDeviceFailure,
   Participant,
   ParticipantEvent,
-  RemoteParticipant, Room, RoomConnectOptions, RoomEvent,
+  RemoteAudioTrack,
+  RemoteParticipant, RemoteVideoTrack, Room, RoomConnectOptions, RoomEvent,
   RoomOptions, RoomState, setLogLevel, Track, TrackPublication,
   VideoCaptureOptions, VideoPresets,
 } from '../src/index';
@@ -16,8 +18,8 @@ const state = {
   encoder: new TextEncoder(),
   decoder: new TextDecoder(),
   defaultDevices: new Map<MediaDeviceKind, string>(),
+  bitrateInterval: undefined as any,
 };
-
 let currentRoom: Room | undefined;
 
 // handles actions from the HTML
@@ -56,6 +58,8 @@ const appActions = {
       await room.localParticipant.enableCameraAndMicrophone();
       updateButtonsForPublishState();
     }
+
+    state.bitrateInterval = setInterval(renderBitrate, 1000);
   },
 
   connectToRoom: async (
@@ -202,6 +206,9 @@ const appActions = {
     if (currentRoom) {
       currentRoom.disconnect();
     }
+    if (state.bitrateInterval) {
+      clearInterval(state.bitrateInterval);
+    }
   },
 
   disconnectSignal: () => {
@@ -342,7 +349,11 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       <div class="info-bar">
         <div id="name-${participant.sid}" class="name">
         </div>
-        <div id="size-${participant.sid}" class="size">
+        <div style="text-align: center;">
+          <span id="size-${participant.sid}" class="size">
+          </span>
+          <span id="bitrate-${participant.sid}" class="bitrate">
+          </span>
         </div>
         <div class="right">
           <span id="signal-${participant.sid}"></span>
@@ -387,11 +398,18 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
 
   const cameraEnabled = cameraPub && cameraPub.isSubscribed && !cameraPub.isMuted;
   if (cameraEnabled) {
-    cameraPub?.videoTrack?.attach(videoElm);
     if (participant instanceof LocalParticipant) {
       // flip
       videoElm.style.transform = 'scale(-1, 1)';
+    } else if (!cameraPub?.videoTrack?.attachedElements.includes(videoElm)) {
+      const startTime = Date.now();
+      // measure time to render
+      videoElm.addEventListener('loadeddata', () => {
+        const elapsed = Date.now() - startTime;
+        appendLog(`RemoteVideoTrack ${cameraPub?.trackSid} rendered in ${elapsed}ms`);
+      });
     }
+    cameraPub?.videoTrack?.attach(videoElm);
   } else if (cameraPub?.videoTrack) {
     // detach manually whenever possible
     cameraPub.videoTrack?.detach(videoElm);
@@ -462,6 +480,32 @@ function renderScreenShare() {
     infoElm.innerHTML = `Screenshare from ${participant.identity}`;
   } else {
     div.style.display = 'none';
+  }
+}
+
+function renderBitrate() {
+  if (!currentRoom || currentRoom.state !== RoomState.Connected) {
+    return;
+  }
+  const participants: Participant[] = [...currentRoom.participants.values()];
+  participants.push(currentRoom.localParticipant);
+
+  for (const p of participants) {
+    const elm = $(`bitrate-${p.sid}`);
+    let totalBitrate = 0;
+    for (const t of p.tracks.values()) {
+      if (t.track instanceof RemoteAudioTrack || t.track instanceof RemoteVideoTrack
+        || t.track instanceof LocalTrack) {
+        totalBitrate += t.track.currentBitrate;
+      }
+    }
+    let displayText = '';
+    if (totalBitrate > 0) {
+      displayText = `${Math.round(totalBitrate / 1024).toLocaleString()} kbps`;
+    }
+    if (elm) {
+      elm.innerHTML = displayText;
+    }
   }
 }
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -416,6 +416,8 @@ export default class LocalParticipant extends Participant {
     const disableLayerPause = this.roomOptions?.expDisableLayerPause ?? false;
     if (track instanceof LocalVideoTrack && !disableLayerPause) {
       track.startMonitor(this.engine.client);
+    } else if (track instanceof LocalAudioTrack) {
+      track.startMonitor();
     }
 
     if (opts.videoCodec) {

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -127,6 +127,8 @@ export default class RemoteParticipant extends Participant {
     track.source = publication.source;
     // keep publication's muted status
     track.isMuted = publication.isMuted;
+    track.receiver = receiver;
+    track.startMonitor();
 
     // when media track is ended, fire the event
     mediaTrack.onended = () => {

--- a/src/room/participant/publishUtils.test.ts
+++ b/src/room/participant/publishUtils.test.ts
@@ -41,7 +41,7 @@ describe('computeVideoEncodings', () => {
     const encodings = computeVideoEncodings(false, 640, 480, {
       simulcast: false,
     });
-    expect(encodings).toBeUndefined();
+    expect(encodings).toEqual([{}]);
   });
 
   it('respects client defined bitrate', () => {

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -60,7 +60,7 @@ export function computeVideoEncodings(
   width?: number,
   height?: number,
   options?: TrackPublishOptions,
-): RTCRtpEncodingParameters[] | undefined {
+): RTCRtpEncodingParameters[] {
   let videoEncoding: VideoEncoding | undefined = options?.videoEncoding;
   if (isScreenShare) {
     videoEncoding = options?.screenShareEncoding;
@@ -68,9 +68,9 @@ export function computeVideoEncodings(
   const useSimulcast = !isScreenShare && options?.simulcast;
 
   if ((!videoEncoding && !useSimulcast) || !width || !height) {
-    // don't set encoding when we are not simulcasting and user isn't restricting
-    // encoding parameters
-    return;
+    // when we aren't simulcasting, will need to return a single encoding without
+    // capping bandwidth. we always require a encoding for dynacast
+    return [{}];
   }
 
   if (!videoEncoding) {

--- a/src/room/stats.ts
+++ b/src/room/stats.ts
@@ -106,13 +106,25 @@ export interface VideoReceiverStats extends ReceiverStats {
   nackCount?: number;
 }
 
-export function computeBitrate(
-  bytesNow?: number, bytesPrev?: number,
-  timeNow?: number, timePrev?: number,
+export function computeBitrate<T extends ReceiverStats | SenderStats>(
+  currentStats: T,
+  prevStats?: T,
 ): number {
-  if (bytesNow === undefined || bytesPrev === undefined || timeNow === undefined
-    || timePrev === undefined) {
+  if (!prevStats) {
     return 0;
   }
-  return ((bytesNow - bytesPrev) * 8 * 1000) / (timeNow - timePrev);
+  let bytesNow: number | undefined;
+  let bytesPrev: number | undefined;
+  if ('bytesReceived' in currentStats) {
+    bytesNow = (currentStats as ReceiverStats).bytesReceived;
+    bytesPrev = (prevStats as ReceiverStats).bytesReceived;
+  } else if ('bytesSent' in currentStats) {
+    bytesNow = (currentStats as SenderStats).bytesSent;
+    bytesPrev = (prevStats as SenderStats).bytesSent;
+  }
+  if (bytesNow === undefined || bytesPrev === undefined
+    || currentStats.timestamp === undefined || prevStats.timestamp === undefined) {
+    return 0;
+  }
+  return ((bytesNow - bytesPrev) * 8 * 1000) / (currentStats.timestamp - prevStats.timestamp);
 }

--- a/src/room/stats.ts
+++ b/src/room/stats.ts
@@ -5,6 +5,9 @@ interface SenderStats {
   /** number of packets sent */
   packetsSent?: number;
 
+  /** number of bytes sent */
+  bytesSent?: number;
+
   /** jitter as perceived by remote */
   jitter?: number;
 
@@ -16,6 +19,8 @@ interface SenderStats {
 
   /** ID of the outbound stream */
   streamId?: string;
+
+  timestamp: number;
 }
 
 export interface AudioSenderStats extends SenderStats {
@@ -45,8 +50,6 @@ export interface VideoSenderStats extends SenderStats {
   qualityLimitationResolutionChanges: number;
 
   retransmittedPacketsSent: number;
-
-  timestamp: number;
 }
 
 interface ReceiverStats {
@@ -58,7 +61,29 @@ interface ReceiverStats {
   /** number of packets sent */
   packetsReceived?: number;
 
+  bytesReceived?: number;
+
   streamId?: string;
+
+  jitter?: number;
+
+  timestamp: number;
+}
+
+export interface AudioReceiverStats extends ReceiverStats {
+  type: 'audio';
+
+  concealedSamples?: number;
+
+  concealmentEvents?: number;
+
+  silentConcealedSamples?: number;
+
+  silentConcealmentEvents?: number;
+
+  totalAudioEnergy?: number;
+
+  totalSamplesDuration?: number;
 }
 
 export interface VideoReceiverStats extends ReceiverStats {
@@ -70,13 +95,24 @@ export interface VideoReceiverStats extends ReceiverStats {
 
   framesReceived: number;
 
-  frameWidth: number;
+  frameWidth?: number;
 
-  frameHeight: number;
+  frameHeight?: number;
 
-  firCount: number;
+  firCount?: number;
 
-  pliCount: number;
+  pliCount?: number;
 
-  nackCount: number;
+  nackCount?: number;
+}
+
+export function computeBitrate(
+  bytesNow?: number, bytesPrev?: number,
+  timeNow?: number, timePrev?: number,
+): number {
+  if (bytesNow === undefined || bytesPrev === undefined || timeNow === undefined
+    || timePrev === undefined) {
+    return 0;
+  }
+  return ((bytesNow - bytesPrev) * 8 * 1000) / (timeNow - timePrev);
 }

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -76,10 +76,7 @@ export default class LocalAudioTrack extends LocalTrack {
     const stats = await this.getSenderStats();
 
     if (stats && this.prevStats) {
-      this._currentBitrate = computeBitrate(
-        stats.bytesSent, this.prevStats.bytesSent,
-        stats.timestamp, this.prevStats.timestamp,
-      );
+      this._currentBitrate = computeBitrate(stats, this.prevStats);
     }
 
     this.prevStats = stats;

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -10,6 +10,8 @@ export default class LocalTrack extends Track {
 
   protected constraints: MediaTrackConstraints;
 
+  protected _currentBitrate: number = 0;
+
   protected constructor(
     mediaTrack: MediaStreamTrack, kind: Track.Kind, constraints?: MediaTrackConstraints,
   ) {
@@ -35,6 +37,11 @@ export default class LocalTrack extends Track {
       };
     }
     return undefined;
+  }
+
+  /** current send bits per second */
+  get currentBitrate(): number {
+    return this._currentBitrate;
   }
 
   /**

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -244,7 +244,7 @@ export default class LocalVideoTrack extends LocalTrack {
       let totalBitrate = 0;
       statsMap.forEach((s, key) => {
         const prev = this.prevStats?.get(key);
-        totalBitrate += computeBitrate(s.bytesSent, prev?.bytesSent, s.timestamp, prev?.timestamp);
+        totalBitrate += computeBitrate(s, prev);
       });
       this._currentBitrate = totalBitrate;
     }

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -1,9 +1,14 @@
 import { TrackEvent } from '../events';
+import { AudioReceiverStats, computeBitrate, monitorFrequency } from '../stats';
 import { Track } from './Track';
 
 export default class RemoteAudioTrack extends Track {
   /** @internal */
   receiver?: RTCRtpReceiver;
+
+  private _currentBitrate: number = 0;
+
+  private prevStats?: AudioReceiverStats;
 
   constructor(
     mediaTrack: MediaStreamTrack,
@@ -13,6 +18,11 @@ export default class RemoteAudioTrack extends Track {
     super(mediaTrack, Track.Kind.Audio);
     this.sid = sid;
     this.receiver = receiver;
+  }
+
+  /** current receive bits per second */
+  get currentBitrate(): number {
+    return this._currentBitrate;
   }
 
   /** @internal */
@@ -31,5 +41,58 @@ export default class RemoteAudioTrack extends Track {
   stop() {
     // use `enabled` of track to enable re-use of transceiver
     super.disable();
+  }
+
+  /* @internal */
+  startMonitor() {
+    setTimeout(() => {
+      this.monitorSender();
+    }, monitorFrequency);
+  }
+
+  private monitorSender = async () => {
+    if (!this.receiver) {
+      this._currentBitrate = 0;
+      return;
+    }
+    const stats = await this.getReceiverStats();
+
+    if (stats && this.prevStats) {
+      this._currentBitrate = computeBitrate(
+        stats.bytesReceived, this.prevStats.bytesReceived,
+        stats.timestamp, this.prevStats.timestamp,
+      );
+    }
+
+    this.prevStats = stats;
+    setTimeout(() => {
+      this.monitorSender();
+    }, monitorFrequency);
+  };
+
+  private async getReceiverStats(): Promise<AudioReceiverStats | undefined> {
+    if (!this.receiver) {
+      return;
+    }
+
+    const stats = await this.receiver.getStats();
+    let receiverStats: AudioReceiverStats | undefined;
+    stats.forEach((v) => {
+      if (v.type === 'inbound-rtp') {
+        receiverStats = {
+          type: 'audio',
+          timestamp: v.timestamp,
+          jitter: v.jitter,
+          bytesReceived: v.bytesReceived,
+          concealedSamples: v.concealedSamples,
+          concealmentEvents: v.concealmentEvents,
+          silentConcealedSamples: v.silentConcealedSamples,
+          silentConcealmentEvents: v.silentConcealmentEvents,
+          totalAudioEnergy: v.totalAudioEnergy,
+          totalSamplesDuration: v.totalSamplesDuration,
+        };
+      }
+    });
+    return receiverStats;
   }
 }

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -46,11 +46,11 @@ export default class RemoteAudioTrack extends Track {
   /* @internal */
   startMonitor() {
     setTimeout(() => {
-      this.monitorSender();
+      this.monitorReceiver();
     }, monitorFrequency);
   }
 
-  private monitorSender = async () => {
+  private monitorReceiver = async () => {
     if (!this.receiver) {
       this._currentBitrate = 0;
       return;
@@ -58,15 +58,12 @@ export default class RemoteAudioTrack extends Track {
     const stats = await this.getReceiverStats();
 
     if (stats && this.prevStats) {
-      this._currentBitrate = computeBitrate(
-        stats.bytesReceived, this.prevStats.bytesReceived,
-        stats.timestamp, this.prevStats.timestamp,
-      );
+      this._currentBitrate = computeBitrate(stats, this.prevStats);
     }
 
     this.prevStats = stats;
     setTimeout(() => {
-      this.monitorSender();
+      this.monitorReceiver();
     }, monitorFrequency);
   };
 

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -118,11 +118,11 @@ export default class RemoteVideoTrack extends Track {
   /* @internal */
   startMonitor() {
     setTimeout(() => {
-      this.monitorSender();
+      this.monitorReceiver();
     }, monitorFrequency);
   }
 
-  private monitorSender = async () => {
+  private monitorReceiver = async () => {
     if (!this.receiver) {
       this._currentBitrate = 0;
       return;
@@ -130,15 +130,12 @@ export default class RemoteVideoTrack extends Track {
     const stats = await this.getReceiverStats();
 
     if (stats && this.prevStats) {
-      this._currentBitrate = computeBitrate(
-        stats.bytesReceived, this.prevStats.bytesReceived,
-        stats.timestamp, this.prevStats.timestamp,
-      );
+      this._currentBitrate = computeBitrate(stats, this.prevStats);
     }
 
     this.prevStats = stats;
     setTimeout(() => {
-      this.monitorSender();
+      this.monitorReceiver();
     }, monitorFrequency);
   };
 

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,6 +1,6 @@
 import { debounce } from 'ts-debounce';
 import { TrackEvent } from '../events';
-import { VideoReceiverStats } from '../stats';
+import { computeBitrate, monitorFrequency, VideoReceiverStats } from '../stats';
 import { getIntersectionObserver, getResizeObserver, ObservableMediaElement } from '../utils';
 import { attachToElement, detachTrack, Track } from './Track';
 
@@ -21,6 +21,8 @@ export default class RemoteVideoTrack extends Track {
 
   private lastDimensions?: Track.Dimensions;
 
+  private _currentBitrate: number = 0;
+
   constructor(
     mediaTrack: MediaStreamTrack,
     sid: string,
@@ -36,6 +38,11 @@ export default class RemoteVideoTrack extends Track {
 
   get isAdaptiveStream(): boolean {
     return this.adaptiveStream ?? false;
+  }
+
+  /** current receive bits per second */
+  get currentBitrate(): number {
+    return this._currentBitrate;
   }
 
   /** @internal */
@@ -86,7 +93,7 @@ export default class RemoteVideoTrack extends Track {
   detach(element?: HTMLMediaElement): HTMLMediaElement | HTMLMediaElement[] {
     let detachedElements: HTMLMediaElement[] = [];
     if (element) {
-      detachedElements.push(element);
+      this.stopObservingElement(element);
       return super.detach(element);
     }
     detachedElements = super.detach();
@@ -106,6 +113,63 @@ export default class RemoteVideoTrack extends Track {
   stop() {
     // use `enabled` of track to enable re-use of transceiver
     super.disable();
+  }
+
+  /* @internal */
+  startMonitor() {
+    setTimeout(() => {
+      this.monitorSender();
+    }, monitorFrequency);
+  }
+
+  private monitorSender = async () => {
+    if (!this.receiver) {
+      this._currentBitrate = 0;
+      return;
+    }
+    const stats = await this.getReceiverStats();
+
+    if (stats && this.prevStats) {
+      this._currentBitrate = computeBitrate(
+        stats.bytesReceived, this.prevStats.bytesReceived,
+        stats.timestamp, this.prevStats.timestamp,
+      );
+    }
+
+    this.prevStats = stats;
+    setTimeout(() => {
+      this.monitorSender();
+    }, monitorFrequency);
+  };
+
+  private async getReceiverStats(): Promise<VideoReceiverStats | undefined> {
+    if (!this.receiver) {
+      return;
+    }
+
+    const stats = await this.receiver.getStats();
+    let receiverStats: VideoReceiverStats | undefined;
+    stats.forEach((v) => {
+      if (v.type === 'inbound-rtp') {
+        receiverStats = {
+          type: 'video',
+          framesDecoded: v.framesDecoded,
+          framesDropped: v.framesDropped,
+          framesReceived: v.framesReceived,
+          packetsReceived: v.packetsReceived,
+          packetsLost: v.packetsLost,
+          frameWidth: v.frameWidth,
+          frameHeight: v.frameHeight,
+          pliCount: v.pliCount,
+          firCount: v.firCount,
+          nackCount: v.nackCount,
+          jitter: v.jitter,
+          timestamp: v.timestamp,
+          bytesReceived: v.bytesReceived,
+        };
+      }
+    });
+    return receiverStats;
   }
 
   private stopObservingElement(element: HTMLMediaElement) {

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import { TrackSource, TrackType } from '../../proto/livekit_models';
 import { StreamState as ProtoStreamState } from '../../proto/livekit_rtc';
 import { TrackEvent } from '../events';
+import { isFireFox } from '../utils';
 
 // keep old audio elements when detached, we would re-use them since on iOS
 // Safari tracks which audio elements have been "blessed" by the user.
@@ -176,9 +177,13 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
   });
 
   mediaStream.addTrack(track);
-  setTimeout(() => {
-    element.srcObject = mediaStream;
-  }, 1);
+  if (isFireFox()) {
+    // sometimes firefox doesn't render local video on the first try.
+    // It needs to be re-attached after a timeout.
+    setTimeout(() => {
+      element.srcObject = mediaStream;
+    }, 1);
+  }
 }
 
 /** @internal */

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -176,6 +176,9 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
   });
 
   mediaStream.addTrack(track);
+  setTimeout(() => {
+    element.srcObject = mediaStream;
+  }, 1);
 }
 
 /** @internal */

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -8,13 +8,12 @@ export function unpackStreamId(packed: string): string[] {
   return [packed, ''];
 }
 
-export function useLegacyAPI(): boolean {
-  // react native is using old stream based API
-  return typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
-}
-
 export async function sleep(duration: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+export function isFireFox(): boolean {
+  return navigator.userAgent.indexOf('Firefox') !== -1;
 }
 
 function roDispatchCallback(entries: ResizeObserverEntry[]) {


### PR DESCRIPTION
Sample app is updated to surface bandwidth stats and time to first render.

Also fixed dynacast for FireFox.
