### PR TITLE
compare video presets by bitrate and fps

### DIFF
--- a/src/room/participant/publishUtils.test.ts
+++ b/src/room/participant/publishUtils.test.ts
@@ -120,11 +120,11 @@ describe('customSimulcastLayers', () => {
     const sortedPresets = sortPresets([
       new VideoPreset(1920, 1080, 3_000_000, 20),
       new VideoPreset(1920, 1080, 2_000_000, 15),
-      new VideoPreset(1920, 1080, 1_000_000, 10),
+      new VideoPreset(1920, 1080, 3_000_000, 15),
     ]) as Array<VideoPreset>;
     expect(sortPresets).not.toBeUndefined();
-    expect(sortedPresets[0].encoding.maxBitrate).toBe(1_000_000);
-    expect(sortedPresets[1].encoding.maxBitrate).toBe(2_000_000);
-    expect(sortedPresets[2].encoding.maxBitrate).toBe(3_000_000);
+    expect(sortedPresets[0].encoding.maxBitrate).toBe(2_000_000);
+    expect(sortedPresets[1].encoding.maxFramerate).toBe(15);
+    expect(sortedPresets[2].encoding.maxFramerate).toBe(20);
   });
 });

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -199,14 +199,15 @@ function encodingsFromPresets(
 export function sortPresets(presets: Array<VideoPreset> | undefined) {
   if (!presets) return;
   return presets.sort((a, b) => {
-    const maxA = Math.max(a.height, a.width);
-    const maxB = Math.max(b.height, b.width);
-    if (maxA > maxB) {
+    const { encoding: aEnc } = a;
+    const { encoding: bEnc } = b;
+
+    if (aEnc.maxBitrate > bEnc.maxBitrate) {
       return 1;
     }
-    if (maxA < maxB) return -1;
-    if (maxA === maxB) {
-      return a.encoding.maxBitrate > b.encoding.maxBitrate ? 1 : -1;
+    if (aEnc.maxBitrate < bEnc.maxBitrate) return -1;
+    if (aEnc.maxBitrate === bEnc.maxBitrate && aEnc.maxFramerate && bEnc.maxFramerate) {
+      return aEnc.maxFramerate > bEnc.maxFramerate ? 1 : -1;
     }
     return 0;
   });


### PR DESCRIPTION
as mentioned in https://github.com/livekit/client-sdk-swift/pull/53 this is to adapt the same preset comparing logic for the js sdk.