### PR TITLE
Removed layer pause, fixed publishing quality upgrade after constraint

### DIFF
--- a/example/sample.ts
+++ b/example/sample.ts
@@ -74,7 +74,9 @@ const appActions = {
       .on(RoomEvent.DataReceived, handleData)
       .on(RoomEvent.Disconnected, handleRoomDisconnect)
       .on(RoomEvent.Reconnecting, () => appendLog('Reconnecting to room'))
-      .on(RoomEvent.Reconnected, () => appendLog('Successfully reconnected!'))
+      .on(RoomEvent.Reconnected, () => {
+        appendLog('Successfully reconnected. server', room.engine.connectedServerAddress);
+      })
       .on(RoomEvent.LocalTrackPublished, () => {
         renderParticipant(room.localParticipant);
         updateButtonsForPublishState();
@@ -109,7 +111,7 @@ const appActions = {
       const start = Date.now();
       await room.connect(url, token, connectOptions);
       const elapsed = Date.now() - start;
-      appendLog(`successfully connected to ${room.name} in ${Math.round(elapsed)}ms`);
+      appendLog(`successfully connected to ${room.name} in ${Math.round(elapsed)}ms`, room.engine.connectedServerAddress);
     } catch (error) {
       let message: any = error;
       if (error.message) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -48,12 +48,6 @@ export interface RoomOptions {
 
   /**
    * @internal
-   * experimental flag, disable client managed layer pause when publishing capability is limited
-   */
-  expDisableLayerPause?: boolean;
-
-  /**
-   * @internal
    * experimental flag, introduce a delay before sending signaling messages
    */
   expSignalLatency?: number;
@@ -143,10 +137,4 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
    * set this to false if you would prefer to clean up unpublished local tracks manually.
    */
   stopLocalTrackOnUnpublish?: boolean;
-
-  /**
-   * @internal
-   * experimental flag, disable client managed layer pause when publishing capability is limited
-   */
-  expDisableLayerPause?: boolean;
 }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -416,8 +416,7 @@ export default class LocalParticipant extends Participant {
     // store RTPSender
     track.sender = transceiver.sender;
     if (track instanceof LocalVideoTrack) {
-      const disableLayerPause = this.roomOptions?.expDisableLayerPause ?? false;
-      track.startMonitor(this.engine.client, disableLayerPause);
+      track.startMonitor(this.engine.client);
     } else if (track instanceof LocalAudioTrack) {
       track.startMonitor();
     }

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -73,7 +73,14 @@ export default class LocalAudioTrack extends LocalTrack {
       this._currentBitrate = 0;
       return;
     }
-    const stats = await this.getSenderStats();
+
+    let stats: AudioSenderStats | undefined;
+    try {
+      stats = await this.getSenderStats();
+    } catch (e) {
+      log.error('could not get audio sender stats', e);
+      return;
+    }
 
     if (stats && this.prevStats) {
       this._currentBitrate = computeBitrate(stats, this.prevStats);

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { TrackSource, TrackType } from '../../proto/livekit_models';
 import { StreamState as ProtoStreamState } from '../../proto/livekit_rtc';
 import { TrackEvent } from '../events';
-import { isSafari } from '../utils';
+import { isFireFox, isSafari } from '../utils';
 
 // keep old audio elements when detached, we would re-use them since on iOS
 // Safari tracks which audio elements have been "blessed" by the user.
@@ -183,7 +183,9 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
   // avoid flicker
   if (element.srcObject !== mediaStream) {
     element.srcObject = mediaStream;
-    if (isSafari() && element instanceof HTMLVideoElement) {
+    if ((isSafari() || isFireFox()) && element instanceof HTMLVideoElement) {
+      // Firefox also has a timing issue where video doesn't actually get attached unless
+      // performed out-of-band
       // Safari 15 has a bug where in certain layouts, video element renders
       // black until the page is resized or other changes take place.
       // Resetting the src triggers it to render.


### PR DESCRIPTION
Publishing layer pause logic had a bug that was preventing it from upgrading again after bandwidth constraint is no longer in place. Verified with NLC to be working.

Fixed reconnect loop for Firefox, always perform full reconnect instead of attempting to resume.