### PR TITLE
Queue signalling until ICE reconnected

### DIFF
--- a/src/api/RequestQueue.ts
+++ b/src/api/RequestQueue.ts
@@ -1,4 +1,4 @@
-import logger from '../logger';
+import log from '../logger';
 
 export default class Queue {
   private queue: Array<() => void>;
@@ -11,34 +11,34 @@ export default class Queue {
   }
 
   enqueue(cb: () => void) {
-    logger.debug('enqueuing request to fire later');
+    log.trace('enqueuing request to fire later');
     this.queue.push(cb);
   }
 
   dequeue() {
     const evt = this.queue.shift();
     if (evt) evt();
-    logger.debug('firing request from queue');
+    log.trace('firing request from queue');
   }
 
   async run() {
     if (this.running) return;
-    logger.debug('start queue');
+    log.trace('start queue');
     this.running = true;
     while (this.running && this.queue.length > 0) {
       this.dequeue();
     }
     this.running = false;
-    logger.debug('queue finished');
+    log.trace('queue finished');
   }
 
   pause() {
-    logger.debug('pausing queue');
+    log.trace('pausing queue');
     this.running = false;
   }
 
   reset() {
-    logger.debug('resetting queue');
+    log.trace('resetting queue');
     this.running = false;
     this.queue = [];
   }

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -234,7 +234,7 @@ export class SignalClient {
 
   // answer a server-initiated offer
   sendAnswer(answer: RTCSessionDescriptionInit) {
-    log.debug('sending answer', answer);
+    log.debug('sending answer');
     this.sendRequest({
       answer: toProtoSessionDescription(answer),
     });

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -238,10 +238,6 @@ export class SignalClient {
     this.sendRequest({
       answer: toProtoSessionDescription(answer),
     });
-    if (this.isReconnecting) {
-      this.isReconnecting = false;
-      this.requestQueue.run();
-    }
   }
 
   sendIceCandidate(candidate: RTCIceCandidateInit, target: SignalTarget) {
@@ -406,6 +402,11 @@ export class SignalClient {
     } else {
       log.debug('unsupported message', msg);
     }
+  }
+
+  setReconnected() {
+    this.isReconnecting = false;
+    this.requestQueue.run();
   }
 
   private handleWSError(ev: Event) {

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -38,6 +38,7 @@ export interface SignalOptions {
 const passThroughQueueSignals: Array<keyof SignalRequest> = [
   'syncState',
   'trickle',
+  'offer',
   'answer',
   'simulate',
 ];

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -444,6 +444,7 @@ export default class RTCEngine extends (
     }
 
     await this.waitForPCConnected();
+    this.client.setReconnected();
 
     // reconnect success
     this.emit(EngineEvent.Restarted, joinResponse);


### PR DESCRIPTION
I'm not entirely sure if
1. just after `sendAnswer` is the right place to set `isReconnecting` to false
2. we'd need more (or rather less) events to pass in `passThroughQueueSignals`. 

tried to keep it flexible by just putting the requests that need to pass in an array.