### PR TITLE
Publish only option

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -100,6 +100,17 @@
                 Force TURN
               </label>
             </div>
+            <div>
+              <input
+                type="checkbox"
+                class="form-check-input"
+                id="publish-only"
+                checked
+              />
+              <label for="publish-only" class="form-check-label">
+                PublishOnly
+              </label>
+            </div>
           </div>
 
           <!-- actions -->

--- a/example/index.html
+++ b/example/index.html
@@ -105,7 +105,6 @@
                 type="checkbox"
                 class="form-check-input"
                 id="publish-only"
-                checked
               />
               <label for="publish-only" class="form-check-label">
                 PublishOnly

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -217,8 +217,8 @@ const appActions = {
       const msg = state.encoder.encode(textField.value);
       currentRoom.localParticipant.publishData(msg, DataPacket_Kind.RELIABLE);
       (<HTMLTextAreaElement>(
-        $('chat')
-      )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
+      $('chat')
+    )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
       textField.value = '';
     }
   },
@@ -481,7 +481,7 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       break;
     default:
       signalElm.innerHTML = '';
-    // do nothing
+      // do nothing
   }
 }
 

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -38,6 +38,7 @@ const appActions = {
     const dynacast = (<HTMLInputElement>$('dynacast')).checked;
     const forceTURN = (<HTMLInputElement>$('force-turn')).checked;
     const adaptiveStream = (<HTMLInputElement>$('adaptive-stream')).checked;
+    const publishOnly = (<HTMLInputElement>$('publish-only')).checked;
     const shouldPublish = (<HTMLInputElement>$('publish-option')).checked;
 
     setLogLevel('debug');
@@ -58,7 +59,10 @@ const appActions = {
       },
     };
 
-    const connectOpts: RoomConnectOptions = {};
+    const connectOpts: RoomConnectOptions = {
+      autoSubscribe: publishOnly ? false : true,
+      publishOnly: publishOnly ? 'publish_only' : undefined,
+    };
     if (forceTURN) {
       connectOpts.rtcConfig = {
         iceTransportPolicy: 'relay',
@@ -213,8 +217,8 @@ const appActions = {
       const msg = state.encoder.encode(textField.value);
       currentRoom.localParticipant.publishData(msg, DataPacket_Kind.RELIABLE);
       (<HTMLTextAreaElement>(
-      $('chat')
-    )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
+        $('chat')
+      )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
       textField.value = '';
     }
   },
@@ -477,7 +481,7 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       break;
     default:
       signalElm.innerHTML = '';
-      // do nothing
+    // do nothing
   }
 }
 

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -28,11 +28,14 @@ interface ConnectOpts {
   autoSubscribe?: boolean;
   /** internal */
   reconnect?: boolean;
+
+  publishOnly?: string;
 }
 
 // public options
 export interface SignalOptions {
   autoSubscribe?: boolean;
+  publishOnly?: string;
 }
 
 const passThroughQueueSignals: Array<keyof SignalRequest> = [
@@ -115,6 +118,7 @@ export class SignalClient {
     this.isConnected = false;
     const res = await this.connect(url, token, {
       autoSubscribe: opts?.autoSubscribe,
+      publishOnly: opts?.publishOnly,
     });
     return res as JoinResponse;
   }
@@ -475,6 +479,10 @@ function createConnectionParams(token: string, info: ClientInfo, opts?: ConnectO
   }
   if (info.browserVersion) {
     params.set('browser_version', info.browserVersion);
+  }
+
+  if (opts?.publishOnly !== undefined) {
+    params.set('publish', opts.publishOnly);
   }
 
   return `?${params.toString()}`;

--- a/src/options.ts
+++ b/src/options.ts
@@ -67,6 +67,11 @@ export interface RoomConnectOptions {
    * use to override any RTCConfiguration options.
    */
   rtcConfig?: RTCConfiguration;
+
+  /**
+   * publish only mode
+   */
+  publishOnly?: string;
 }
 
 /**


### PR DESCRIPTION
Simply adds `&publish=` to the connection url.
Publish only mode works for local server but fails with cloud.