### PR TITLE
Process reconnect when connectionstatechange callback not called

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -41,8 +41,6 @@ export default class RTCEngine extends EventEmitter {
 
   private pcConnected: boolean = false;
 
-  private reconnected: boolean = false;
-
   private isClosed: boolean = true;
 
   private pendingTrackResolvers: { [key: string]: (info: TrackInfo) => void } = {};
@@ -182,8 +180,6 @@ export default class RTCEngine extends EventEmitter {
         if (!this.pcConnected) {
           this.pcConnected = true;
           this.emit(EngineEvent.Connected);
-        } else {
-          this.reconnected = true;
         }
         getConnectedAddress(primaryPC).then((v) => {
           this.connectedServerAddr = v;
@@ -359,6 +355,7 @@ export default class RTCEngine extends EventEmitter {
     }
     this.reconnectAttempts += 1;
 
+    this.pcConnected = false;
     await this.client.reconnect(this.url, this.token);
     this.emit(EngineEvent.SignalConnected);
 
@@ -375,9 +372,8 @@ export default class RTCEngine extends EventEmitter {
 
     const startTime = (new Date()).getTime();
 
-    this.reconnected = false;
     while ((new Date()).getTime() - startTime < maxICEConnectTimeout * 2) {
-      if (this.reconnected) {
+      if (this.pcConnected) {
         // reconnect success
         this.emit(EngineEvent.Reconnected);
         return;

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -379,7 +379,7 @@ export default class RTCEngine extends EventEmitter {
     let now = startTime;
     while (now - startTime < maxICEConnectTimeout) {
       // if there is no connectionstatechange callback fired
-      // check connectionstate after maxReconnectingTimeout
+      // check connectionstate after minReconnectWait
       if (now - startTime > minReconnectWait && this.primaryPC?.connectionState === 'connected') {
         this.pcConnected = true;
       }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 export const version = '0.15.4';
-export const protocolVersion = 5;
+export const protocolVersion = 6;


### PR DESCRIPTION
in case of ice restart, there is a chance that neither iceconnectionstatechange or connectionstatechange will be called, there is no ice conn or pc conn state transit (sticky on connected). in this case, detect peerconnection state is still connected after 2 second.