### PR TITLE
device pixel ratio as setting

### DIFF
--- a/example/sample.ts
+++ b/example/sample.ts
@@ -200,8 +200,8 @@ const appActions = {
       const msg = state.encoder.encode(textField.value);
       currentRoom.localParticipant.publishData(msg, DataPacket_Kind.RELIABLE);
       (<HTMLTextAreaElement>(
-        $('chat')
-      )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
+      $('chat')
+    )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
       textField.value = '';
     }
   },
@@ -464,7 +464,7 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       break;
     default:
       signalElm.innerHTML = '';
-    // do nothing
+      // do nothing
   }
 }
 

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -32,7 +32,10 @@ const appActions = {
     setLogLevel('debug');
 
     const roomOpts: RoomOptions = {
-      adaptiveStream,
+      adaptiveStream: {
+        enabled: true,
+        pixelDensity: window.devicePixelRatio,
+      },
       dynacast,
       publishDefaults: {
         simulcast,
@@ -197,8 +200,8 @@ const appActions = {
       const msg = state.encoder.encode(textField.value);
       currentRoom.localParticipant.publishData(msg, DataPacket_Kind.RELIABLE);
       (<HTMLTextAreaElement>(
-      $('chat')
-    )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
+        $('chat')
+      )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
       textField.value = '';
     }
   },
@@ -461,7 +464,7 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       break;
     default:
       signalElm.innerHTML = '';
-      // do nothing
+    // do nothing
   }
 }
 

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -32,10 +32,9 @@ const appActions = {
     setLogLevel('debug');
 
     const roomOpts: RoomOptions = {
-      adaptiveStream: {
-        enabled: true,
-        pixelDensity: window.devicePixelRatio,
-      },
+      adaptiveStream: adaptiveStream ? {
+        pixelDensity: 'screen',
+      } : false,
       dynacast,
       publishDefaults: {
         simulcast,

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -32,7 +32,7 @@ export async function connect(
 ): Promise<Room> {
   options ??= {};
   if (options.adaptiveStream === undefined) {
-    options.adaptiveStream = { enabled: options.autoManageVideo ?? false };
+    options.adaptiveStream = options.autoManageVideo ?? false;
   }
   setLogLevel(options.logLevel ?? LogLevel.warn);
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -65,7 +65,7 @@ export async function connect(
 
           // when it's a device issue, try to publish the other kind
           if (errKind === MediaDeviceFailure.NotFound
-            || errKind === MediaDeviceFailure.DeviceInUse) {
+              || errKind === MediaDeviceFailure.DeviceInUse) {
             try {
               await room.localParticipant.setMicrophoneEnabled(true);
             } catch (audioErr) {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -32,7 +32,7 @@ export async function connect(
 ): Promise<Room> {
   options ??= {};
   if (options.adaptiveStream === undefined) {
-    options.adaptiveStream = options.autoManageVideo;
+    options.adaptiveStream = { enabled: options.autoManageVideo ?? false };
   }
   setLogLevel(options.logLevel ?? LogLevel.warn);
 
@@ -65,7 +65,7 @@ export async function connect(
 
           // when it's a device issue, try to publish the other kind
           if (errKind === MediaDeviceFailure.NotFound
-             || errKind === MediaDeviceFailure.DeviceInUse) {
+            || errKind === MediaDeviceFailure.DeviceInUse) {
             try {
               await room.localParticipant.setMicrophoneEnabled(true);
             } catch (audioErr) {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -32,7 +32,7 @@ export async function connect(
 ): Promise<Room> {
   options ??= {};
   if (options.adaptiveStream === undefined) {
-    options.adaptiveStream = options.autoManageVideo ?? false;
+    options.adaptiveStream = options.autoManageVideo === true ? {} : undefined;
   }
   setLogLevel(options.logLevel ?? LogLevel.warn);
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -65,7 +65,7 @@ export async function connect(
 
           // when it's a device issue, try to publish the other kind
           if (errKind === MediaDeviceFailure.NotFound
-              || errKind === MediaDeviceFailure.DeviceInUse) {
+             || errKind === MediaDeviceFailure.DeviceInUse) {
             try {
               await room.localParticipant.setMicrophoneEnabled(true);
             } catch (audioErr) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -17,7 +17,7 @@ export interface RoomOptions {
    * When none of the video elements are visible, it'll temporarily pause
    * the data flow until they are visible again.
    */
-  adaptiveStream?: AdaptiveStreamSettings;
+  adaptiveStream?: AdaptiveStreamSettings | boolean;
 
   /**
    * enable Dynacast, off by default. With Dynacast dynamically pauses

--- a/src/options.ts
+++ b/src/options.ts
@@ -78,7 +78,7 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
   /**
    * see [[RoomOptions.adaptiveStream]]
    */
-  adaptiveStream?: AdaptiveStreamSettings;
+  adaptiveStream?: AdaptiveStreamSettings | boolean;
 
   /**
    * alias for adaptiveStream

--- a/src/options.ts
+++ b/src/options.ts
@@ -78,7 +78,7 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
   /**
    * see [[RoomOptions.adaptiveStream]]
    */
-  adaptiveStream?: AdaptiveStreamSettings | boolean;
+  adaptiveStream?: AdaptiveStreamSettings;
 
   /**
    * alias for adaptiveStream

--- a/src/options.ts
+++ b/src/options.ts
@@ -17,7 +17,7 @@ export interface RoomOptions {
    * When none of the video elements are visible, it'll temporarily pause
    * the data flow until they are visible again.
    */
-  adaptiveStream?: AdaptiveStreamSettings | boolean;
+  adaptiveStream?: AdaptiveStreamSettings;
 
   /**
    * enable Dynacast, off by default. With Dynacast dynamically pauses

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,6 +2,7 @@ import { LogLevel, LogLevelDesc } from './logger';
 import {
   AudioCaptureOptions, CreateLocalTracksOptions, TrackPublishDefaults, VideoCaptureOptions,
 } from './room/track/options';
+import { AdaptiveStreamSettings } from './room/track/types';
 
 /**
  * Options for when creating a new room
@@ -16,7 +17,7 @@ export interface RoomOptions {
    * When none of the video elements are visible, it'll temporarily pause
    * the data flow until they are visible again.
    */
-  adaptiveStream?: boolean;
+  adaptiveStream?: AdaptiveStreamSettings | boolean;
 
   /**
    * enable Dynacast, off by default. With Dynacast dynamically pauses
@@ -77,7 +78,7 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
   /**
    * see [[RoomOptions.adaptiveStream]]
    */
-  adaptiveStream?: boolean;
+  adaptiveStream?: AdaptiveStreamSettings | boolean;
 
   /**
    * alias for adaptiveStream

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -522,7 +522,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // handle changes to participant state, and send events
     participantInfos.forEach((info) => {
       if (info.sid === this.localParticipant.sid
-        || info.identity === this.localParticipant.identity) {
+          || info.identity === this.localParticipant.identity) {
         this.localParticipant.updateInfo(info);
         return;
       }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -28,7 +28,7 @@ import LocalTrackPublication from './track/LocalTrackPublication';
 import RemoteTrackPublication from './track/RemoteTrackPublication';
 import { Track } from './track/Track';
 import { TrackPublication } from './track/TrackPublication';
-import { RemoteTrack } from './track/types';
+import { AdaptiveStreamSettings, RemoteTrack } from './track/types';
 import { unpackStreamId } from './utils';
 
 export enum RoomState {
@@ -437,12 +437,20 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (!trackId || trackId === '') trackId = mediaTrack.id;
 
     const participant = this.getOrCreateParticipant(participantId);
+    let adaptiveStreamSettings: AdaptiveStreamSettings | undefined;
+    if (this.options.adaptiveStream) {
+      if (typeof this.options.adaptiveStream === 'object') {
+        adaptiveStreamSettings = this.options.adaptiveStream;
+      } else {
+        adaptiveStreamSettings = {};
+      }
+    }
     participant.addSubscribedMediaTrack(
       mediaTrack,
       trackId,
       stream,
       receiver,
-      this.options.adaptiveStream,
+      adaptiveStreamSettings,
     );
   }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -442,7 +442,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       trackId,
       stream,
       receiver,
-      this.options.adaptiveStream,
+      typeof this.options.adaptiveStream === 'boolean' ? { enabled: this.options.adaptiveStream } : this.options.adaptiveStream,
     );
   }
 
@@ -522,7 +522,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // handle changes to participant state, and send events
     participantInfos.forEach((info) => {
       if (info.sid === this.localParticipant.sid
-          || info.identity === this.localParticipant.identity) {
+        || info.identity === this.localParticipant.identity) {
         this.localParticipant.updateInfo(info);
         return;
       }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -442,7 +442,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       trackId,
       stream,
       receiver,
-      typeof this.options.adaptiveStream === 'boolean' ? { enabled: this.options.adaptiveStream } : this.options.adaptiveStream,
+      this.options.adaptiveStream,
     );
   }
 

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -10,7 +10,7 @@ import RemoteAudioTrack from '../track/RemoteAudioTrack';
 import RemoteTrackPublication from '../track/RemoteTrackPublication';
 import RemoteVideoTrack from '../track/RemoteVideoTrack';
 import { Track } from '../track/Track';
-import { RemoteTrack } from '../track/types';
+import { AdaptiveStreamSettings, RemoteTrack } from '../track/types';
 import Participant, { ParticipantEventCallbacks } from './Participant';
 
 export default class RemoteParticipant extends Participant {
@@ -82,7 +82,7 @@ export default class RemoteParticipant extends Participant {
     sid: Track.SID,
     mediaStream: MediaStream,
     receiver?: RTCRtpReceiver,
-    adaptiveStream?: boolean,
+    adaptiveStreamSettings?: AdaptiveStreamSettings,
     triesLeft?: number,
   ) {
     // find the track publication
@@ -114,7 +114,7 @@ export default class RemoteParticipant extends Participant {
       if (triesLeft === undefined) triesLeft = 20;
       setTimeout(() => {
         this.addSubscribedMediaTrack(mediaTrack, sid, mediaStream,
-          receiver, adaptiveStream, triesLeft! - 1);
+          receiver, adaptiveStreamSettings, triesLeft! - 1);
       }, 150);
       return;
     }
@@ -122,7 +122,7 @@ export default class RemoteParticipant extends Participant {
     const isVideo = mediaTrack.kind === 'video';
     let track: RemoteTrack;
     if (isVideo) {
-      track = new RemoteVideoTrack(mediaTrack, sid, receiver, adaptiveStream);
+      track = new RemoteVideoTrack(mediaTrack, sid, receiver, adaptiveStreamSettings);
     } else {
       track = new RemoteAudioTrack(mediaTrack, sid, receiver);
     }
@@ -199,7 +199,7 @@ export default class RemoteParticipant extends Participant {
 
   /** @internal */
   unpublishTrack(sid: Track.SID, sendUnpublish?: boolean) {
-    const publication = <RemoteTrackPublication> this.tracks.get(sid);
+    const publication = <RemoteTrackPublication>this.tracks.get(sid);
     if (!publication) {
       return;
     }

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -199,7 +199,7 @@ export default class RemoteParticipant extends Participant {
 
   /** @internal */
   unpublishTrack(sid: Track.SID, sendUnpublish?: boolean) {
-    const publication = <RemoteTrackPublication>this.tracks.get(sid);
+    const publication = <RemoteTrackPublication> this.tracks.get(sid);
     if (!publication) {
       return;
     }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -29,11 +29,11 @@ export default class RemoteVideoTrack extends RemoteTrack {
     adaptiveStreamSettings?: AdaptiveStreamSettings,
   ) {
     super(mediaTrack, sid, Track.Kind.Video, receiver);
-    this.adaptiveStreamSettings = typeof adaptiveStreamSettings === 'boolean' ? { enabled: adaptiveStreamSettings } : adaptiveStreamSettings;
+    this.adaptiveStreamSettings = adaptiveStreamSettings;
   }
 
   get isAdaptiveStream(): boolean {
-    return this.adaptiveStreamSettings ? this.adaptiveStreamSettings.enabled : false;
+    return this.adaptiveStreamSettings === true || typeof this.adaptiveStreamSettings === 'object';
   }
 
   /** @internal */
@@ -61,7 +61,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
 
     // It's possible attach is called multiple times on an element. When that's
     // the case, we'd want to avoid adding duplicate elementInfos
-    if (this.adaptiveStreamSettings?.enabled
+    if (this.adaptiveStreamSettings
       && this.elementInfos.find((info) => info.element === element) === undefined
     ) {
       this.elementInfos.push({
@@ -196,10 +196,11 @@ export default class RemoteVideoTrack extends RemoteTrack {
     let maxWidth = 0;
     let maxHeight = 0;
     for (const info of this.elementInfos) {
-      const pixelDensity = this.adaptiveStreamSettings?.enabled
-        ? this.adaptiveStreamSettings?.pixelDensity ?? 1 : 1;
-      const currentElementWidth = info.element.clientWidth * pixelDensity;
-      const currentElementHeight = info.element.clientHeight * pixelDensity;
+      const pixelDensity = this.adaptiveStreamSettings && typeof this.adaptiveStreamSettings === 'object'
+        ? this.adaptiveStreamSettings.pixelDensity ?? 1 : 1;
+      const pixelDensityValue = pixelDensity === 'screen' ? window.devicePixelRatio : pixelDensity;
+      const currentElementWidth = info.element.clientWidth * pixelDensityValue;
+      const currentElementHeight = info.element.clientHeight * pixelDensityValue;
       if (currentElementWidth + currentElementHeight > maxWidth + maxHeight) {
         maxWidth = currentElementWidth;
         maxHeight = currentElementHeight;

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -33,7 +33,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
   }
 
   get isAdaptiveStream(): boolean {
-    return this.adaptiveStreamSettings === true || typeof this.adaptiveStreamSettings === 'object';
+    return this.adaptiveStreamSettings !== undefined;
   }
 
   /** @internal */
@@ -196,8 +196,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
     let maxWidth = 0;
     let maxHeight = 0;
     for (const info of this.elementInfos) {
-      const pixelDensity = this.adaptiveStreamSettings && typeof this.adaptiveStreamSettings === 'object'
-        ? this.adaptiveStreamSettings.pixelDensity ?? 1 : 1;
+      const pixelDensity = this.adaptiveStreamSettings?.pixelDensity ?? 1;
       const pixelDensityValue = pixelDensity === 'screen' ? window.devicePixelRatio : pixelDensity;
       const currentElementWidth = info.element.clientWidth * pixelDensityValue;
       const currentElementHeight = info.element.clientHeight * pixelDensityValue;

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -195,9 +195,11 @@ export default class RemoteVideoTrack extends RemoteTrack {
     let maxWidth = 0;
     let maxHeight = 0;
     for (const info of this.elementInfos) {
-      if (info.element.clientWidth + info.element.clientHeight > maxWidth + maxHeight) {
-        maxWidth = info.element.clientWidth;
-        maxHeight = info.element.clientHeight;
+      const currentElementWidth = info.element.clientWidth * (window.devicePixelRatio ?? 1);
+      const currentElementHeight = info.element.clientHeight * (window.devicePixelRatio ?? 1);
+      if (currentElementWidth + currentElementHeight > maxWidth + maxHeight) {
+        maxWidth = currentElementWidth;
+        maxHeight = currentElementHeight;
       }
     }
 

--- a/src/room/track/types.ts
+++ b/src/room/track/types.ts
@@ -12,7 +12,7 @@ export type AdaptiveStreamSettings = boolean | {
    * Set a custom pixel density, defaults to 1
    * When streaming videos on a ultra high definition screen this setting
    * let's you account for the devicePixelRatio of those screens.
-   * Set it to `window.devicePixelRatio` to use the actual pixel density of the screen
+   * Set it to `screen` to use the actual pixel density of the screen
    * Note: this might significantly increase the bandwidth consumed by people
    * streaming on high definition screens.
    */

--- a/src/room/track/types.ts
+++ b/src/room/track/types.ts
@@ -7,7 +7,7 @@ export type RemoteTrack = RemoteAudioTrack | RemoteVideoTrack;
 export type AudioTrack = RemoteAudioTrack | LocalAudioTrack;
 export type VideoTrack = RemoteVideoTrack | LocalVideoTrack;
 
-export type AdaptiveStreamSettings = boolean | {
+export type AdaptiveStreamSettings = {
   /**
    * Set a custom pixel density, defaults to 1
    * When streaming videos on a ultra high definition screen this setting

--- a/src/room/track/types.ts
+++ b/src/room/track/types.ts
@@ -6,3 +6,19 @@ import type RemoteVideoTrack from './RemoteVideoTrack';
 export type RemoteTrack = RemoteAudioTrack | RemoteVideoTrack;
 export type AudioTrack = RemoteAudioTrack | LocalAudioTrack;
 export type VideoTrack = RemoteVideoTrack | LocalVideoTrack;
+
+export type AdaptiveStreamSettings = {
+  /**
+   * Enable adaptive streaming
+   */
+  enabled: boolean,
+  /**
+   * Set a custom pixel density, defaults to 1
+   * When streaming videos on a ultra high definition screen this setting
+   * let's you account for the devicePixelRatio of those screens.
+   * Set it to `window.devicePixelRatio` to use the actual pixel density of the screen
+   * Note: this might significantly increase the bandwidth consumed by people
+   * streaming on high definition screens.
+   */
+  pixelDensity?: number
+};

--- a/src/room/track/types.ts
+++ b/src/room/track/types.ts
@@ -7,11 +7,7 @@ export type RemoteTrack = RemoteAudioTrack | RemoteVideoTrack;
 export type AudioTrack = RemoteAudioTrack | LocalAudioTrack;
 export type VideoTrack = RemoteVideoTrack | LocalVideoTrack;
 
-export type AdaptiveStreamSettings = {
-  /**
-   * Enable adaptive streaming
-   */
-  enabled: boolean,
+export type AdaptiveStreamSettings = boolean | {
   /**
    * Set a custom pixel density, defaults to 1
    * When streaming videos on a ultra high definition screen this setting
@@ -20,5 +16,5 @@ export type AdaptiveStreamSettings = {
    * Note: this might significantly increase the bandwidth consumed by people
    * streaming on high definition screens.
    */
-  pixelDensity?: number
+  pixelDensity?: number | 'screen'
 };


### PR DESCRIPTION
With #141 reverted, this would be an approach of letting users define the `pixelDensity`.

In this PR this is achieved with a client side setting, which gives users the flexibility to decide whether or not to use it depending on custom constraints. For example *"use a higher pixelDensity on desktop devices, but default to 1 on mobile devices"*.

Biggest change here is that the `adaptiveStream` setting can now take the type `AdaptiveStreamSettings`. 
Conceptually `pixelDensity` belongs to the `adaptiveStream` setting and to foreshadow for when it might be possible to customize the adaptiveStream even further, I thought it would be worth it.