### PR TITLE
Fix reconnect loop on Safari

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -184,7 +184,8 @@ export default class RTCEngine extends EventEmitter {
         getConnectedAddress(primaryPC).then((v) => {
           this.connectedServerAddr = v;
         });
-      } else if (primaryPC.iceConnectionState === 'disconnected' || primaryPC.iceConnectionState === 'failed') {
+      } else if (primaryPC.iceConnectionState === 'failed') {
+        // on Safari, PeerConnection will switch to 'disconnected' during renegotiation
         log.trace('ICE disconnected');
         if (this.iceConnected) {
           this.iceConnected = false;


### PR DESCRIPTION
Safari flips ICE connection to disconnected temporarily during re-negotiations. We cannot use it as a trigger to reconnect to the server