### PR TITLE
handle app in background for mobile devices

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -29,6 +29,7 @@ import RemoteTrackPublication from './track/RemoteTrackPublication';
 import { Track } from './track/Track';
 import { TrackPublication } from './track/TrackPublication';
 import { AdaptiveStreamSettings, RemoteTrack } from './track/types';
+import { getNewAudioContext } from './track/utils';
 import { unpackStreamId } from './utils';
 
 export enum RoomState {
@@ -725,10 +726,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
     // by using an AudioContext, it reduces lag on audio elements
     // https://stackoverflow.com/questions/9811429/html5-audio-tag-on-safari-has-a-delay/54119854#54119854
-    // @ts-ignore
-    const AudioContext = window.AudioContext || window.webkitAudioContext;
-    if (AudioContext) {
-      this.audioContext = new AudioContext();
+    const ctx = getNewAudioContext();
+    if (ctx) {
+      this.audioContext = ctx;
     }
   }
 

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -400,6 +400,11 @@ export enum TrackEvent {
   AudioPlaybackStarted = 'audioPlaybackStarted',
   /** @internal */
   AudioPlaybackFailed = 'audioPlaybackFailed',
+  /**
+   * @internal
+   * Only fires on LocalAudioTrack instances
+  */
+  AudioSilenceDetected = 'audioSilenceDetected',
   /** @internal */
   VisibilityChanged = 'visibilityChanged',
   /** @internal */

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -9,6 +9,8 @@ export default class LocalTrack extends Track {
   sender?: RTCRtpSender;
 
   protected constraints: MediaTrackConstraints;
+  protected isInBackground: boolean;
+  protected reaquireTrack: boolean;
 
   protected constructor(
     mediaTrack: MediaStreamTrack, kind: Track.Kind, constraints?: MediaTrackConstraints,
@@ -17,6 +19,8 @@ export default class LocalTrack extends Track {
     this.mediaStreamTrack.addEventListener('ended', this.handleEnded);
     document.addEventListener('visibilitychange', this.handleAppVisibilityChanged);
     this.constraints = constraints ?? mediaTrack.getConstraints();
+    this.isInBackground = document.visibilityState === 'hidden';
+    this.reaquireTrack = false;
   }
 
   get id(): string {
@@ -120,7 +124,11 @@ export default class LocalTrack extends Track {
   }
 
   protected handleAppVisibilityChanged = () => {
+    this.isInBackground = document.visibilityState === 'hidden';
 
+    if(!this.isInBackground && this.reaquireTrack) {
+      this.restart(this.constraints);
+    }
   };
 
   private handleEnded = () => {

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -22,7 +22,7 @@ export default class LocalTrack extends Track {
   ) {
     super(mediaTrack, kind);
     this.mediaStreamTrack.addEventListener('ended', this.handleEnded);
-    document.addEventListener('visibilitychange', this.visibilityChangedListener); // TODO when to remove this event listener?
+    document.addEventListener('visibilitychange', this.visibilityChangedListener);
     this.constraints = constraints ?? mediaTrack.getConstraints();
     this.isInBackground = document.visibilityState === 'hidden';
     this.reacquireTrack = false;

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -11,8 +11,6 @@ export default class LocalTrack extends Track {
 
   protected constraints: MediaTrackConstraints;
 
-  protected isInBackground: boolean;
-
   protected wasMuted: boolean;
 
   protected reacquireTrack: boolean;
@@ -22,9 +20,7 @@ export default class LocalTrack extends Track {
   ) {
     super(mediaTrack, kind);
     this.mediaStreamTrack.addEventListener('ended', this.handleEnded);
-    document.addEventListener('visibilitychange', this.visibilityChangedListener);
     this.constraints = constraints ?? mediaTrack.getConstraints();
-    this.isInBackground = document.visibilityState === 'hidden';
     this.reacquireTrack = false;
     this.wasMuted = false;
   }
@@ -136,13 +132,9 @@ export default class LocalTrack extends Track {
       || this.reacquireTrack;
   }
 
-  visibilityChangedListener = () => {
-    this.handleAppVisibilityChanged();
-  };
-
   protected async handleAppVisibilityChanged() {
+    await super.handleAppVisibilityChanged();
     if (!isMobile()) return;
-    this.isInBackground = document.visibilityState === 'hidden';
     log.debug('visibility changed, is in Background: ', this.isInBackground);
 
     if (!this.isInBackground && this.needsReAcquisition) {
@@ -165,9 +157,4 @@ export default class LocalTrack extends Track {
     }
     this.emit(TrackEvent.Ended, this);
   };
-
-  stop(): void {
-    super.stop();
-    document.removeEventListener('visibilitychange', this.visibilityChangedListener);
-  }
 }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -15,6 +15,7 @@ export default class LocalTrack extends Track {
   ) {
     super(mediaTrack, kind);
     this.mediaStreamTrack.addEventListener('ended', this.handleEnded);
+    document.addEventListener('visibilitychange', this.handleAppVisibilityChanged);
     this.constraints = constraints ?? mediaTrack.getConstraints();
   }
 
@@ -117,6 +118,10 @@ export default class LocalTrack extends Track {
     this.mediaStreamTrack.enabled = !muted;
     this.emit(muted ? TrackEvent.Muted : TrackEvent.Unmuted, this);
   }
+
+  protected handleAppVisibilityChanged = () => {
+
+  };
 
   private handleEnded = () => {
     this.emit(TrackEvent.Ended, this);

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -3,7 +3,7 @@ import log from '../../logger';
 import { VideoLayer, VideoQuality } from '../../proto/livekit_models';
 import { SubscribedQuality } from '../../proto/livekit_rtc';
 import { computeBitrate, monitorFrequency, VideoSenderStats } from '../stats';
-import { isFireFox } from '../utils';
+import { isFireFox, isMobile } from '../utils';
 import LocalTrack from './LocalTrack';
 import { VideoCaptureOptions } from './options';
 import { Track } from './Track';
@@ -238,6 +238,14 @@ export default class LocalVideoTrack extends LocalTrack {
       this.monitorSender();
     }, monitorFrequency);
   };
+
+  protected async handleAppVisibilityChanged() {
+    await super.handleAppVisibilityChanged();
+    if (!isMobile()) return;
+    if (this.isInBackground && this.source === Track.Source.Camera) {
+      this.mediaStreamTrack.enabled = false;
+    }
+  }
 }
 
 export function videoQualityForRid(rid: string): VideoQuality {

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,5 +1,4 @@
 import { debounce } from 'ts-debounce';
-import log from '../../logger';
 import { TrackEvent } from '../events';
 import { computeBitrate, monitorFrequency, VideoReceiverStats } from '../stats';
 import { getIntersectionObserver, getResizeObserver, ObservableMediaElement } from '../utils';
@@ -182,7 +181,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
       0,
     );
     const isVisible = this.elementInfos.some((info) => info.visible) && !this.isInBackground;
-    log.info('update visibility', isVisible);
 
     if (this.lastVisible === isVisible) {
       return;

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -167,6 +167,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
   };
 
   protected async handleAppVisibilityChanged() {
+    if (!this.isAdaptiveStream) return;
     await super.handleAppVisibilityChanged();
     this.updateVisibility();
   }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,4 +1,5 @@
 import { debounce } from 'ts-debounce';
+import log from '../../logger';
 import { TrackEvent } from '../events';
 import { computeBitrate, monitorFrequency, VideoReceiverStats } from '../stats';
 import { getIntersectionObserver, getResizeObserver, ObservableMediaElement } from '../utils';
@@ -165,6 +166,11 @@ export default class RemoteVideoTrack extends RemoteTrack {
     this.updateVisibility();
   };
 
+  protected async handleAppVisibilityChanged() {
+    await super.handleAppVisibilityChanged();
+    this.updateVisibility();
+  }
+
   private readonly debouncedHandleResize = debounce(() => {
     this.updateDimensions();
   }, REACTION_DELAY);
@@ -174,7 +180,8 @@ export default class RemoteVideoTrack extends RemoteTrack {
       (prev, info) => Math.max(prev, info.visibilityChangedAt || 0),
       0,
     );
-    const isVisible = this.elementInfos.some((info) => info.visible);
+    const isVisible = this.elementInfos.some((info) => info.visible) && !this.isInBackground;
+    log.info('update visibility', isVisible);
 
     if (this.lastVisible === isVisible) {
       return;

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -22,6 +22,8 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
   source: Track.Source;
 
+  protected isInBackground: boolean;
+
   /**
    * sid is set after track is published to server, or if it's a remote track
    */
@@ -34,6 +36,8 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
     this.kind = kind;
     this.mediaStreamTrack = mediaTrack;
     this.source = Track.Source.Unknown;
+    this.isInBackground = document.visibilityState === 'hidden';
+    document.addEventListener('visibilitychange', this.appVisibilityChangedListener);
   }
 
   /** current receive bits per second */
@@ -131,6 +135,7 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
   stop() {
     this.mediaStreamTrack.stop();
+    document.removeEventListener('visibilitychange', this.appVisibilityChangedListener);
   }
 
   protected enable() {
@@ -155,6 +160,14 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
         recycledElements.push(element);
       }
     }
+  }
+
+  appVisibilityChangedListener = () => {
+    this.handleAppVisibilityChanged();
+  };
+
+  protected async handleAppVisibilityChanged() {
+    this.isInBackground = document.visibilityState === 'hidden';
   }
 }
 

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -318,6 +318,7 @@ export type TrackEventCallbacks = {
   updateSubscription: () => void,
   audioPlaybackStarted: () => void,
   audioPlaybackFailed: (error: Error) => void,
+  audioSilenceDetected: () => void,
   visibilityChanged: (visible: boolean, track?: any) => void,
   videoDimensionsChanged: (dimensions: Track.Dimensions, track?: any) => void,
 };

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -24,7 +24,7 @@ export function isSafari(): boolean {
 }
 
 export function isMobile(): boolean {
-  return /Mobile|Android|BlackBerry/.test(navigator.userAgent);
+  return /Tablet|iPad|Mobile|Android|BlackBerry/.test(navigator.userAgent);
 }
 
 function roDispatchCallback(entries: ResizeObserverEntry[]) {

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -25,7 +25,6 @@ export function isSafari(): boolean {
 
 export function isMobile(): boolean {
   return /Mobile|Android|BlackBerry/.test(navigator.userAgent);
-
 }
 
 function roDispatchCallback(entries: ResizeObserverEntry[]) {

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -23,6 +23,11 @@ export function isSafari(): boolean {
   return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 }
 
+export function isMobile(): boolean {
+  return /Mobile|Android|BlackBerry/.test(navigator.userAgent);
+
+}
+
 function roDispatchCallback(entries: ResizeObserverEntry[]) {
   for (const entry of entries) {
     (entry.target as ObservableMediaElement).handleResize(entry);


### PR DESCRIPTION
- [x] pause video (camera only) when in background
- [x] reacquire tracks if neccessary (always reaquire video)
- [x] restore muted state after reacquiring
- [x] detect silence when acquiring microphone track and emit event 

for the last point I'm undecided on how to handle it.
I added a helper function `detectSilence` that allows users to pipe in AudioTracks and check if they are silent. It seems wrong to emit an error whenever there is silence detected on reaquiring a track (it might just be, that a user who put the app into background has an external mic switch and that mic is turned off).
