### PR TITLE
enable screen share simulcast by default

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -17,7 +17,8 @@ import LocalVideoTrack, { videoLayersFromEncodings } from '../track/LocalVideoTr
 import {
   CreateLocalTracksOptions,
   ScreenShareCaptureOptions,
-  TrackPublishOptions, VideoCodec, VideoPresets,
+  ScreenSharePresets,
+  TrackPublishOptions, VideoCodec,
 } from '../track/options';
 import { Track } from '../track/Track';
 import { constraintsForOptions, mergeDefaultOptions } from '../track/utils';
@@ -272,7 +273,7 @@ export default class LocalParticipant extends Participant {
       options = {};
     }
     if (options.resolution === undefined) {
-      options.resolution = VideoPresets.fhd.resolution;
+      options.resolution = ScreenSharePresets.h720fps15.resolution;
     }
 
     let videoConstraints: MediaTrackConstraints | boolean = true;

--- a/src/room/participant/publishUtils.test.ts
+++ b/src/room/participant/publishUtils.test.ts
@@ -1,5 +1,8 @@
-import { VideoPreset, VideoPresets, VideoPresets43 } from '../track/options';
 import {
+  ScreenSharePresets, VideoPreset, VideoPresets, VideoPresets43,
+} from '../track/options';
+import {
+  computeDefaultScreenShareSimulcastPresets,
   computeVideoEncodings,
   determineAppropriateEncoding,
   presets169,
@@ -126,5 +129,17 @@ describe('customSimulcastLayers', () => {
     expect(sortedPresets[0].encoding.maxBitrate).toBe(2_000_000);
     expect(sortedPresets[1].encoding.maxFramerate).toBe(15);
     expect(sortedPresets[2].encoding.maxFramerate).toBe(20);
+  });
+});
+
+describe('screenShareSimulcastDefaults', () => {
+  it('computes appropriate bitrate from original preset', () => {
+    const defaultSimulcastLayers = computeDefaultScreenShareSimulcastPresets(
+      ScreenSharePresets.h720fps15,
+    );
+    expect(defaultSimulcastLayers[0].width).toBe(640);
+    expect(defaultSimulcastLayers[0].height).toBe(360);
+    expect(defaultSimulcastLayers[0].encoding.maxFramerate).toBe(3);
+    expect(defaultSimulcastLayers[0].encoding.maxBitrate).toBe(100_000);
   });
 });

--- a/src/room/participant/publishUtils.test.ts
+++ b/src/room/participant/publishUtils.test.ts
@@ -140,6 +140,6 @@ describe('screenShareSimulcastDefaults', () => {
     expect(defaultSimulcastLayers[0].width).toBe(640);
     expect(defaultSimulcastLayers[0].height).toBe(360);
     expect(defaultSimulcastLayers[0].encoding.maxFramerate).toBe(3);
-    expect(defaultSimulcastLayers[0].encoding.maxBitrate).toBe(100_000);
+    expect(defaultSimulcastLayers[0].encoding.maxBitrate).toBe(150_000);
   });
 });

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -52,9 +52,9 @@ export const computeDefaultScreenShareSimulcastPresets = (fromPreset: VideoPrese
   return layers.map((t) => new VideoPreset(
     Math.floor(fromPreset.width / t.scaleResolutionDownBy),
     Math.floor(fromPreset.height / t.scaleResolutionDownBy),
-    Math.floor(fromPreset.encoding.maxBitrate
-      / (t.scaleResolutionDownBy * ((fromPreset.encoding.maxFramerate ?? 30) / t.fps))),
-    t.fps,
+    Math.max(150_000, Math.floor(fromPreset.encoding.maxBitrate
+      / (t.scaleResolutionDownBy ** 2 * ((fromPreset.encoding.maxFramerate ?? 30) / t.fps))),
+    t.fps),
   ));
 };
 

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -53,8 +53,8 @@ export const computeDefaultScreenShareSimulcastPresets = (fromPreset: VideoPrese
     Math.floor(fromPreset.width / t.scaleResolutionDownBy),
     Math.floor(fromPreset.height / t.scaleResolutionDownBy),
     Math.max(150_000, Math.floor(fromPreset.encoding.maxBitrate
-      / (t.scaleResolutionDownBy ** 2 * ((fromPreset.encoding.maxFramerate ?? 30) / t.fps))),
-    t.fps),
+      / (t.scaleResolutionDownBy ** 2 * ((fromPreset.encoding.maxFramerate ?? 30) / t.fps)))),
+    t.fps,
   ));
 };
 

--- a/src/room/track/defaults.ts
+++ b/src/room/track/defaults.ts
@@ -9,9 +9,6 @@ export const publishDefaults: TrackPublishDefaults = {
   simulcast: true,
   screenShareEncoding: ScreenSharePresets.h720fps15.encoding,
   stopMicTrackOnMute: false,
-  screenShareSimulcastLayers: [
-    ScreenSharePresets.h360fps3,
-  ],
 };
 
 export const audioDefaults: AudioCaptureOptions = {

--- a/src/room/track/defaults.ts
+++ b/src/room/track/defaults.ts
@@ -7,8 +7,11 @@ export const publishDefaults: TrackPublishDefaults = {
   audioBitrate: AudioPresets.speech.maxBitrate,
   dtx: true,
   simulcast: true,
-  screenShareEncoding: ScreenSharePresets.hd_15.encoding,
+  screenShareEncoding: ScreenSharePresets.h720fps15.encoding,
   stopMicTrackOnMute: false,
+  screenShareSimulcastLayers: [
+    ScreenSharePresets.h360fps3,
+  ],
 };
 
 export const audioDefaults: AudioCaptureOptions = {
@@ -19,5 +22,5 @@ export const audioDefaults: AudioCaptureOptions = {
 };
 
 export const videoDefaults: VideoCaptureOptions = {
-  resolution: VideoPresets.qhd.resolution,
+  resolution: VideoPresets.h540.resolution,
 };


### PR DESCRIPTION
Considerations:
- hardcode the default simulcast layer to something that makes sense with the default `screenShareEncoding`
  * would be nice to have all defaults in one place
- dynamically compute the default simulcast layer from the supplied default `screenShareEncoding`
  * a lot more flexibel, not sure if a linear computation of the bitrate makes sense


First commit is using the first option only, second commit computes the layer from the provided original preset.
I'd favor the automatic computation
