### PR TITLE
added option to update token

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -120,6 +120,10 @@ export default class RTCEngine extends EventEmitter {
     this.client.sendMuteTrack(trackSid, muted);
   }
 
+  updateToken(token: string) {
+    this.token = token;
+  }
+
   get dataSubscriberReadyState(): string | undefined {
     return this.reliableDCSub?.readyState;
   }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -329,6 +329,15 @@ class Room extends EventEmitter {
     }
   }
 
+  /**
+   * This will update previously used token with new one.
+   */
+  updateToken = (token: string) => {
+    if (token !== '') {
+      this.engine.updateToken(token);
+    }
+  };
+
   private onBeforeUnload = () => {
     this.disconnect();
   };


### PR DESCRIPTION
Added option to update token. In long run meeting sometime token got expire & if client need to run reconnect for any reason that time it failed. Now it will be possible to update token periodically. 