### PR TITLE
typesafe roomevents

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ts-jest": "^27.0.7",
     "ts-loader": "^8.1.0",
     "ts-proto": "^1.85.0",
+    "typed-emitter": "^2.1.0",
     "typedoc": "^0.20.35",
     "typedoc-plugin-no-inherit": "1.3.0",
     "typescript": "~4.2.3",

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -1,3 +1,6 @@
+import { DataPacket_Kind, LocalTrackPublication, Participant, RemoteTrack, RemoteTrackPublication } from '..';
+import RemoteParticipant from './participant/RemoteParticipant';
+
 /**
  * Events are the primary way LiveKit notifies your application of changes.
  *
@@ -7,28 +10,29 @@
  * room.on(RoomEvent.TrackPublished, (track, publication, participant) => {})
  * ```
  */
-export enum RoomEvent {
+
+export const RoomEvent = {
   /**
    * When the connection to the server has been interrupted and it's attempting
    * to reconnect.
    */
-  Reconnecting = 'reconnecting',
+  Reconnecting: 'reconnecting',
 
   /**
    * Fires when a reconnection has been successful.
    */
-  Reconnected = 'reconnected',
+  Reconnected: 'reconnected',
 
   /**
    * When disconnected from room. This fires when room.disconnect() is called or
    * when an unrecoverable connection issue had occured
    */
-  Disconnected = 'disconnected',
+  Disconnected: 'disconnected',
 
   /**
    * When input or output devices on the machine have changed.
    */
-  MediaDevicesChanged = 'mediaDevicesChanged',
+  MediaDevicesChanged: 'mediaDevicesChanged',
 
   /**
    * When a [[RemoteParticipant]] joins *after* the local
@@ -37,7 +41,7 @@ export enum RoomEvent {
    *
    * args: ([[RemoteParticipant]])
    */
-  ParticipantConnected = 'participantConnected',
+  ParticipantConnected: 'participantConnected',
 
   /**
    * When a [[RemoteParticipant]] leaves *after* the local
@@ -45,7 +49,7 @@ export enum RoomEvent {
    *
    * args: ([[RemoteParticipant]])
    */
-  ParticipantDisconnected = 'participantDisconnected',
+  ParticipantDisconnected: 'participantDisconnected',
 
   /**
    * When a new track is published to room *after* the local
@@ -56,7 +60,7 @@ export enum RoomEvent {
    *
    * args: ([[RemoteTrackPublication]], [[RemoteParticipant]])
    */
-  TrackPublished = 'trackPublished',
+  TrackPublished: 'trackPublished',
 
   /**
    * The [[LocalParticipant]] has subscribed to a new track. This event will **always**
@@ -64,21 +68,21 @@ export enum RoomEvent {
    *
    * args: ([[RemoteTrack]], [[RemoteTrackPublication]], [[RemoteParticipant]])
    */
-  TrackSubscribed = 'trackSubscribed',
+  TrackSubscribed: 'trackSubscribed',
 
   /**
    * Could not subscribe to a track
    *
    * args: (track sid, [[RemoteParticipant]])
    */
-  TrackSubscriptionFailed = 'trackSubscriptionFailed',
+  TrackSubscriptionFailed: 'trackSubscriptionFailed',
 
   /**
    * A [[RemoteParticipant]] has unpublished a track
    *
    * args: ([[RemoteTrackPublication]], [[RemoteParticipant]])
    */
-  TrackUnpublished = 'trackUnpublished',
+  TrackUnpublished: 'trackUnpublished',
 
   /**
    * A subscribed track is no longer available. Clients should listen to this
@@ -86,21 +90,21 @@ export enum RoomEvent {
    *
    * args: ([[Track]], [[RemoteTrackPublication]], [[RemoteParticipant]])
    */
-  TrackUnsubscribed = 'trackUnsubscribed',
+  TrackUnsubscribed: 'trackUnsubscribed',
 
   /**
    * A track that was muted, fires on both [[RemoteParticipant]]s and [[LocalParticipant]]
    *
    * args: ([[TrackPublication]], [[Participant]])
    */
-  TrackMuted = 'trackMuted',
+  TrackMuted: 'trackMuted',
 
   /**
    * A track that was unmuted, fires on both [[RemoteParticipant]]s and [[LocalParticipant]]
    *
    * args: ([[TrackPublication]], [[Participant]])
    */
-  TrackUnmuted = 'trackUnmuted',
+  TrackUnmuted: 'trackUnmuted',
 
   /**
    * A local track was published successfully. This event is helpful to know
@@ -108,7 +112,7 @@ export enum RoomEvent {
    *
    * args: ([[LocalTrackPublication]], [[LocalParticipant]])
    */
-  LocalTrackPublished = 'localTrackPublished',
+  LocalTrackPublished: 'localTrackPublished',
 
   /**
    * A local track was unpublished. This event is helpful to know when to remove
@@ -119,7 +123,7 @@ export enum RoomEvent {
    *
    * args: ([[LocalTrackPublication]], [[LocalParticipant]])
    */
-  LocalTrackUnpublished = 'localTrackUnpublished',
+  LocalTrackUnpublished: 'localTrackUnpublished',
 
   /**
    * Active speakers changed. List of speakers are ordered by their audio level.
@@ -129,13 +133,13 @@ export enum RoomEvent {
    *
    * args: (Array<[[Participant]]>)
    */
-  ActiveSpeakersChanged = 'activeSpeakersChanged',
+  ActiveSpeakersChanged: 'activeSpeakersChanged',
 
   /**
    * @deprecated Use ParticipantMetadataChanged instead
    * @internal
    */
-  MetadataChanged = 'metadataChanged',
+  MetadataChanged: 'metadataChanged',
 
   /**
    * Participant metadata is a simple way for app-specific state to be pushed to
@@ -146,7 +150,7 @@ export enum RoomEvent {
    * args: (prevMetadata: string, [[Participant]])
    *
    */
-  ParticipantMetadataChanged = 'participantMetaDataChanged',
+  ParticipantMetadataChanged: 'participantMetadataChanged',
 
   /**
    * Room metadata is a simple way for app-specific state to be pushed to
@@ -156,7 +160,7 @@ export enum RoomEvent {
    *
    * args: (string)
    */
-  RoomMetadataChanged = 'roomMetadataChanged',
+  RoomMetadataChanged: 'roomMetadataChanged',
 
   /**
    * Data received from another participant.
@@ -165,7 +169,7 @@ export enum RoomEvent {
    *
    * args: (payload: Uint8Array, participant: [[Participant]], kind: [[DataPacket_Kind]])
    */
-  DataReceived = 'dataReceived',
+  DataReceived: 'dataReceived',
 
   /**
    * Connection quality was changed for a Participant. It'll receive updates
@@ -174,7 +178,7 @@ export enum RoomEvent {
    *
    * args: (connectionQuality: [[ConnectionQuality]], participant: [[Participant]])
    */
-  ConnectionQualityChanged = 'connectionQualityChanged',
+  ConnectionQualityChanged: 'connectionQualityChanged',
 
   /**
    * StreamState indicates if a subscribed track has been paused by the SFU
@@ -186,7 +190,7 @@ export enum RoomEvent {
    * args: (pub: [[RemoteTrackPublication]], streamState: [[Track.StreamState]],
    *        participant: [[RemoteParticipant]])
    */
-  TrackStreamStateChanged = 'trackStreamStateChanged',
+  TrackStreamStateChanged: 'trackStreamStateChanged',
 
   /**
    * One of subscribed tracks have changed its permissions for the current
@@ -198,14 +202,14 @@ export enum RoomEvent {
    *        status: [[TrackPublication.SubscriptionStatus]],
    *        participant: [[RemoteParticipant]])
    */
-  TrackSubscriptionPermissionChanged = 'trackSubscriptionPermissionChanged',
+  TrackSubscriptionPermissionChanged: 'trackSubscriptionPermissionChanged',
 
   /**
    * LiveKit will attempt to autoplay all audio tracks when you attach them to
    * audio elements. However, if that fails, we'll notify you via AudioPlaybackStatusChanged.
    * `Room.canPlayAudio` will indicate if audio playback is permitted.
    */
-  AudioPlaybackStatusChanged = 'audioPlaybackChanged',
+  AudioPlaybackStatusChanged: 'audioPlaybackChanged',
 
   /**
    * When we have encountered an error while attempting to create a track.
@@ -216,8 +220,53 @@ export enum RoomEvent {
    *
    * args: (error: Error)
    */
-  MediaDevicesError = 'mediaDevicesError',
-}
+  MediaDevicesError: 'mediaDevicesError',
+} as const;
+
+type RoomEvents = {
+  [P in Capitalize<keyof RoomEventCallbacks>]: keyof RoomEventCallbacks;
+};
+
+export type RoomEventCallbacks = {
+  /**
+   * When the connection to the server has been interrupted and it's attempting
+   * to reconnect.
+   */
+  reconnecting: () => void,
+  reconnected: () => void,
+  disconnected: () => void,
+  mediaDevicesChanged: () => void,
+  participantConnected: (participant: RemoteParticipant) => void,
+  participantDisconnected: (participant: RemoteParticipant) => void,
+  trackPublished: (publication: RemoteTrackPublication, participant?: RemoteParticipant) => void,
+  trackSubscribed: (
+    track: RemoteTrack,
+    publication: RemoteTrackPublication,
+    participant?: RemoteParticipant
+  ) => void,
+  trackSubscriptionFailed: (trackSid: string, participant: RemoteParticipant) => void,
+  trackUnpublished: (publication: RemoteTrackPublication) => void,
+  trackUnsubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void,
+  trackMuted: (publication: RemoteTrackPublication) => void,
+  trackUnmuted: (publication: RemoteTrackPublication) => void,
+  localTrackPublished: (publication: LocalTrackPublication) => void,
+  localTrackUnpublished: (publication: LocalTrackPublication) => void,
+  participantMetadataChanged: (metadata: string, participant: Participant) => void,
+  activeSpeakersChanged: (speakers: Array<Participant>) => void,
+  roomMetadataChanged: (metadata: string) => void,
+  dataReceived: (
+    payload: Uint8Array,
+    participant?: RemoteParticipant,
+    kind?: DataPacket_Kind
+  ) => void,
+};
+
+// type KeysMissingFromRoomEventCallbacks = Exclude<RoomEvent, keyof RoomEventCallbacks>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+// type VerifyISomething<
+//   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+//   Missing extends never = KeysMissingFromRoomEventCallbacks,
+//   > = 0; // no error
 
 export enum ParticipantEvent {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4529,6 +4529,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@^7.5.2:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
+  integrity sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -5118,6 +5125,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
@@ -5161,6 +5173,13 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typed-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-2.1.0.tgz#ca78e3d8ef1476f228f548d62e04e3d4d3fd77fb"
+  integrity sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==
+  optionalDependencies:
+    rxjs "^7.5.2"
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
this would be a way to type the events. Works for both emitter and listener.
It's not finished and some cyclic dependencies would need to be fixed.

I also tried to get rid of the need to declare the events twice (once with the callback types and once as the enum) by generating the enum automatically from the callback types, but it seems like we would lose the JSdocs description of the enum, which I guess is a rather big loss.

