### PR TITLE
Increase default screenshare resolution and bitrate.

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -275,7 +275,7 @@ export default class LocalParticipant extends Participant {
       options = {};
     }
     if (options.resolution === undefined) {
-      options.resolution = ScreenSharePresets.h720fps15.resolution;
+      options.resolution = ScreenSharePresets.h1080fps15.resolution;
     }
 
     let videoConstraints: MediaTrackConstraints | boolean = true;

--- a/src/room/track/defaults.ts
+++ b/src/room/track/defaults.ts
@@ -7,7 +7,7 @@ export const publishDefaults: TrackPublishDefaults = {
   audioBitrate: AudioPresets.speech.maxBitrate,
   dtx: true,
   simulcast: true,
-  screenShareEncoding: ScreenSharePresets.h720fps15.encoding,
+  screenShareEncoding: ScreenSharePresets.h1080fps15.encoding,
   stopMicTrackOnMute: false,
 };
 


### PR DESCRIPTION
Screenshare typically uses way less than max bitrate allowed due to lack of motion. Giving it more bits to work with to improve sharpness