### PR TITLE
Bugfix: send disconnected events when connection severed

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -156,6 +156,7 @@
                 <option value="signal-reconnect">Signal reconnect</option>
                 <option value="speaker">Speaker update</option>
                 <option value="node-failure">Node failure</option>
+                <option value="server-leave">Server booted</option>
                 <option value="migration">Migration</option>
               </select>
               <button

--- a/src/proto/livekit_rtc.ts
+++ b/src/proto/livekit_rtc.ts
@@ -310,6 +310,8 @@ export interface SimulateScenario {
   nodeFailure: boolean | undefined;
   /** simulate migration */
   migration: boolean | undefined;
+  /** server to send leave */
+  serverLeave: boolean | undefined;
 }
 
 const baseSignalRequest: object = {};
@@ -3295,6 +3297,9 @@ export const SimulateScenario = {
     if (message.migration !== undefined) {
       writer.uint32(24).bool(message.migration);
     }
+    if (message.serverLeave !== undefined) {
+      writer.uint32(32).bool(message.serverLeave);
+    }
     return writer;
   },
 
@@ -3313,6 +3318,9 @@ export const SimulateScenario = {
           break;
         case 3:
           message.migration = reader.bool();
+          break;
+        case 4:
+          message.serverLeave = reader.bool();
           break;
         default:
           reader.skipType(tag & 7);
@@ -3339,6 +3347,11 @@ export const SimulateScenario = {
     } else {
       message.migration = undefined;
     }
+    if (object.serverLeave !== undefined && object.serverLeave !== null) {
+      message.serverLeave = Boolean(object.serverLeave);
+    } else {
+      message.serverLeave = undefined;
+    }
     return message;
   },
 
@@ -3349,6 +3362,8 @@ export const SimulateScenario = {
     message.nodeFailure !== undefined &&
       (obj.nodeFailure = message.nodeFailure);
     message.migration !== undefined && (obj.migration = message.migration);
+    message.serverLeave !== undefined &&
+      (obj.serverLeave = message.serverLeave);
     return obj;
   },
 
@@ -3357,6 +3372,7 @@ export const SimulateScenario = {
     message.speakerUpdate = object.speakerUpdate ?? undefined;
     message.nodeFailure = object.nodeFailure ?? undefined;
     message.migration = object.migration ?? undefined;
+    message.serverLeave = object.serverLeave ?? undefined;
     return message;
   },
 };

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -68,6 +68,9 @@ export default class PCTransport {
         this.renegotiate = true;
         return;
       }
+    } else if (this.pc.signalingState === 'closed') {
+      log.warn('could not createOffer with closed peer connection');
+      return;
     }
 
     // actually negotiate

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -175,7 +175,7 @@ export default class RTCEngine extends EventEmitter {
           this.iceConnected = true;
           this.emit(EngineEvent.Connected);
         }
-      } else if (primaryPC.iceConnectionState === 'failed') {
+      } else if (primaryPC.iceConnectionState === 'disconnected' || primaryPC.iceConnectionState === 'failed') {
         log.trace('ICE disconnected');
         if (this.iceConnected) {
           this.iceConnected = false;
@@ -262,8 +262,8 @@ export default class RTCEngine extends EventEmitter {
     };
 
     this.client.onLeave = () => {
-      this.close();
       this.emit(EngineEvent.Disconnected);
+      this.close();
     };
   }
 
@@ -315,8 +315,8 @@ export default class RTCEngine extends EventEmitter {
         maxReconnectRetries,
         'attempts. giving up',
       );
-      this.close();
       this.emit(EngineEvent.Disconnected);
+      this.close();
       return;
     }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -312,6 +312,11 @@ class Room extends EventEmitter {
           nodeFailure: true,
         });
         break;
+      case 'server-leave':
+        req = SimulateScenario.fromPartial({
+          serverLeave: true,
+        });
+        break;
       case 'migration':
         req = SimulateScenario.fromPartial({
           migration: true,


### PR DESCRIPTION
EngineEvent.Disconnected has to be emitted prior to closing the engine. Once Engine is closed, it removes all event listeners on it