### PR TITLE
example: Use location pathname when saving search parameters

### DIFF
--- a/example/sample.ts
+++ b/example/sample.ts
@@ -26,7 +26,11 @@ const storedToken = searchParams.get('token') ?? '';
 
 function updateSearchParams(url: string, token: string) {
   const params = new URLSearchParams({ url, token });
-  window.history.replaceState(null, '', `/?${params.toString()}`);
+  window.history.replaceState(
+    null,
+    '',
+    `${window.location.pathname}?${params.toString()}`,
+  );
 }
 
 // handles actions from the HTML


### PR DESCRIPTION
If the sample is hosted from a path other than `/`, it would get reset
to the root path. Set the path based on the current location when adding
the search parameters.