### PR TITLE
Default case for createLocalAudio/VideoTrack

### DIFF
--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -55,7 +55,7 @@ export async function createLocalVideoTrack(
 ): Promise<LocalVideoTrack> {
   const tracks = await createLocalTracks({
     audio: false,
-    video: options,
+    video: options ?? true,
   });
   return <LocalVideoTrack>tracks[0];
 }
@@ -64,7 +64,7 @@ export async function createLocalAudioTrack(
   options?: AudioCaptureOptions,
 ): Promise<LocalAudioTrack> {
   const tracks = await createLocalTracks({
-    audio: options,
+    audio: options ?? true,
     video: false,
   });
   return <LocalAudioTrack>tracks[0];


### PR DESCRIPTION
Hey LiveKit team! 

First of all, upgrading from v0.14 to v0.15 was super easy, so nice work on that release.

I noticed the previous `createLocalVideoTrack` behavior didn't require any arguments to actually get a video track with the default camera. It seemed redundant to have to add `createLocalVideoTrack(true)`, and Chrome threw a getUserMedia error for me if I don't include it. I just made this PR to automatically fallback to that for these helper functions.