### PR TITLE
Added new RTCEngine event to signal when the publisher/subscriber transports are created

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -169,6 +169,8 @@ export default class RTCEngine extends (
     this.publisher = new PCTransport(this.rtcConfig);
     this.subscriber = new PCTransport(this.rtcConfig);
 
+    this.emit(EngineEvent.TransportsCreated, this.publisher, this.subscriber)
+
     this.publisher.pc.onicecandidate = (ev) => {
       if (!ev.candidate) return;
       log.trace('adding ICE candidate for peer', ev.candidate);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -169,7 +169,7 @@ export default class RTCEngine extends (
     this.publisher = new PCTransport(this.rtcConfig);
     this.subscriber = new PCTransport(this.rtcConfig);
 
-    this.emit(EngineEvent.TransportsCreated, this.publisher, this.subscriber)
+    this.emit(EngineEvent.TransportsCreated, this.publisher, this.subscriber);
 
     this.publisher.pc.onicecandidate = (ev) => {
       if (!ev.candidate) return;
@@ -625,4 +625,5 @@ export type EngineEventCallbacks = {
   ) => void,
   activeSpeakersUpdate: (speakers: Array<SpeakerInfo>) => void,
   dataPacketReceived: (userPacket: UserPacket, kind: DataPacket_Kind) => void,
+  transportsCreated: (publisher: PCTransport, subscriber: PCTransport) => void,
 };

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -367,6 +367,7 @@ export enum ParticipantEvent {
 
 /** @internal */
 export enum EngineEvent {
+  TransportsCreated = 'transportsCreated',
   Connected = 'connected',
   Disconnected = 'disconnected',
   Resuming = 'resuming',


### PR DESCRIPTION
As per the discussion in slack, I've create a new event that will be fired on `RTCEngine` that will signal when the transports are created.