### PR TITLE
Add prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['airbnb-typescript/base'],
+  extends: ['airbnb-typescript/base', 'prettier'],
   parserOptions: {
     project: './tsconfig.eslint.json',
   },

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true,
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/example/index.html
+++ b/example/index.html
@@ -3,10 +3,7 @@
   <head>
     <title>Livekit test app</title>
     <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
     <link
       rel="stylesheet"
@@ -15,7 +12,7 @@
       crossorigin="anonymous"
     />
 
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css" />
   </head>
 
   <body>
@@ -23,18 +20,13 @@
       <div class="row">
         <div class="col-md-8">
           <h2>Livekit Sample App</h2>
-          <br/>
+          <br />
           <div id="connect-area">
             <div>
               <b>LiveKit URL</b>
             </div>
             <div>
-              <input
-                type="text"
-                class="form-control"
-                id="url"
-                value="ws://localhost:7880"
-              />
+              <input type="text" class="form-control" id="url" value="ws://localhost:7880" />
             </div>
             <div>
               <b>Token</b>
@@ -47,71 +39,31 @@
           <!-- connect options -->
           <div id="options-area">
             <div>
-              <input
-                type="checkbox"
-                class="form-check-input"
-                id="publish-option"
-                checked
-              />
-              <label for="publish-option" class="form-check-label">
-                Publish
-              </label>
+              <input type="checkbox" class="form-check-input" id="publish-option" checked />
+              <label for="publish-option" class="form-check-label"> Publish </label>
             </div>
             <div>
-              <input
-                type="checkbox"
-                class="form-check-input"
-                id="simulcast"
-                checked
-              />
-              <label for="simulcast" class="form-check-label">
-                Simulcast
-              </label>
+              <input type="checkbox" class="form-check-input" id="simulcast" checked />
+              <label for="simulcast" class="form-check-label"> Simulcast </label>
             </div>
             <div>
-              <input
-                type="checkbox"
-                class="form-check-input"
-                id="dynacast"
-                checked
-              />
-              <label for="dynacast" class="form-check-label">
-                Dynacast
-              </label>
+              <input type="checkbox" class="form-check-input" id="dynacast" checked />
+              <label for="dynacast" class="form-check-label"> Dynacast </label>
             </div>
             <div>
-              <input
-                type="checkbox"
-                class="form-check-input"
-                id="adaptive-stream"
-                checked
-              />
-              <label for="adaptive-stream" class="form-check-label">
-                AdaptiveStream
-              </label>
+              <input type="checkbox" class="form-check-input" id="adaptive-stream" checked />
+              <label for="adaptive-stream" class="form-check-label"> AdaptiveStream </label>
             </div>
             <div>
-              <input
-                type="checkbox"
-                class="form-check-input"
-                id="force-turn"
-              />
-              <label for="force-turn" class="form-check-label">
-                Force TURN
-              </label>
+              <input type="checkbox" class="form-check-input" id="force-turn" />
+              <label for="force-turn" class="form-check-label"> Force TURN </label>
             </div>
             <div>
-              <input
-                type="checkbox"
-                class="form-check-input"
-                id="publish-only"
-              />
-              <label for="publish-only" class="form-check-label">
-                PublishOnly
-              </label>
+              <input type="checkbox" class="form-check-input" id="publish-only" />
+              <label for="publish-only" class="form-check-label"> PublishOnly </label>
             </div>
             <div>
-              <select id="preferred-codec" class="custom-select" style="width: auto;">
+              <select id="preferred-codec" class="custom-select" style="width: auto">
                 <option value="" selected>PreferredCodec</option>
                 <option value="h264">H264</option>
                 <option value="vp9">VP9</option>
@@ -169,7 +121,12 @@
               >
                 Share Screen
               </button>
-              <select id="simulate-scenario" class="custom-select" style="width: auto;" onchange="appActions.handleScenario(event)">
+              <select
+                id="simulate-scenario"
+                class="custom-select"
+                style="width: auto"
+                onchange="appActions.handleScenario(event)"
+              >
                 <option value="" selected>Simulate</option>
                 <option value="signal-reconnect">Signal reconnect</option>
                 <option value="speaker">Speaker update</option>
@@ -200,17 +157,29 @@
 
           <div id="inputs-area">
             <div>
-              <select id="video-input" class="custom-select" onchange="appActions.handleDeviceSelected(event)">
+              <select
+                id="video-input"
+                class="custom-select"
+                onchange="appActions.handleDeviceSelected(event)"
+              >
                 <option selected>Video Input (default)</option>
               </select>
             </div>
             <div>
-              <select id="audio-input" class="custom-select" onchange="appActions.handleDeviceSelected(event)">
+              <select
+                id="audio-input"
+                class="custom-select"
+                onchange="appActions.handleDeviceSelected(event)"
+              >
                 <option selected>Audio Input (default)</option>
               </select>
             </div>
             <div>
-              <select id="audio-output" class="custom-select" onchange="appActions.handleDeviceSelected(event)">
+              <select
+                id="audio-output"
+                class="custom-select"
+                onchange="appActions.handleDeviceSelected(event)"
+              >
                 <option selected>Audio Output (default)</option>
               </select>
             </div>
@@ -222,8 +191,12 @@
             <textarea class="form-control" id="chat" rows="9"></textarea>
             <div id="chat-input-area">
               <div>
-                <input type="text" class="form-control" id="entry"
-                  placeholder="Type your message here" />
+                <input
+                  type="text"
+                  class="form-control"
+                  id="entry"
+                  placeholder="Type your message here"
+                />
               </div>
               <div>
                 <button
@@ -243,16 +216,13 @@
 
       <div id="screenshare-area">
         <div>
-          <span id="screenshare-info">
-          </span>
-          <span id="screenshare-resolution">
-          </span>
+          <span id="screenshare-info"> </span>
+          <span id="screenshare-resolution"> </span>
         </div>
         <video id="screenshare-video" autoplay playsinline></video>
       </div>
 
-      <div id="participants-area">
-      </div>
+      <div id="participants-area"></div>
 
       <div id="log-area">
         <textarea id="log"></textarea>

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -1,10 +1,22 @@
 import {
   ConnectionQuality,
-  DataPacket_Kind, LocalParticipant, MediaDeviceFailure,
-  Participant, ParticipantEvent, RemoteParticipant, Room,
-  RoomConnectOptions, RoomEvent,
-  RoomOptions, RoomState, setLogLevel, Track, TrackPublication,
-  VideoCaptureOptions, VideoPresets, VideoCodec,
+  DataPacket_Kind,
+  LocalParticipant,
+  MediaDeviceFailure,
+  Participant,
+  ParticipantEvent,
+  RemoteParticipant,
+  Room,
+  RoomConnectOptions,
+  RoomEvent,
+  RoomOptions,
+  RoomState,
+  setLogLevel,
+  Track,
+  TrackPublication,
+  VideoCaptureOptions,
+  VideoPresets,
+  VideoCodec,
 } from '../src/index';
 
 const $ = (id: string) => document.getElementById(id);
@@ -26,11 +38,7 @@ const storedToken = searchParams.get('token') ?? '';
 
 function updateSearchParams(url: string, token: string) {
   const params = new URLSearchParams({ url, token });
-  window.history.replaceState(
-    null,
-    '',
-    `${window.location.pathname}?${params.toString()}`,
-  );
+  window.history.replaceState(null, '', `${window.location.pathname}?${params.toString()}`);
 }
 
 // handles actions from the HTML
@@ -50,16 +58,15 @@ const appActions = {
     updateSearchParams(url, token);
 
     const roomOpts: RoomOptions = {
-      adaptiveStream: adaptiveStream ? {
-        pixelDensity: 'screen',
-      } : false,
+      adaptiveStream: adaptiveStream
+        ? {
+            pixelDensity: 'screen',
+          }
+        : false,
       dynacast,
       publishDefaults: {
         simulcast,
-        videoSimulcastLayers: [
-          VideoPresets.h90,
-          VideoPresets.h216,
-        ],
+        videoSimulcastLayers: [VideoPresets.h90, VideoPresets.h216],
         videoCodec: preferredCodec,
       },
       videoCaptureDefaults: {
@@ -130,16 +137,21 @@ const appActions = {
         const failure = MediaDeviceFailure.getFailure(e);
         appendLog('media device failure', failure);
       })
-      .on(RoomEvent.ConnectionQualityChanged,
+      .on(
+        RoomEvent.ConnectionQualityChanged,
         (quality: ConnectionQuality, participant?: Participant) => {
           appendLog('connection quality changed', participant?.identity, quality);
-        });
+        },
+      );
 
     try {
       const start = Date.now();
       await room.connect(url, token, connectOptions);
       const elapsed = Date.now() - start;
-      appendLog(`successfully connected to ${room.name} in ${Math.round(elapsed)}ms`, room.engine.connectedServerAddress);
+      appendLog(
+        `successfully connected to ${room.name} in ${Math.round(elapsed)}ms`,
+        room.engine.connectedServerAddress,
+      );
     } catch (error) {
       let message: any = error;
       if (error.message) {
@@ -231,8 +243,8 @@ const appActions = {
       const msg = state.encoder.encode(textField.value);
       currentRoom.localParticipant.publishData(msg, DataPacket_Kind.RELIABLE);
       (<HTMLTextAreaElement>(
-      $('chat')
-    )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
+        $('chat')
+      )).value += `${currentRoom.localParticipant.identity} (me): ${textField.value}\n`;
       textField.value = '';
     }
   },
@@ -367,10 +379,9 @@ function appendLog(...args: any[]) {
   const logger = $('log')!;
   for (let i = 0; i < arguments.length; i += 1) {
     if (typeof args[i] === 'object') {
-      logger.innerHTML
-        += `${JSON && JSON.stringify
-          ? JSON.stringify(args[i], undefined, 2)
-          : args[i]} `;
+      logger.innerHTML += `${
+        JSON && JSON.stringify ? JSON.stringify(args[i], undefined, 2) : args[i]
+      } `;
     } else {
       logger.innerHTML += `${args[i]} `;
     }
@@ -408,11 +419,12 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
           <span id="mic-${identity}" class="mic-on"></span>
         </div>
       </div>
-      ${participant instanceof RemoteParticipant
-    && `<div class="volume-control">
+      ${
+        participant instanceof RemoteParticipant &&
+        `<div class="volume-control">
         <input id="volume-${identity}" type="range" min="0" max="1" step="0.1" value="1" orient="vertical" />
       </div>`
-}
+      }
       
     `;
     container.appendChild(div);
@@ -470,7 +482,9 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       // measure time to render
       videoElm.onloadeddata = () => {
         const elapsed = Date.now() - startTime;
-        appendLog(`RemoteVideoTrack ${cameraPub?.trackSid} (${videoElm.videoWidth}x${videoElm.videoHeight}) rendered in ${elapsed}ms`);
+        appendLog(
+          `RemoteVideoTrack ${cameraPub?.trackSid} (${videoElm.videoWidth}x${videoElm.videoHeight}) rendered in ${elapsed}ms`,
+        );
       };
     }
     cameraPub?.videoTrack?.attach(videoElm);
@@ -508,7 +522,7 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       break;
     default:
       signalElm.innerHTML = '';
-      // do nothing
+    // do nothing
   }
 }
 
@@ -580,10 +594,12 @@ function updateVideoSize(element: HTMLVideoElement, target: HTMLElement) {
   target.innerHTML = `(${element.videoWidth}x${element.videoHeight})`;
 }
 
-function setButtonState(buttonId: string,
+function setButtonState(
+  buttonId: string,
   buttonText: string,
   isActive: boolean,
-  isDisabled: boolean | undefined = undefined) {
+  isDisabled: boolean | undefined = undefined,
+) {
   const el = $(buttonId) as HTMLButtonElement;
   if (!el) return;
   if (isDisabled !== undefined) {
@@ -629,15 +645,17 @@ const elementMapping: { [k: string]: MediaDeviceKind } = {
   'audio-output': 'audiooutput',
 };
 async function handleDevicesChanged() {
-  Promise.all(Object.keys(elementMapping).map(async (id) => {
-    const kind = elementMapping[id];
-    if (!kind) {
-      return;
-    }
-    const devices = await Room.getLocalDevices(kind);
-    const element = <HTMLSelectElement>$(id);
-    populateSelect(kind, element, devices, state.defaultDevices.get(kind));
-  }));
+  Promise.all(
+    Object.keys(elementMapping).map(async (id) => {
+      const kind = elementMapping[id];
+      if (!kind) {
+        return;
+      }
+      const devices = await Room.getLocalDevices(kind);
+      const element = <HTMLSelectElement>$(id);
+      populateSelect(kind, element, devices, state.defaultDevices.get(kind));
+    }),
+  );
 }
 
 function populateSelect(

--- a/example/styles.css
+++ b/example/styles.css
@@ -61,7 +61,7 @@
 }
 
 #participants-area > .participant::before {
-  content: "";
+  content: '';
   display: inline-block;
   width: 1px;
   height: 0;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build-sample": "cd example && webpack && cp styles.css index.html dist/",
     "lint": "eslint src",
     "test": "jest",
-    "deploy": "gh-pages -d example/dist"
+    "deploy": "gh-pages -d example/dist",
+    "prettify": "prettier ./src ./example"
   },
   "dependencies": {
     "events": "^3.3.0",
@@ -36,6 +37,7 @@
     "eslint-plugin-import": "^2.24.2",
     "gh-pages": "^3.2.3",
     "jest": "^27.4.3",
+    "prettier": "^2.6.1",
     "ts-jest": "^27.0.7",
     "ts-loader": "^8.1.0",
     "ts-proto": "^1.110.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint src",
     "test": "jest",
     "deploy": "gh-pages -d example/dist",
-    "prettify": "prettier ./src ./example"
+    "prettify": "prettier --write ./src ./example",
+    "prettify:check": "prettier --check ./src ./example"
   },
   "dependencies": {
     "events": "^3.3.0",
@@ -34,6 +35,7 @@
     "@webpack-cli/serve": "^1.5.2",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-typescript": "^12.3.1",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.24.2",
     "gh-pages": "^3.2.3",
     "jest": "^27.4.3",

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -1,7 +1,10 @@
 import log from '../logger';
 import {
   ClientInfo,
-  ParticipantInfo, Room, SpeakerInfo, VideoLayer,
+  ParticipantInfo,
+  Room,
+  SpeakerInfo,
+  VideoLayer,
 } from '../proto/livekit_models';
 import {
   AddTrackRequest,
@@ -11,13 +14,17 @@ import {
   SessionDescription,
   SignalRequest,
   SignalResponse,
-  SignalTarget, SimulateScenario,
+  SignalTarget,
+  SimulateScenario,
   StreamStateUpdate,
   SubscribedQualityUpdate,
-  SubscriptionPermissionUpdate, SyncState, TrackPermission,
+  SubscriptionPermissionUpdate,
+  SyncState,
+  TrackPermission,
   TrackPublishedResponse,
   TrackUnpublishedResponse,
-  UpdateSubscription, UpdateTrackSettings,
+  UpdateSubscription,
+  UpdateTrackSettings,
 } from '../proto/livekit_rtc';
 import { ConnectionError } from '../room/errors';
 import { getClientInfo, isWeb, sleep } from '../room/utils';
@@ -52,8 +59,9 @@ const passThroughQueueSignals: Array<keyof SignalRequest> = [
 ];
 
 function canPassThroughQueue(req: SignalRequest): boolean {
-  const canPass = Object.keys(req)
-    .find((key) => passThroughQueueSignals.includes(key as keyof SignalRequest)) !== undefined;
+  const canPass =
+    Object.keys(req).find((key) => passThroughQueueSignals.includes(key as keyof SignalRequest)) !==
+    undefined;
   log.trace('request allowed to bypass queue:', canPass, req);
   return canPass;
 }
@@ -115,11 +123,7 @@ export class SignalClient {
     this.requestQueue = new Queue();
   }
 
-  async join(
-    url: string,
-    token: string,
-    opts?: SignalOptions,
-  ): Promise<JoinResponse> {
+  async join(url: string, token: string, opts?: SignalOptions): Promise<JoinResponse> {
     // during a full reconnect, we'd want to start the sequence even if currently
     // connected
     this.isConnected = false;
@@ -137,11 +141,7 @@ export class SignalClient {
     });
   }
 
-  connect(
-    url: string,
-    token: string,
-    opts: ConnectOpts,
-  ): Promise<JoinResponse | void> {
+  connect(url: string, token: string, opts: ConnectOpts): Promise<JoinResponse | void> {
     if (url.startsWith('http')) {
       url = url.replace('http', 'ws');
     }
@@ -298,10 +298,7 @@ export class SignalClient {
     });
   }
 
-  sendUpdateSubscriptionPermissions(
-    allParticipants: boolean,
-    trackPermissions: TrackPermission[],
-  ) {
+  sendUpdateSubscriptionPermissions(allParticipants: boolean, trackPermissions: TrackPermission[]) {
     this.sendRequest({
       subscriptionPermission: {
         allParticipants,
@@ -325,7 +322,7 @@ export class SignalClient {
     // keep order by queueing up new events as long as the queue is not empty
     // unless the request originates from the queue, then don't enqueue again
     const canQueue = !fromQueue && !canPassThroughQueue(req);
-    if (canQueue && (this.isReconnecting || (!this.requestQueue.isEmpty()))) {
+    if (canQueue && (this.isReconnecting || !this.requestQueue.isEmpty())) {
       this.requestQueue.enqueue(() => this.sendRequest(req, true));
       return;
     }
@@ -360,9 +357,7 @@ export class SignalClient {
         this.onOffer(sd);
       }
     } else if (msg.trickle) {
-      const candidate: RTCIceCandidateInit = JSON.parse(
-        msg.trickle.candidateInit,
-      );
+      const candidate: RTCIceCandidateInit = JSON.parse(msg.trickle.candidateInit);
       if (this.onTrickle) {
         this.onTrickle(candidate, msg.trickle.target);
       }
@@ -429,9 +424,7 @@ export class SignalClient {
   }
 }
 
-function fromProtoSessionDescription(
-  sd: SessionDescription,
-): RTCSessionDescriptionInit {
+function fromProtoSessionDescription(sd: SessionDescription): RTCSessionDescriptionInit {
   const rsd: RTCSessionDescriptionInit = {
     type: 'offer',
     sdp: sd.sdp,

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,7 +1,5 @@
 import log, { LogLevel, setLogLevel } from './logger';
-import {
-  ConnectOptions,
-} from './options';
+import { ConnectOptions } from './options';
 import { MediaDeviceFailure } from './room/errors';
 import { RoomEvent } from './room/events';
 import Room from './room/Room';
@@ -25,11 +23,7 @@ export { version } from './version';
  * @param token AccessToken, a JWT token that includes authentication and room details
  * @param options
  */
-export async function connect(
-  url: string,
-  token: string,
-  options?: ConnectOptions,
-): Promise<Room> {
+export async function connect(url: string, token: string, options?: ConnectOptions): Promise<Room> {
   options ??= {};
   if (options.adaptiveStream === undefined) {
     options.adaptiveStream = options.autoManageVideo === true ? {} : undefined;
@@ -64,8 +58,10 @@ export async function connect(
           }
 
           // when it's a device issue, try to publish the other kind
-          if (errKind === MediaDeviceFailure.NotFound
-             || errKind === MediaDeviceFailure.DeviceInUse) {
+          if (
+            errKind === MediaDeviceFailure.NotFound ||
+            errKind === MediaDeviceFailure.DeviceInUse
+          ) {
             try {
               await room.localParticipant.setMicrophoneEnabled(true);
             } catch (audioErr) {

--- a/src/proto/google/protobuf/timestamp.ts
+++ b/src/proto/google/protobuf/timestamp.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
 
-export const protobufPackage = "google.protobuf";
+export const protobufPackage = 'google.protobuf';
 
 /**
  * A Timestamp represents a point in time independent of any time zone or local
@@ -118,10 +118,7 @@ function createBaseTimestamp(): Timestamp {
 }
 
 export const Timestamp = {
-  encode(
-    message: Timestamp,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: Timestamp, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
     }
@@ -161,15 +158,12 @@ export const Timestamp = {
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined &&
-      (obj.seconds = Math.round(message.seconds));
+    message.seconds !== undefined && (obj.seconds = Math.round(message.seconds));
     message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(
-    object: I
-  ): Timestamp {
+  fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(object: I): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
     message.nanos = object.nanos ?? 0;
@@ -181,21 +175,14 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== "undefined") return globalThis;
-  if (typeof self !== "undefined") return self;
-  if (typeof window !== "undefined") return window;
-  if (typeof global !== "undefined") return global;
-  throw "Unable to locate global object";
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
 })();
 
-type Builtin =
-  | Date
-  | Function
-  | Uint8Array
-  | string
-  | number
-  | boolean
-  | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
 export type DeepPartial<T> = T extends Builtin
   ? T
@@ -210,14 +197,11 @@ export type DeepPartial<T> = T extends Builtin
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
-        never
-      >;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
   }
   return long.toNumber();
 }

--- a/src/proto/livekit_models.ts
+++ b/src/proto/livekit_models.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import Long from "long";
-import * as _m0 from "protobufjs/minimal";
-import { Timestamp } from "./google/protobuf/timestamp";
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
+import { Timestamp } from './google/protobuf/timestamp';
 
-export const protobufPackage = "livekit";
+export const protobufPackage = 'livekit';
 
 export enum TrackType {
   AUDIO = 0,
@@ -15,16 +15,16 @@ export enum TrackType {
 export function trackTypeFromJSON(object: any): TrackType {
   switch (object) {
     case 0:
-    case "AUDIO":
+    case 'AUDIO':
       return TrackType.AUDIO;
     case 1:
-    case "VIDEO":
+    case 'VIDEO':
       return TrackType.VIDEO;
     case 2:
-    case "DATA":
+    case 'DATA':
       return TrackType.DATA;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return TrackType.UNRECOGNIZED;
   }
@@ -33,13 +33,13 @@ export function trackTypeFromJSON(object: any): TrackType {
 export function trackTypeToJSON(object: TrackType): string {
   switch (object) {
     case TrackType.AUDIO:
-      return "AUDIO";
+      return 'AUDIO';
     case TrackType.VIDEO:
-      return "VIDEO";
+      return 'VIDEO';
     case TrackType.DATA:
-      return "DATA";
+      return 'DATA';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -55,22 +55,22 @@ export enum TrackSource {
 export function trackSourceFromJSON(object: any): TrackSource {
   switch (object) {
     case 0:
-    case "UNKNOWN":
+    case 'UNKNOWN':
       return TrackSource.UNKNOWN;
     case 1:
-    case "CAMERA":
+    case 'CAMERA':
       return TrackSource.CAMERA;
     case 2:
-    case "MICROPHONE":
+    case 'MICROPHONE':
       return TrackSource.MICROPHONE;
     case 3:
-    case "SCREEN_SHARE":
+    case 'SCREEN_SHARE':
       return TrackSource.SCREEN_SHARE;
     case 4:
-    case "SCREEN_SHARE_AUDIO":
+    case 'SCREEN_SHARE_AUDIO':
       return TrackSource.SCREEN_SHARE_AUDIO;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return TrackSource.UNRECOGNIZED;
   }
@@ -79,17 +79,17 @@ export function trackSourceFromJSON(object: any): TrackSource {
 export function trackSourceToJSON(object: TrackSource): string {
   switch (object) {
     case TrackSource.UNKNOWN:
-      return "UNKNOWN";
+      return 'UNKNOWN';
     case TrackSource.CAMERA:
-      return "CAMERA";
+      return 'CAMERA';
     case TrackSource.MICROPHONE:
-      return "MICROPHONE";
+      return 'MICROPHONE';
     case TrackSource.SCREEN_SHARE:
-      return "SCREEN_SHARE";
+      return 'SCREEN_SHARE';
     case TrackSource.SCREEN_SHARE_AUDIO:
-      return "SCREEN_SHARE_AUDIO";
+      return 'SCREEN_SHARE_AUDIO';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -104,19 +104,19 @@ export enum VideoQuality {
 export function videoQualityFromJSON(object: any): VideoQuality {
   switch (object) {
     case 0:
-    case "LOW":
+    case 'LOW':
       return VideoQuality.LOW;
     case 1:
-    case "MEDIUM":
+    case 'MEDIUM':
       return VideoQuality.MEDIUM;
     case 2:
-    case "HIGH":
+    case 'HIGH':
       return VideoQuality.HIGH;
     case 3:
-    case "OFF":
+    case 'OFF':
       return VideoQuality.OFF;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return VideoQuality.UNRECOGNIZED;
   }
@@ -125,15 +125,15 @@ export function videoQualityFromJSON(object: any): VideoQuality {
 export function videoQualityToJSON(object: VideoQuality): string {
   switch (object) {
     case VideoQuality.LOW:
-      return "LOW";
+      return 'LOW';
     case VideoQuality.MEDIUM:
-      return "MEDIUM";
+      return 'MEDIUM';
     case VideoQuality.HIGH:
-      return "HIGH";
+      return 'HIGH';
     case VideoQuality.OFF:
-      return "OFF";
+      return 'OFF';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -147,16 +147,16 @@ export enum ConnectionQuality {
 export function connectionQualityFromJSON(object: any): ConnectionQuality {
   switch (object) {
     case 0:
-    case "POOR":
+    case 'POOR':
       return ConnectionQuality.POOR;
     case 1:
-    case "GOOD":
+    case 'GOOD':
       return ConnectionQuality.GOOD;
     case 2:
-    case "EXCELLENT":
+    case 'EXCELLENT':
       return ConnectionQuality.EXCELLENT;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ConnectionQuality.UNRECOGNIZED;
   }
@@ -165,13 +165,13 @@ export function connectionQualityFromJSON(object: any): ConnectionQuality {
 export function connectionQualityToJSON(object: ConnectionQuality): string {
   switch (object) {
     case ConnectionQuality.POOR:
-      return "POOR";
+      return 'POOR';
     case ConnectionQuality.GOOD:
-      return "GOOD";
+      return 'GOOD';
     case ConnectionQuality.EXCELLENT:
-      return "EXCELLENT";
+      return 'EXCELLENT';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -185,16 +185,16 @@ export enum ClientConfigSetting {
 export function clientConfigSettingFromJSON(object: any): ClientConfigSetting {
   switch (object) {
     case 0:
-    case "UNSET":
+    case 'UNSET':
       return ClientConfigSetting.UNSET;
     case 1:
-    case "DISABLED":
+    case 'DISABLED':
       return ClientConfigSetting.DISABLED;
     case 2:
-    case "ENABLED":
+    case 'ENABLED':
       return ClientConfigSetting.ENABLED;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ClientConfigSetting.UNRECOGNIZED;
   }
@@ -203,13 +203,13 @@ export function clientConfigSettingFromJSON(object: any): ClientConfigSetting {
 export function clientConfigSettingToJSON(object: ClientConfigSetting): string {
   switch (object) {
     case ClientConfigSetting.UNSET:
-      return "UNSET";
+      return 'UNSET';
     case ClientConfigSetting.DISABLED:
-      return "DISABLED";
+      return 'DISABLED';
     case ClientConfigSetting.ENABLED:
-      return "ENABLED";
+      return 'ENABLED';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -269,43 +269,39 @@ export enum ParticipantInfo_State {
   UNRECOGNIZED = -1,
 }
 
-export function participantInfo_StateFromJSON(
-  object: any
-): ParticipantInfo_State {
+export function participantInfo_StateFromJSON(object: any): ParticipantInfo_State {
   switch (object) {
     case 0:
-    case "JOINING":
+    case 'JOINING':
       return ParticipantInfo_State.JOINING;
     case 1:
-    case "JOINED":
+    case 'JOINED':
       return ParticipantInfo_State.JOINED;
     case 2:
-    case "ACTIVE":
+    case 'ACTIVE':
       return ParticipantInfo_State.ACTIVE;
     case 3:
-    case "DISCONNECTED":
+    case 'DISCONNECTED':
       return ParticipantInfo_State.DISCONNECTED;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ParticipantInfo_State.UNRECOGNIZED;
   }
 }
 
-export function participantInfo_StateToJSON(
-  object: ParticipantInfo_State
-): string {
+export function participantInfo_StateToJSON(object: ParticipantInfo_State): string {
   switch (object) {
     case ParticipantInfo_State.JOINING:
-      return "JOINING";
+      return 'JOINING';
     case ParticipantInfo_State.JOINED:
-      return "JOINED";
+      return 'JOINED';
     case ParticipantInfo_State.ACTIVE:
-      return "ACTIVE";
+      return 'ACTIVE';
     case ParticipantInfo_State.DISCONNECTED:
-      return "DISCONNECTED";
+      return 'DISCONNECTED';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -360,13 +356,13 @@ export enum DataPacket_Kind {
 export function dataPacket_KindFromJSON(object: any): DataPacket_Kind {
   switch (object) {
     case 0:
-    case "RELIABLE":
+    case 'RELIABLE':
       return DataPacket_Kind.RELIABLE;
     case 1:
-    case "LOSSY":
+    case 'LOSSY':
       return DataPacket_Kind.LOSSY;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return DataPacket_Kind.UNRECOGNIZED;
   }
@@ -375,11 +371,11 @@ export function dataPacket_KindFromJSON(object: any): DataPacket_Kind {
 export function dataPacket_KindToJSON(object: DataPacket_Kind): string {
   switch (object) {
     case DataPacket_Kind.RELIABLE:
-      return "RELIABLE";
+      return 'RELIABLE';
     case DataPacket_Kind.LOSSY:
-      return "LOSSY";
+      return 'LOSSY';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -437,28 +433,28 @@ export enum ClientInfo_SDK {
 export function clientInfo_SDKFromJSON(object: any): ClientInfo_SDK {
   switch (object) {
     case 0:
-    case "UNKNOWN":
+    case 'UNKNOWN':
       return ClientInfo_SDK.UNKNOWN;
     case 1:
-    case "JS":
+    case 'JS':
       return ClientInfo_SDK.JS;
     case 2:
-    case "SWIFT":
+    case 'SWIFT':
       return ClientInfo_SDK.SWIFT;
     case 3:
-    case "ANDROID":
+    case 'ANDROID':
       return ClientInfo_SDK.ANDROID;
     case 4:
-    case "FLUTTER":
+    case 'FLUTTER':
       return ClientInfo_SDK.FLUTTER;
     case 5:
-    case "GO":
+    case 'GO':
       return ClientInfo_SDK.GO;
     case 6:
-    case "UNITY":
+    case 'UNITY':
       return ClientInfo_SDK.UNITY;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ClientInfo_SDK.UNRECOGNIZED;
   }
@@ -467,21 +463,21 @@ export function clientInfo_SDKFromJSON(object: any): ClientInfo_SDK {
 export function clientInfo_SDKToJSON(object: ClientInfo_SDK): string {
   switch (object) {
     case ClientInfo_SDK.UNKNOWN:
-      return "UNKNOWN";
+      return 'UNKNOWN';
     case ClientInfo_SDK.JS:
-      return "JS";
+      return 'JS';
     case ClientInfo_SDK.SWIFT:
-      return "SWIFT";
+      return 'SWIFT';
     case ClientInfo_SDK.ANDROID:
-      return "ANDROID";
+      return 'ANDROID';
     case ClientInfo_SDK.FLUTTER:
-      return "FLUTTER";
+      return 'FLUTTER';
     case ClientInfo_SDK.GO:
-      return "GO";
+      return 'GO';
     case ClientInfo_SDK.UNITY:
-      return "UNITY";
+      return 'UNITY';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -542,14 +538,14 @@ export interface RTPStats_GapHistogramEntry {
 
 function createBaseRoom(): Room {
   return {
-    sid: "",
-    name: "",
+    sid: '',
+    name: '',
     emptyTimeout: 0,
     maxParticipants: 0,
     creationTime: 0,
-    turnPassword: "",
+    turnPassword: '',
     enabledCodecs: [],
-    metadata: "",
+    metadata: '',
     numParticipants: 0,
     activeRecording: false,
   };
@@ -557,10 +553,10 @@ function createBaseRoom(): Room {
 
 export const Room = {
   encode(message: Room, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.sid !== "") {
+    if (message.sid !== '') {
       writer.uint32(10).string(message.sid);
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(18).string(message.name);
     }
     if (message.emptyTimeout !== 0) {
@@ -572,13 +568,13 @@ export const Room = {
     if (message.creationTime !== 0) {
       writer.uint32(40).int64(message.creationTime);
     }
-    if (message.turnPassword !== "") {
+    if (message.turnPassword !== '') {
       writer.uint32(50).string(message.turnPassword);
     }
     for (const v of message.enabledCodecs) {
       Codec.encode(v!, writer.uint32(58).fork()).ldelim();
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== '') {
       writer.uint32(66).string(message.metadata);
     }
     if (message.numParticipants !== 0) {
@@ -637,30 +633,18 @@ export const Room = {
 
   fromJSON(object: any): Room {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : "",
-      name: isSet(object.name) ? String(object.name) : "",
-      emptyTimeout: isSet(object.emptyTimeout)
-        ? Number(object.emptyTimeout)
-        : 0,
-      maxParticipants: isSet(object.maxParticipants)
-        ? Number(object.maxParticipants)
-        : 0,
-      creationTime: isSet(object.creationTime)
-        ? Number(object.creationTime)
-        : 0,
-      turnPassword: isSet(object.turnPassword)
-        ? String(object.turnPassword)
-        : "",
+      sid: isSet(object.sid) ? String(object.sid) : '',
+      name: isSet(object.name) ? String(object.name) : '',
+      emptyTimeout: isSet(object.emptyTimeout) ? Number(object.emptyTimeout) : 0,
+      maxParticipants: isSet(object.maxParticipants) ? Number(object.maxParticipants) : 0,
+      creationTime: isSet(object.creationTime) ? Number(object.creationTime) : 0,
+      turnPassword: isSet(object.turnPassword) ? String(object.turnPassword) : '',
       enabledCodecs: Array.isArray(object?.enabledCodecs)
         ? object.enabledCodecs.map((e: any) => Codec.fromJSON(e))
         : [],
-      metadata: isSet(object.metadata) ? String(object.metadata) : "",
-      numParticipants: isSet(object.numParticipants)
-        ? Number(object.numParticipants)
-        : 0,
-      activeRecording: isSet(object.activeRecording)
-        ? Boolean(object.activeRecording)
-        : false,
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
+      numParticipants: isSet(object.numParticipants) ? Number(object.numParticipants) : 0,
+      activeRecording: isSet(object.activeRecording) ? Boolean(object.activeRecording) : false,
     };
   },
 
@@ -668,40 +652,33 @@ export const Room = {
     const obj: any = {};
     message.sid !== undefined && (obj.sid = message.sid);
     message.name !== undefined && (obj.name = message.name);
-    message.emptyTimeout !== undefined &&
-      (obj.emptyTimeout = Math.round(message.emptyTimeout));
+    message.emptyTimeout !== undefined && (obj.emptyTimeout = Math.round(message.emptyTimeout));
     message.maxParticipants !== undefined &&
       (obj.maxParticipants = Math.round(message.maxParticipants));
-    message.creationTime !== undefined &&
-      (obj.creationTime = Math.round(message.creationTime));
-    message.turnPassword !== undefined &&
-      (obj.turnPassword = message.turnPassword);
+    message.creationTime !== undefined && (obj.creationTime = Math.round(message.creationTime));
+    message.turnPassword !== undefined && (obj.turnPassword = message.turnPassword);
     if (message.enabledCodecs) {
-      obj.enabledCodecs = message.enabledCodecs.map((e) =>
-        e ? Codec.toJSON(e) : undefined
-      );
+      obj.enabledCodecs = message.enabledCodecs.map((e) => (e ? Codec.toJSON(e) : undefined));
     } else {
       obj.enabledCodecs = [];
     }
     message.metadata !== undefined && (obj.metadata = message.metadata);
     message.numParticipants !== undefined &&
       (obj.numParticipants = Math.round(message.numParticipants));
-    message.activeRecording !== undefined &&
-      (obj.activeRecording = message.activeRecording);
+    message.activeRecording !== undefined && (obj.activeRecording = message.activeRecording);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<Room>, I>>(object: I): Room {
     const message = createBaseRoom();
-    message.sid = object.sid ?? "";
-    message.name = object.name ?? "";
+    message.sid = object.sid ?? '';
+    message.name = object.name ?? '';
     message.emptyTimeout = object.emptyTimeout ?? 0;
     message.maxParticipants = object.maxParticipants ?? 0;
     message.creationTime = object.creationTime ?? 0;
-    message.turnPassword = object.turnPassword ?? "";
-    message.enabledCodecs =
-      object.enabledCodecs?.map((e) => Codec.fromPartial(e)) || [];
-    message.metadata = object.metadata ?? "";
+    message.turnPassword = object.turnPassword ?? '';
+    message.enabledCodecs = object.enabledCodecs?.map((e) => Codec.fromPartial(e)) || [];
+    message.metadata = object.metadata ?? '';
     message.numParticipants = object.numParticipants ?? 0;
     message.activeRecording = object.activeRecording ?? false;
     return message;
@@ -709,15 +686,15 @@ export const Room = {
 };
 
 function createBaseCodec(): Codec {
-  return { mime: "", fmtpLine: "" };
+  return { mime: '', fmtpLine: '' };
 }
 
 export const Codec = {
   encode(message: Codec, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.mime !== "") {
+    if (message.mime !== '') {
       writer.uint32(10).string(message.mime);
     }
-    if (message.fmtpLine !== "") {
+    if (message.fmtpLine !== '') {
       writer.uint32(18).string(message.fmtpLine);
     }
     return writer;
@@ -746,8 +723,8 @@ export const Codec = {
 
   fromJSON(object: any): Codec {
     return {
-      mime: isSet(object.mime) ? String(object.mime) : "",
-      fmtpLine: isSet(object.fmtpLine) ? String(object.fmtpLine) : "",
+      mime: isSet(object.mime) ? String(object.mime) : '',
+      fmtpLine: isSet(object.fmtpLine) ? String(object.fmtpLine) : '',
     };
   },
 
@@ -760,8 +737,8 @@ export const Codec = {
 
   fromPartial<I extends Exact<DeepPartial<Codec>, I>>(object: I): Codec {
     const message = createBaseCodec();
-    message.mime = object.mime ?? "";
-    message.fmtpLine = object.fmtpLine ?? "";
+    message.mime = object.mime ?? '';
+    message.fmtpLine = object.fmtpLine ?? '';
     return message;
   },
 };
@@ -777,10 +754,7 @@ function createBaseParticipantPermission(): ParticipantPermission {
 }
 
 export const ParticipantPermission = {
-  encode(
-    message: ParticipantPermission,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: ParticipantPermission, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.canSubscribe === true) {
       writer.uint32(8).bool(message.canSubscribe);
     }
@@ -799,10 +773,7 @@ export const ParticipantPermission = {
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): ParticipantPermission {
+  decode(input: _m0.Reader | Uint8Array, length?: number): ParticipantPermission {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseParticipantPermission();
@@ -834,13 +805,9 @@ export const ParticipantPermission = {
 
   fromJSON(object: any): ParticipantPermission {
     return {
-      canSubscribe: isSet(object.canSubscribe)
-        ? Boolean(object.canSubscribe)
-        : false,
+      canSubscribe: isSet(object.canSubscribe) ? Boolean(object.canSubscribe) : false,
       canPublish: isSet(object.canPublish) ? Boolean(object.canPublish) : false,
-      canPublishData: isSet(object.canPublishData)
-        ? Boolean(object.canPublishData)
-        : false,
+      canPublishData: isSet(object.canPublishData) ? Boolean(object.canPublishData) : false,
       hidden: isSet(object.hidden) ? Boolean(object.hidden) : false,
       recorder: isSet(object.recorder) ? Boolean(object.recorder) : false,
     };
@@ -848,18 +815,16 @@ export const ParticipantPermission = {
 
   toJSON(message: ParticipantPermission): unknown {
     const obj: any = {};
-    message.canSubscribe !== undefined &&
-      (obj.canSubscribe = message.canSubscribe);
+    message.canSubscribe !== undefined && (obj.canSubscribe = message.canSubscribe);
     message.canPublish !== undefined && (obj.canPublish = message.canPublish);
-    message.canPublishData !== undefined &&
-      (obj.canPublishData = message.canPublishData);
+    message.canPublishData !== undefined && (obj.canPublishData = message.canPublishData);
     message.hidden !== undefined && (obj.hidden = message.hidden);
     message.recorder !== undefined && (obj.recorder = message.recorder);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<ParticipantPermission>, I>>(
-    object: I
+    object: I,
   ): ParticipantPermission {
     const message = createBaseParticipantPermission();
     message.canSubscribe = object.canSubscribe ?? false;
@@ -873,27 +838,24 @@ export const ParticipantPermission = {
 
 function createBaseParticipantInfo(): ParticipantInfo {
   return {
-    sid: "",
-    identity: "",
+    sid: '',
+    identity: '',
     state: 0,
     tracks: [],
-    metadata: "",
+    metadata: '',
     joinedAt: 0,
-    name: "",
+    name: '',
     version: 0,
     permission: undefined,
   };
 }
 
 export const ParticipantInfo = {
-  encode(
-    message: ParticipantInfo,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.sid !== "") {
+  encode(message: ParticipantInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.sid !== '') {
       writer.uint32(10).string(message.sid);
     }
-    if (message.identity !== "") {
+    if (message.identity !== '') {
       writer.uint32(18).string(message.identity);
     }
     if (message.state !== 0) {
@@ -902,23 +864,20 @@ export const ParticipantInfo = {
     for (const v of message.tracks) {
       TrackInfo.encode(v!, writer.uint32(34).fork()).ldelim();
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== '') {
       writer.uint32(42).string(message.metadata);
     }
     if (message.joinedAt !== 0) {
       writer.uint32(48).int64(message.joinedAt);
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(74).string(message.name);
     }
     if (message.version !== 0) {
       writer.uint32(80).uint32(message.version);
     }
     if (message.permission !== undefined) {
-      ParticipantPermission.encode(
-        message.permission,
-        writer.uint32(90).fork()
-      ).ldelim();
+      ParticipantPermission.encode(message.permission, writer.uint32(90).fork()).ldelim();
     }
     return writer;
   },
@@ -955,10 +914,7 @@ export const ParticipantInfo = {
           message.version = reader.uint32();
           break;
         case 11:
-          message.permission = ParticipantPermission.decode(
-            reader,
-            reader.uint32()
-          );
+          message.permission = ParticipantPermission.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -970,17 +926,15 @@ export const ParticipantInfo = {
 
   fromJSON(object: any): ParticipantInfo {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : "",
-      identity: isSet(object.identity) ? String(object.identity) : "",
-      state: isSet(object.state)
-        ? participantInfo_StateFromJSON(object.state)
-        : 0,
+      sid: isSet(object.sid) ? String(object.sid) : '',
+      identity: isSet(object.identity) ? String(object.identity) : '',
+      state: isSet(object.state) ? participantInfo_StateFromJSON(object.state) : 0,
       tracks: Array.isArray(object?.tracks)
         ? object.tracks.map((e: any) => TrackInfo.fromJSON(e))
         : [],
-      metadata: isSet(object.metadata) ? String(object.metadata) : "",
+      metadata: isSet(object.metadata) ? String(object.metadata) : '',
       joinedAt: isSet(object.joinedAt) ? Number(object.joinedAt) : 0,
-      name: isSet(object.name) ? String(object.name) : "",
+      name: isSet(object.name) ? String(object.name) : '',
       version: isSet(object.version) ? Number(object.version) : 0,
       permission: isSet(object.permission)
         ? ParticipantPermission.fromJSON(object.permission)
@@ -992,21 +946,16 @@ export const ParticipantInfo = {
     const obj: any = {};
     message.sid !== undefined && (obj.sid = message.sid);
     message.identity !== undefined && (obj.identity = message.identity);
-    message.state !== undefined &&
-      (obj.state = participantInfo_StateToJSON(message.state));
+    message.state !== undefined && (obj.state = participantInfo_StateToJSON(message.state));
     if (message.tracks) {
-      obj.tracks = message.tracks.map((e) =>
-        e ? TrackInfo.toJSON(e) : undefined
-      );
+      obj.tracks = message.tracks.map((e) => (e ? TrackInfo.toJSON(e) : undefined));
     } else {
       obj.tracks = [];
     }
     message.metadata !== undefined && (obj.metadata = message.metadata);
-    message.joinedAt !== undefined &&
-      (obj.joinedAt = Math.round(message.joinedAt));
+    message.joinedAt !== undefined && (obj.joinedAt = Math.round(message.joinedAt));
     message.name !== undefined && (obj.name = message.name);
-    message.version !== undefined &&
-      (obj.version = Math.round(message.version));
+    message.version !== undefined && (obj.version = Math.round(message.version));
     message.permission !== undefined &&
       (obj.permission = message.permission
         ? ParticipantPermission.toJSON(message.permission)
@@ -1014,17 +963,15 @@ export const ParticipantInfo = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ParticipantInfo>, I>>(
-    object: I
-  ): ParticipantInfo {
+  fromPartial<I extends Exact<DeepPartial<ParticipantInfo>, I>>(object: I): ParticipantInfo {
     const message = createBaseParticipantInfo();
-    message.sid = object.sid ?? "";
-    message.identity = object.identity ?? "";
+    message.sid = object.sid ?? '';
+    message.identity = object.identity ?? '';
     message.state = object.state ?? 0;
     message.tracks = object.tracks?.map((e) => TrackInfo.fromPartial(e)) || [];
-    message.metadata = object.metadata ?? "";
+    message.metadata = object.metadata ?? '';
     message.joinedAt = object.joinedAt ?? 0;
-    message.name = object.name ?? "";
+    message.name = object.name ?? '';
     message.version = object.version ?? 0;
     message.permission =
       object.permission !== undefined && object.permission !== null
@@ -1036,9 +983,9 @@ export const ParticipantInfo = {
 
 function createBaseTrackInfo(): TrackInfo {
   return {
-    sid: "",
+    sid: '',
     type: 0,
-    name: "",
+    name: '',
     muted: false,
     width: 0,
     height: 0,
@@ -1046,23 +993,20 @@ function createBaseTrackInfo(): TrackInfo {
     disableDtx: false,
     source: 0,
     layers: [],
-    mimeType: "",
-    mid: "",
+    mimeType: '',
+    mid: '',
   };
 }
 
 export const TrackInfo = {
-  encode(
-    message: TrackInfo,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.sid !== "") {
+  encode(message: TrackInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.sid !== '') {
       writer.uint32(10).string(message.sid);
     }
     if (message.type !== 0) {
       writer.uint32(16).int32(message.type);
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(26).string(message.name);
     }
     if (message.muted === true) {
@@ -1086,10 +1030,10 @@ export const TrackInfo = {
     for (const v of message.layers) {
       VideoLayer.encode(v!, writer.uint32(82).fork()).ldelim();
     }
-    if (message.mimeType !== "") {
+    if (message.mimeType !== '') {
       writer.uint32(90).string(message.mimeType);
     }
-    if (message.mid !== "") {
+    if (message.mid !== '') {
       writer.uint32(98).string(message.mid);
     }
     return writer;
@@ -1148,9 +1092,9 @@ export const TrackInfo = {
 
   fromJSON(object: any): TrackInfo {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : "",
+      sid: isSet(object.sid) ? String(object.sid) : '',
       type: isSet(object.type) ? trackTypeFromJSON(object.type) : 0,
-      name: isSet(object.name) ? String(object.name) : "",
+      name: isSet(object.name) ? String(object.name) : '',
       muted: isSet(object.muted) ? Boolean(object.muted) : false,
       width: isSet(object.width) ? Number(object.width) : 0,
       height: isSet(object.height) ? Number(object.height) : 0,
@@ -1160,8 +1104,8 @@ export const TrackInfo = {
       layers: Array.isArray(object?.layers)
         ? object.layers.map((e: any) => VideoLayer.fromJSON(e))
         : [],
-      mimeType: isSet(object.mimeType) ? String(object.mimeType) : "",
-      mid: isSet(object.mid) ? String(object.mid) : "",
+      mimeType: isSet(object.mimeType) ? String(object.mimeType) : '',
+      mid: isSet(object.mid) ? String(object.mid) : '',
     };
   },
 
@@ -1175,12 +1119,9 @@ export const TrackInfo = {
     message.height !== undefined && (obj.height = Math.round(message.height));
     message.simulcast !== undefined && (obj.simulcast = message.simulcast);
     message.disableDtx !== undefined && (obj.disableDtx = message.disableDtx);
-    message.source !== undefined &&
-      (obj.source = trackSourceToJSON(message.source));
+    message.source !== undefined && (obj.source = trackSourceToJSON(message.source));
     if (message.layers) {
-      obj.layers = message.layers.map((e) =>
-        e ? VideoLayer.toJSON(e) : undefined
-      );
+      obj.layers = message.layers.map((e) => (e ? VideoLayer.toJSON(e) : undefined));
     } else {
       obj.layers = [];
     }
@@ -1189,13 +1130,11 @@ export const TrackInfo = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<TrackInfo>, I>>(
-    object: I
-  ): TrackInfo {
+  fromPartial<I extends Exact<DeepPartial<TrackInfo>, I>>(object: I): TrackInfo {
     const message = createBaseTrackInfo();
-    message.sid = object.sid ?? "";
+    message.sid = object.sid ?? '';
     message.type = object.type ?? 0;
-    message.name = object.name ?? "";
+    message.name = object.name ?? '';
     message.muted = object.muted ?? false;
     message.width = object.width ?? 0;
     message.height = object.height ?? 0;
@@ -1203,8 +1142,8 @@ export const TrackInfo = {
     message.disableDtx = object.disableDtx ?? false;
     message.source = object.source ?? 0;
     message.layers = object.layers?.map((e) => VideoLayer.fromPartial(e)) || [];
-    message.mimeType = object.mimeType ?? "";
-    message.mid = object.mid ?? "";
+    message.mimeType = object.mimeType ?? '';
+    message.mid = object.mid ?? '';
     return message;
   },
 };
@@ -1214,10 +1153,7 @@ function createBaseVideoLayer(): VideoLayer {
 }
 
 export const VideoLayer = {
-  encode(
-    message: VideoLayer,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: VideoLayer, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.quality !== 0) {
       writer.uint32(8).int32(message.quality);
     }
@@ -1278,19 +1214,15 @@ export const VideoLayer = {
 
   toJSON(message: VideoLayer): unknown {
     const obj: any = {};
-    message.quality !== undefined &&
-      (obj.quality = videoQualityToJSON(message.quality));
+    message.quality !== undefined && (obj.quality = videoQualityToJSON(message.quality));
     message.width !== undefined && (obj.width = Math.round(message.width));
     message.height !== undefined && (obj.height = Math.round(message.height));
-    message.bitrate !== undefined &&
-      (obj.bitrate = Math.round(message.bitrate));
+    message.bitrate !== undefined && (obj.bitrate = Math.round(message.bitrate));
     message.ssrc !== undefined && (obj.ssrc = Math.round(message.ssrc));
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<VideoLayer>, I>>(
-    object: I
-  ): VideoLayer {
+  fromPartial<I extends Exact<DeepPartial<VideoLayer>, I>>(object: I): VideoLayer {
     const message = createBaseVideoLayer();
     message.quality = object.quality ?? 0;
     message.width = object.width ?? 0;
@@ -1306,10 +1238,7 @@ function createBaseDataPacket(): DataPacket {
 }
 
 export const DataPacket = {
-  encode(
-    message: DataPacket,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: DataPacket, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.kind !== 0) {
       writer.uint32(8).int32(message.kind);
     }
@@ -1317,10 +1246,7 @@ export const DataPacket = {
       UserPacket.encode(message.user, writer.uint32(18).fork()).ldelim();
     }
     if (message.speaker !== undefined) {
-      ActiveSpeakerUpdate.encode(
-        message.speaker,
-        writer.uint32(26).fork()
-      ).ldelim();
+      ActiveSpeakerUpdate.encode(message.speaker, writer.uint32(26).fork()).ldelim();
     }
     return writer;
   },
@@ -1353,28 +1279,21 @@ export const DataPacket = {
     return {
       kind: isSet(object.kind) ? dataPacket_KindFromJSON(object.kind) : 0,
       user: isSet(object.user) ? UserPacket.fromJSON(object.user) : undefined,
-      speaker: isSet(object.speaker)
-        ? ActiveSpeakerUpdate.fromJSON(object.speaker)
-        : undefined,
+      speaker: isSet(object.speaker) ? ActiveSpeakerUpdate.fromJSON(object.speaker) : undefined,
     };
   },
 
   toJSON(message: DataPacket): unknown {
     const obj: any = {};
-    message.kind !== undefined &&
-      (obj.kind = dataPacket_KindToJSON(message.kind));
+    message.kind !== undefined && (obj.kind = dataPacket_KindToJSON(message.kind));
     message.user !== undefined &&
       (obj.user = message.user ? UserPacket.toJSON(message.user) : undefined);
     message.speaker !== undefined &&
-      (obj.speaker = message.speaker
-        ? ActiveSpeakerUpdate.toJSON(message.speaker)
-        : undefined);
+      (obj.speaker = message.speaker ? ActiveSpeakerUpdate.toJSON(message.speaker) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<DataPacket>, I>>(
-    object: I
-  ): DataPacket {
+  fromPartial<I extends Exact<DeepPartial<DataPacket>, I>>(object: I): DataPacket {
     const message = createBaseDataPacket();
     message.kind = object.kind ?? 0;
     message.user =
@@ -1394,10 +1313,7 @@ function createBaseActiveSpeakerUpdate(): ActiveSpeakerUpdate {
 }
 
 export const ActiveSpeakerUpdate = {
-  encode(
-    message: ActiveSpeakerUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: ActiveSpeakerUpdate, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.speakers) {
       SpeakerInfo.encode(v!, writer.uint32(10).fork()).ldelim();
     }
@@ -1433,9 +1349,7 @@ export const ActiveSpeakerUpdate = {
   toJSON(message: ActiveSpeakerUpdate): unknown {
     const obj: any = {};
     if (message.speakers) {
-      obj.speakers = message.speakers.map((e) =>
-        e ? SpeakerInfo.toJSON(e) : undefined
-      );
+      obj.speakers = message.speakers.map((e) => (e ? SpeakerInfo.toJSON(e) : undefined));
     } else {
       obj.speakers = [];
     }
@@ -1443,25 +1357,21 @@ export const ActiveSpeakerUpdate = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ActiveSpeakerUpdate>, I>>(
-    object: I
+    object: I,
   ): ActiveSpeakerUpdate {
     const message = createBaseActiveSpeakerUpdate();
-    message.speakers =
-      object.speakers?.map((e) => SpeakerInfo.fromPartial(e)) || [];
+    message.speakers = object.speakers?.map((e) => SpeakerInfo.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseSpeakerInfo(): SpeakerInfo {
-  return { sid: "", level: 0, active: false };
+  return { sid: '', level: 0, active: false };
 }
 
 export const SpeakerInfo = {
-  encode(
-    message: SpeakerInfo,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.sid !== "") {
+  encode(message: SpeakerInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.sid !== '') {
       writer.uint32(10).string(message.sid);
     }
     if (message.level !== 0) {
@@ -1499,7 +1409,7 @@ export const SpeakerInfo = {
 
   fromJSON(object: any): SpeakerInfo {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : "",
+      sid: isSet(object.sid) ? String(object.sid) : '',
       level: isSet(object.level) ? Number(object.level) : 0,
       active: isSet(object.active) ? Boolean(object.active) : false,
     };
@@ -1513,11 +1423,9 @@ export const SpeakerInfo = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SpeakerInfo>, I>>(
-    object: I
-  ): SpeakerInfo {
+  fromPartial<I extends Exact<DeepPartial<SpeakerInfo>, I>>(object: I): SpeakerInfo {
     const message = createBaseSpeakerInfo();
-    message.sid = object.sid ?? "";
+    message.sid = object.sid ?? '';
     message.level = object.level ?? 0;
     message.active = object.active ?? false;
     return message;
@@ -1525,15 +1433,12 @@ export const SpeakerInfo = {
 };
 
 function createBaseUserPacket(): UserPacket {
-  return { participantSid: "", payload: new Uint8Array(), destinationSids: [] };
+  return { participantSid: '', payload: new Uint8Array(), destinationSids: [] };
 }
 
 export const UserPacket = {
-  encode(
-    message: UserPacket,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.participantSid !== "") {
+  encode(message: UserPacket, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.participantSid !== '') {
       writer.uint32(10).string(message.participantSid);
     }
     if (message.payload.length !== 0) {
@@ -1571,12 +1476,8 @@ export const UserPacket = {
 
   fromJSON(object: any): UserPacket {
     return {
-      participantSid: isSet(object.participantSid)
-        ? String(object.participantSid)
-        : "",
-      payload: isSet(object.payload)
-        ? bytesFromBase64(object.payload)
-        : new Uint8Array(),
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
+      payload: isSet(object.payload) ? bytesFromBase64(object.payload) : new Uint8Array(),
       destinationSids: Array.isArray(object?.destinationSids)
         ? object.destinationSids.map((e: any) => String(e))
         : [],
@@ -1585,11 +1486,10 @@ export const UserPacket = {
 
   toJSON(message: UserPacket): unknown {
     const obj: any = {};
-    message.participantSid !== undefined &&
-      (obj.participantSid = message.participantSid);
+    message.participantSid !== undefined && (obj.participantSid = message.participantSid);
     message.payload !== undefined &&
       (obj.payload = base64FromBytes(
-        message.payload !== undefined ? message.payload : new Uint8Array()
+        message.payload !== undefined ? message.payload : new Uint8Array(),
       ));
     if (message.destinationSids) {
       obj.destinationSids = message.destinationSids.map((e) => e);
@@ -1599,11 +1499,9 @@ export const UserPacket = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UserPacket>, I>>(
-    object: I
-  ): UserPacket {
+  fromPartial<I extends Exact<DeepPartial<UserPacket>, I>>(object: I): UserPacket {
     const message = createBaseUserPacket();
-    message.participantSid = object.participantSid ?? "";
+    message.participantSid = object.participantSid ?? '';
     message.payload = object.payload ?? new Uint8Array();
     message.destinationSids = object.destinationSids?.map((e) => e) || [];
     return message;
@@ -1611,15 +1509,12 @@ export const UserPacket = {
 };
 
 function createBaseParticipantTracks(): ParticipantTracks {
-  return { participantSid: "", trackSids: [] };
+  return { participantSid: '', trackSids: [] };
 }
 
 export const ParticipantTracks = {
-  encode(
-    message: ParticipantTracks,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.participantSid !== "") {
+  encode(message: ParticipantTracks, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.participantSid !== '') {
       writer.uint32(10).string(message.participantSid);
     }
     for (const v of message.trackSids) {
@@ -1651,9 +1546,7 @@ export const ParticipantTracks = {
 
   fromJSON(object: any): ParticipantTracks {
     return {
-      participantSid: isSet(object.participantSid)
-        ? String(object.participantSid)
-        : "",
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
       trackSids: Array.isArray(object?.trackSids)
         ? object.trackSids.map((e: any) => String(e))
         : [],
@@ -1662,8 +1555,7 @@ export const ParticipantTracks = {
 
   toJSON(message: ParticipantTracks): unknown {
     const obj: any = {};
-    message.participantSid !== undefined &&
-      (obj.participantSid = message.participantSid);
+    message.participantSid !== undefined && (obj.participantSid = message.participantSid);
     if (message.trackSids) {
       obj.trackSids = message.trackSids.map((e) => e);
     } else {
@@ -1672,11 +1564,9 @@ export const ParticipantTracks = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ParticipantTracks>, I>>(
-    object: I
-  ): ParticipantTracks {
+  fromPartial<I extends Exact<DeepPartial<ParticipantTracks>, I>>(object: I): ParticipantTracks {
     const message = createBaseParticipantTracks();
-    message.participantSid = object.participantSid ?? "";
+    message.participantSid = object.participantSid ?? '';
     message.trackSids = object.trackSids?.map((e) => e) || [];
     return message;
   },
@@ -1685,47 +1575,44 @@ export const ParticipantTracks = {
 function createBaseClientInfo(): ClientInfo {
   return {
     sdk: 0,
-    version: "",
+    version: '',
     protocol: 0,
-    os: "",
-    osVersion: "",
-    deviceModel: "",
-    browser: "",
-    browserVersion: "",
-    address: "",
+    os: '',
+    osVersion: '',
+    deviceModel: '',
+    browser: '',
+    browserVersion: '',
+    address: '',
   };
 }
 
 export const ClientInfo = {
-  encode(
-    message: ClientInfo,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: ClientInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.sdk !== 0) {
       writer.uint32(8).int32(message.sdk);
     }
-    if (message.version !== "") {
+    if (message.version !== '') {
       writer.uint32(18).string(message.version);
     }
     if (message.protocol !== 0) {
       writer.uint32(24).int32(message.protocol);
     }
-    if (message.os !== "") {
+    if (message.os !== '') {
       writer.uint32(34).string(message.os);
     }
-    if (message.osVersion !== "") {
+    if (message.osVersion !== '') {
       writer.uint32(42).string(message.osVersion);
     }
-    if (message.deviceModel !== "") {
+    if (message.deviceModel !== '') {
       writer.uint32(50).string(message.deviceModel);
     }
-    if (message.browser !== "") {
+    if (message.browser !== '') {
       writer.uint32(58).string(message.browser);
     }
-    if (message.browserVersion !== "") {
+    if (message.browserVersion !== '') {
       writer.uint32(66).string(message.browserVersion);
     }
-    if (message.address !== "") {
+    if (message.address !== '') {
       writer.uint32(74).string(message.address);
     }
     return writer;
@@ -1776,16 +1663,14 @@ export const ClientInfo = {
   fromJSON(object: any): ClientInfo {
     return {
       sdk: isSet(object.sdk) ? clientInfo_SDKFromJSON(object.sdk) : 0,
-      version: isSet(object.version) ? String(object.version) : "",
+      version: isSet(object.version) ? String(object.version) : '',
       protocol: isSet(object.protocol) ? Number(object.protocol) : 0,
-      os: isSet(object.os) ? String(object.os) : "",
-      osVersion: isSet(object.osVersion) ? String(object.osVersion) : "",
-      deviceModel: isSet(object.deviceModel) ? String(object.deviceModel) : "",
-      browser: isSet(object.browser) ? String(object.browser) : "",
-      browserVersion: isSet(object.browserVersion)
-        ? String(object.browserVersion)
-        : "",
-      address: isSet(object.address) ? String(object.address) : "",
+      os: isSet(object.os) ? String(object.os) : '',
+      osVersion: isSet(object.osVersion) ? String(object.osVersion) : '',
+      deviceModel: isSet(object.deviceModel) ? String(object.deviceModel) : '',
+      browser: isSet(object.browser) ? String(object.browser) : '',
+      browserVersion: isSet(object.browserVersion) ? String(object.browserVersion) : '',
+      address: isSet(object.address) ? String(object.address) : '',
     };
   },
 
@@ -1793,32 +1678,27 @@ export const ClientInfo = {
     const obj: any = {};
     message.sdk !== undefined && (obj.sdk = clientInfo_SDKToJSON(message.sdk));
     message.version !== undefined && (obj.version = message.version);
-    message.protocol !== undefined &&
-      (obj.protocol = Math.round(message.protocol));
+    message.protocol !== undefined && (obj.protocol = Math.round(message.protocol));
     message.os !== undefined && (obj.os = message.os);
     message.osVersion !== undefined && (obj.osVersion = message.osVersion);
-    message.deviceModel !== undefined &&
-      (obj.deviceModel = message.deviceModel);
+    message.deviceModel !== undefined && (obj.deviceModel = message.deviceModel);
     message.browser !== undefined && (obj.browser = message.browser);
-    message.browserVersion !== undefined &&
-      (obj.browserVersion = message.browserVersion);
+    message.browserVersion !== undefined && (obj.browserVersion = message.browserVersion);
     message.address !== undefined && (obj.address = message.address);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ClientInfo>, I>>(
-    object: I
-  ): ClientInfo {
+  fromPartial<I extends Exact<DeepPartial<ClientInfo>, I>>(object: I): ClientInfo {
     const message = createBaseClientInfo();
     message.sdk = object.sdk ?? 0;
-    message.version = object.version ?? "";
+    message.version = object.version ?? '';
     message.protocol = object.protocol ?? 0;
-    message.os = object.os ?? "";
-    message.osVersion = object.osVersion ?? "";
-    message.deviceModel = object.deviceModel ?? "";
-    message.browser = object.browser ?? "";
-    message.browserVersion = object.browserVersion ?? "";
-    message.address = object.address ?? "";
+    message.os = object.os ?? '';
+    message.osVersion = object.osVersion ?? '';
+    message.deviceModel = object.deviceModel ?? '';
+    message.browser = object.browser ?? '';
+    message.browserVersion = object.browserVersion ?? '';
+    message.address = object.address ?? '';
     return message;
   },
 };
@@ -1828,21 +1708,12 @@ function createBaseClientConfiguration(): ClientConfiguration {
 }
 
 export const ClientConfiguration = {
-  encode(
-    message: ClientConfiguration,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: ClientConfiguration, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.video !== undefined) {
-      VideoConfiguration.encode(
-        message.video,
-        writer.uint32(10).fork()
-      ).ldelim();
+      VideoConfiguration.encode(message.video, writer.uint32(10).fork()).ldelim();
     }
     if (message.screen !== undefined) {
-      VideoConfiguration.encode(
-        message.screen,
-        writer.uint32(18).fork()
-      ).ldelim();
+      VideoConfiguration.encode(message.screen, writer.uint32(18).fork()).ldelim();
     }
     if (message.resumeConnection !== 0) {
       writer.uint32(24).int32(message.resumeConnection);
@@ -1876,12 +1747,8 @@ export const ClientConfiguration = {
 
   fromJSON(object: any): ClientConfiguration {
     return {
-      video: isSet(object.video)
-        ? VideoConfiguration.fromJSON(object.video)
-        : undefined,
-      screen: isSet(object.screen)
-        ? VideoConfiguration.fromJSON(object.screen)
-        : undefined,
+      video: isSet(object.video) ? VideoConfiguration.fromJSON(object.video) : undefined,
+      screen: isSet(object.screen) ? VideoConfiguration.fromJSON(object.screen) : undefined,
       resumeConnection: isSet(object.resumeConnection)
         ? clientConfigSettingFromJSON(object.resumeConnection)
         : 0,
@@ -1891,22 +1758,16 @@ export const ClientConfiguration = {
   toJSON(message: ClientConfiguration): unknown {
     const obj: any = {};
     message.video !== undefined &&
-      (obj.video = message.video
-        ? VideoConfiguration.toJSON(message.video)
-        : undefined);
+      (obj.video = message.video ? VideoConfiguration.toJSON(message.video) : undefined);
     message.screen !== undefined &&
-      (obj.screen = message.screen
-        ? VideoConfiguration.toJSON(message.screen)
-        : undefined);
+      (obj.screen = message.screen ? VideoConfiguration.toJSON(message.screen) : undefined);
     message.resumeConnection !== undefined &&
-      (obj.resumeConnection = clientConfigSettingToJSON(
-        message.resumeConnection
-      ));
+      (obj.resumeConnection = clientConfigSettingToJSON(message.resumeConnection));
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<ClientConfiguration>, I>>(
-    object: I
+    object: I,
   ): ClientConfiguration {
     const message = createBaseClientConfiguration();
     message.video =
@@ -1927,10 +1788,7 @@ function createBaseVideoConfiguration(): VideoConfiguration {
 }
 
 export const VideoConfiguration = {
-  encode(
-    message: VideoConfiguration,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: VideoConfiguration, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.hardwareEncoder !== 0) {
       writer.uint32(8).int32(message.hardwareEncoder);
     }
@@ -1966,15 +1824,11 @@ export const VideoConfiguration = {
   toJSON(message: VideoConfiguration): unknown {
     const obj: any = {};
     message.hardwareEncoder !== undefined &&
-      (obj.hardwareEncoder = clientConfigSettingToJSON(
-        message.hardwareEncoder
-      ));
+      (obj.hardwareEncoder = clientConfigSettingToJSON(message.hardwareEncoder));
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<VideoConfiguration>, I>>(
-    object: I
-  ): VideoConfiguration {
+  fromPartial<I extends Exact<DeepPartial<VideoConfiguration>, I>>(object: I): VideoConfiguration {
     const message = createBaseVideoConfiguration();
     message.hardwareEncoder = object.hardwareEncoder ?? 0;
     return message;
@@ -2023,21 +1877,12 @@ function createBaseRTPStats(): RTPStats {
 }
 
 export const RTPStats = {
-  encode(
-    message: RTPStats,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: RTPStats, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.startTime !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.startTime),
-        writer.uint32(10).fork()
-      ).ldelim();
+      Timestamp.encode(toTimestamp(message.startTime), writer.uint32(10).fork()).ldelim();
     }
     if (message.endTime !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.endTime),
-        writer.uint32(18).fork()
-      ).ldelim();
+      Timestamp.encode(toTimestamp(message.endTime), writer.uint32(18).fork()).ldelim();
     }
     if (message.duration !== 0) {
       writer.uint32(25).double(message.duration);
@@ -2105,7 +1950,7 @@ export const RTPStats = {
     Object.entries(message.gapHistogram).forEach(([key, value]) => {
       RTPStats_GapHistogramEntry.encode(
         { key: key as any, value },
-        writer.uint32(194).fork()
+        writer.uint32(194).fork(),
       ).ldelim();
     });
     if (message.nacks !== 0) {
@@ -2118,19 +1963,13 @@ export const RTPStats = {
       writer.uint32(216).uint32(message.plis);
     }
     if (message.lastPli !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.lastPli),
-        writer.uint32(226).fork()
-      ).ldelim();
+      Timestamp.encode(toTimestamp(message.lastPli), writer.uint32(226).fork()).ldelim();
     }
     if (message.firs !== 0) {
       writer.uint32(232).uint32(message.firs);
     }
     if (message.lastFir !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.lastFir),
-        writer.uint32(242).fork()
-      ).ldelim();
+      Timestamp.encode(toTimestamp(message.lastFir), writer.uint32(242).fork()).ldelim();
     }
     if (message.rttCurrent !== 0) {
       writer.uint32(248).uint32(message.rttCurrent);
@@ -2142,19 +1981,13 @@ export const RTPStats = {
       writer.uint32(264).uint32(message.keyFrames);
     }
     if (message.lastKeyFrame !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.lastKeyFrame),
-        writer.uint32(274).fork()
-      ).ldelim();
+      Timestamp.encode(toTimestamp(message.lastKeyFrame), writer.uint32(274).fork()).ldelim();
     }
     if (message.layerLockPlis !== 0) {
       writer.uint32(280).uint32(message.layerLockPlis);
     }
     if (message.lastLayerLockPli !== undefined) {
-      Timestamp.encode(
-        toTimestamp(message.lastLayerLockPli),
-        writer.uint32(290).fork()
-      ).ldelim();
+      Timestamp.encode(toTimestamp(message.lastLayerLockPli), writer.uint32(290).fork()).ldelim();
     }
     return writer;
   },
@@ -2167,14 +2000,10 @@ export const RTPStats = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.startTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
-          );
+          message.startTime = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
           break;
         case 2:
-          message.endTime = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
-          );
+          message.endTime = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
           break;
         case 3:
           message.duration = reader.double();
@@ -2240,10 +2069,7 @@ export const RTPStats = {
           message.jitterMax = reader.double();
           break;
         case 24:
-          const entry24 = RTPStats_GapHistogramEntry.decode(
-            reader,
-            reader.uint32()
-          );
+          const entry24 = RTPStats_GapHistogramEntry.decode(reader, reader.uint32());
           if (entry24.value !== undefined) {
             message.gapHistogram[entry24.key] = entry24.value;
           }
@@ -2258,17 +2084,13 @@ export const RTPStats = {
           message.plis = reader.uint32();
           break;
         case 28:
-          message.lastPli = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
-          );
+          message.lastPli = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
           break;
         case 29:
           message.firs = reader.uint32();
           break;
         case 30:
-          message.lastFir = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
-          );
+          message.lastFir = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
           break;
         case 31:
           message.rttCurrent = reader.uint32();
@@ -2280,17 +2102,13 @@ export const RTPStats = {
           message.keyFrames = reader.uint32();
           break;
         case 34:
-          message.lastKeyFrame = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
-          );
+          message.lastKeyFrame = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
           break;
         case 35:
           message.layerLockPlis = reader.uint32();
           break;
         case 36:
-          message.lastLayerLockPli = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
-          );
+          message.lastLayerLockPli = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -2302,56 +2120,32 @@ export const RTPStats = {
 
   fromJSON(object: any): RTPStats {
     return {
-      startTime: isSet(object.startTime)
-        ? fromJsonTimestamp(object.startTime)
-        : undefined,
-      endTime: isSet(object.endTime)
-        ? fromJsonTimestamp(object.endTime)
-        : undefined,
+      startTime: isSet(object.startTime) ? fromJsonTimestamp(object.startTime) : undefined,
+      endTime: isSet(object.endTime) ? fromJsonTimestamp(object.endTime) : undefined,
       duration: isSet(object.duration) ? Number(object.duration) : 0,
       packets: isSet(object.packets) ? Number(object.packets) : 0,
       packetRate: isSet(object.packetRate) ? Number(object.packetRate) : 0,
       bytes: isSet(object.bytes) ? Number(object.bytes) : 0,
       bitrate: isSet(object.bitrate) ? Number(object.bitrate) : 0,
       packetsLost: isSet(object.packetsLost) ? Number(object.packetsLost) : 0,
-      packetLossRate: isSet(object.packetLossRate)
-        ? Number(object.packetLossRate)
-        : 0,
+      packetLossRate: isSet(object.packetLossRate) ? Number(object.packetLossRate) : 0,
       packetLossPercentage: isSet(object.packetLossPercentage)
         ? Number(object.packetLossPercentage)
         : 0,
-      packetsDuplicate: isSet(object.packetsDuplicate)
-        ? Number(object.packetsDuplicate)
-        : 0,
+      packetsDuplicate: isSet(object.packetsDuplicate) ? Number(object.packetsDuplicate) : 0,
       packetDuplicateRate: isSet(object.packetDuplicateRate)
         ? Number(object.packetDuplicateRate)
         : 0,
-      bytesDuplicate: isSet(object.bytesDuplicate)
-        ? Number(object.bytesDuplicate)
-        : 0,
-      bitrateDuplicate: isSet(object.bitrateDuplicate)
-        ? Number(object.bitrateDuplicate)
-        : 0,
-      packetsPadding: isSet(object.packetsPadding)
-        ? Number(object.packetsPadding)
-        : 0,
-      packetPaddingRate: isSet(object.packetPaddingRate)
-        ? Number(object.packetPaddingRate)
-        : 0,
-      bytesPadding: isSet(object.bytesPadding)
-        ? Number(object.bytesPadding)
-        : 0,
-      bitratePadding: isSet(object.bitratePadding)
-        ? Number(object.bitratePadding)
-        : 0,
-      packetsOutOfOrder: isSet(object.packetsOutOfOrder)
-        ? Number(object.packetsOutOfOrder)
-        : 0,
+      bytesDuplicate: isSet(object.bytesDuplicate) ? Number(object.bytesDuplicate) : 0,
+      bitrateDuplicate: isSet(object.bitrateDuplicate) ? Number(object.bitrateDuplicate) : 0,
+      packetsPadding: isSet(object.packetsPadding) ? Number(object.packetsPadding) : 0,
+      packetPaddingRate: isSet(object.packetPaddingRate) ? Number(object.packetPaddingRate) : 0,
+      bytesPadding: isSet(object.bytesPadding) ? Number(object.bytesPadding) : 0,
+      bitratePadding: isSet(object.bitratePadding) ? Number(object.bitratePadding) : 0,
+      packetsOutOfOrder: isSet(object.packetsOutOfOrder) ? Number(object.packetsOutOfOrder) : 0,
       frames: isSet(object.frames) ? Number(object.frames) : 0,
       frameRate: isSet(object.frameRate) ? Number(object.frameRate) : 0,
-      jitterCurrent: isSet(object.jitterCurrent)
-        ? Number(object.jitterCurrent)
-        : 0,
+      jitterCurrent: isSet(object.jitterCurrent) ? Number(object.jitterCurrent) : 0,
       jitterMax: isSet(object.jitterMax) ? Number(object.jitterMax) : 0,
       gapHistogram: isObject(object.gapHistogram)
         ? Object.entries(object.gapHistogram).reduce<{ [key: number]: number }>(
@@ -2359,28 +2153,20 @@ export const RTPStats = {
               acc[Number(key)] = Number(value);
               return acc;
             },
-            {}
+            {},
           )
         : {},
       nacks: isSet(object.nacks) ? Number(object.nacks) : 0,
       nackMisses: isSet(object.nackMisses) ? Number(object.nackMisses) : 0,
       plis: isSet(object.plis) ? Number(object.plis) : 0,
-      lastPli: isSet(object.lastPli)
-        ? fromJsonTimestamp(object.lastPli)
-        : undefined,
+      lastPli: isSet(object.lastPli) ? fromJsonTimestamp(object.lastPli) : undefined,
       firs: isSet(object.firs) ? Number(object.firs) : 0,
-      lastFir: isSet(object.lastFir)
-        ? fromJsonTimestamp(object.lastFir)
-        : undefined,
+      lastFir: isSet(object.lastFir) ? fromJsonTimestamp(object.lastFir) : undefined,
       rttCurrent: isSet(object.rttCurrent) ? Number(object.rttCurrent) : 0,
       rttMax: isSet(object.rttMax) ? Number(object.rttMax) : 0,
       keyFrames: isSet(object.keyFrames) ? Number(object.keyFrames) : 0,
-      lastKeyFrame: isSet(object.lastKeyFrame)
-        ? fromJsonTimestamp(object.lastKeyFrame)
-        : undefined,
-      layerLockPlis: isSet(object.layerLockPlis)
-        ? Number(object.layerLockPlis)
-        : 0,
+      lastKeyFrame: isSet(object.lastKeyFrame) ? fromJsonTimestamp(object.lastKeyFrame) : undefined,
+      layerLockPlis: isSet(object.layerLockPlis) ? Number(object.layerLockPlis) : 0,
       lastLayerLockPli: isSet(object.lastLayerLockPli)
         ? fromJsonTimestamp(object.lastLayerLockPli)
         : undefined,
@@ -2389,20 +2175,15 @@ export const RTPStats = {
 
   toJSON(message: RTPStats): unknown {
     const obj: any = {};
-    message.startTime !== undefined &&
-      (obj.startTime = message.startTime.toISOString());
-    message.endTime !== undefined &&
-      (obj.endTime = message.endTime.toISOString());
+    message.startTime !== undefined && (obj.startTime = message.startTime.toISOString());
+    message.endTime !== undefined && (obj.endTime = message.endTime.toISOString());
     message.duration !== undefined && (obj.duration = message.duration);
-    message.packets !== undefined &&
-      (obj.packets = Math.round(message.packets));
+    message.packets !== undefined && (obj.packets = Math.round(message.packets));
     message.packetRate !== undefined && (obj.packetRate = message.packetRate);
     message.bytes !== undefined && (obj.bytes = Math.round(message.bytes));
     message.bitrate !== undefined && (obj.bitrate = message.bitrate);
-    message.packetsLost !== undefined &&
-      (obj.packetsLost = Math.round(message.packetsLost));
-    message.packetLossRate !== undefined &&
-      (obj.packetLossRate = message.packetLossRate);
+    message.packetsLost !== undefined && (obj.packetsLost = Math.round(message.packetsLost));
+    message.packetLossRate !== undefined && (obj.packetLossRate = message.packetLossRate);
     message.packetLossPercentage !== undefined &&
       (obj.packetLossPercentage = message.packetLossPercentage);
     message.packetsDuplicate !== undefined &&
@@ -2411,22 +2192,17 @@ export const RTPStats = {
       (obj.packetDuplicateRate = message.packetDuplicateRate);
     message.bytesDuplicate !== undefined &&
       (obj.bytesDuplicate = Math.round(message.bytesDuplicate));
-    message.bitrateDuplicate !== undefined &&
-      (obj.bitrateDuplicate = message.bitrateDuplicate);
+    message.bitrateDuplicate !== undefined && (obj.bitrateDuplicate = message.bitrateDuplicate);
     message.packetsPadding !== undefined &&
       (obj.packetsPadding = Math.round(message.packetsPadding));
-    message.packetPaddingRate !== undefined &&
-      (obj.packetPaddingRate = message.packetPaddingRate);
-    message.bytesPadding !== undefined &&
-      (obj.bytesPadding = Math.round(message.bytesPadding));
-    message.bitratePadding !== undefined &&
-      (obj.bitratePadding = message.bitratePadding);
+    message.packetPaddingRate !== undefined && (obj.packetPaddingRate = message.packetPaddingRate);
+    message.bytesPadding !== undefined && (obj.bytesPadding = Math.round(message.bytesPadding));
+    message.bitratePadding !== undefined && (obj.bitratePadding = message.bitratePadding);
     message.packetsOutOfOrder !== undefined &&
       (obj.packetsOutOfOrder = Math.round(message.packetsOutOfOrder));
     message.frames !== undefined && (obj.frames = Math.round(message.frames));
     message.frameRate !== undefined && (obj.frameRate = message.frameRate);
-    message.jitterCurrent !== undefined &&
-      (obj.jitterCurrent = message.jitterCurrent);
+    message.jitterCurrent !== undefined && (obj.jitterCurrent = message.jitterCurrent);
     message.jitterMax !== undefined && (obj.jitterMax = message.jitterMax);
     obj.gapHistogram = {};
     if (message.gapHistogram) {
@@ -2435,23 +2211,16 @@ export const RTPStats = {
       });
     }
     message.nacks !== undefined && (obj.nacks = Math.round(message.nacks));
-    message.nackMisses !== undefined &&
-      (obj.nackMisses = Math.round(message.nackMisses));
+    message.nackMisses !== undefined && (obj.nackMisses = Math.round(message.nackMisses));
     message.plis !== undefined && (obj.plis = Math.round(message.plis));
-    message.lastPli !== undefined &&
-      (obj.lastPli = message.lastPli.toISOString());
+    message.lastPli !== undefined && (obj.lastPli = message.lastPli.toISOString());
     message.firs !== undefined && (obj.firs = Math.round(message.firs));
-    message.lastFir !== undefined &&
-      (obj.lastFir = message.lastFir.toISOString());
-    message.rttCurrent !== undefined &&
-      (obj.rttCurrent = Math.round(message.rttCurrent));
+    message.lastFir !== undefined && (obj.lastFir = message.lastFir.toISOString());
+    message.rttCurrent !== undefined && (obj.rttCurrent = Math.round(message.rttCurrent));
     message.rttMax !== undefined && (obj.rttMax = Math.round(message.rttMax));
-    message.keyFrames !== undefined &&
-      (obj.keyFrames = Math.round(message.keyFrames));
-    message.lastKeyFrame !== undefined &&
-      (obj.lastKeyFrame = message.lastKeyFrame.toISOString());
-    message.layerLockPlis !== undefined &&
-      (obj.layerLockPlis = Math.round(message.layerLockPlis));
+    message.keyFrames !== undefined && (obj.keyFrames = Math.round(message.keyFrames));
+    message.lastKeyFrame !== undefined && (obj.lastKeyFrame = message.lastKeyFrame.toISOString());
+    message.layerLockPlis !== undefined && (obj.layerLockPlis = Math.round(message.layerLockPlis));
     message.lastLayerLockPli !== undefined &&
       (obj.lastLayerLockPli = message.lastLayerLockPli.toISOString());
     return obj;
@@ -2513,7 +2282,7 @@ function createBaseRTPStats_GapHistogramEntry(): RTPStats_GapHistogramEntry {
 export const RTPStats_GapHistogramEntry = {
   encode(
     message: RTPStats_GapHistogramEntry,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.key !== 0) {
       writer.uint32(8).int32(message.key);
@@ -2524,10 +2293,7 @@ export const RTPStats_GapHistogramEntry = {
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): RTPStats_GapHistogramEntry {
+  decode(input: _m0.Reader | Uint8Array, length?: number): RTPStats_GapHistogramEntry {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseRTPStats_GapHistogramEntry();
@@ -2563,7 +2329,7 @@ export const RTPStats_GapHistogramEntry = {
   },
 
   fromPartial<I extends Exact<DeepPartial<RTPStats_GapHistogramEntry>, I>>(
-    object: I
+    object: I,
   ): RTPStats_GapHistogramEntry {
     const message = createBaseRTPStats_GapHistogramEntry();
     message.key = object.key ?? 0;
@@ -2576,16 +2342,15 @@ declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;
 var globalThis: any = (() => {
-  if (typeof globalThis !== "undefined") return globalThis;
-  if (typeof self !== "undefined") return self;
-  if (typeof window !== "undefined") return window;
-  if (typeof global !== "undefined") return global;
-  throw "Unable to locate global object";
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
 })();
 
 const atob: (b64: string) => string =
-  globalThis.atob ||
-  ((b64) => globalThis.Buffer.from(b64, "base64").toString("binary"));
+  globalThis.atob || ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
 function bytesFromBase64(b64: string): Uint8Array {
   const bin = atob(b64);
   const arr = new Uint8Array(bin.length);
@@ -2596,24 +2361,16 @@ function bytesFromBase64(b64: string): Uint8Array {
 }
 
 const btoa: (bin: string) => string =
-  globalThis.btoa ||
-  ((bin) => globalThis.Buffer.from(bin, "binary").toString("base64"));
+  globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
 function base64FromBytes(arr: Uint8Array): string {
   const bin: string[] = [];
   for (const byte of arr) {
     bin.push(String.fromCharCode(byte));
   }
-  return btoa(bin.join(""));
+  return btoa(bin.join(''));
 }
 
-type Builtin =
-  | Date
-  | Function
-  | Uint8Array
-  | string
-  | number
-  | boolean
-  | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
 export type DeepPartial<T> = T extends Builtin
   ? T
@@ -2628,10 +2385,7 @@ export type DeepPartial<T> = T extends Builtin
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
-        never
-      >;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
 
 function toTimestamp(date: Date): Timestamp {
   const seconds = date.getTime() / 1_000;
@@ -2648,7 +2402,7 @@ function fromTimestamp(t: Timestamp): Date {
 function fromJsonTimestamp(o: any): Date {
   if (o instanceof Date) {
     return o;
-  } else if (typeof o === "string") {
+  } else if (typeof o === 'string') {
     return new Date(o);
   } else {
     return fromTimestamp(Timestamp.fromJSON(o));
@@ -2657,7 +2411,7 @@ function fromJsonTimestamp(o: any): Date {
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
+    throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
   }
   return long.toNumber();
 }
@@ -2668,7 +2422,7 @@ if (_m0.util.Long !== Long) {
 }
 
 function isObject(value: any): boolean {
-  return typeof value === "object" && value !== null;
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/src/proto/livekit_rtc.ts
+++ b/src/proto/livekit_rtc.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from 'long';
+import * as _m0 from 'protobufjs/minimal';
 import {
   TrackType,
   TrackSource,
@@ -21,9 +21,9 @@ import {
   videoQualityToJSON,
   connectionQualityFromJSON,
   connectionQualityToJSON,
-} from "./livekit_models";
+} from './livekit_models';
 
-export const protobufPackage = "livekit";
+export const protobufPackage = 'livekit';
 
 export enum SignalTarget {
   PUBLISHER = 0,
@@ -34,13 +34,13 @@ export enum SignalTarget {
 export function signalTargetFromJSON(object: any): SignalTarget {
   switch (object) {
     case 0:
-    case "PUBLISHER":
+    case 'PUBLISHER':
       return SignalTarget.PUBLISHER;
     case 1:
-    case "SUBSCRIBER":
+    case 'SUBSCRIBER':
       return SignalTarget.SUBSCRIBER;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return SignalTarget.UNRECOGNIZED;
   }
@@ -49,11 +49,11 @@ export function signalTargetFromJSON(object: any): SignalTarget {
 export function signalTargetToJSON(object: SignalTarget): string {
   switch (object) {
     case SignalTarget.PUBLISHER:
-      return "PUBLISHER";
+      return 'PUBLISHER';
     case SignalTarget.SUBSCRIBER:
-      return "SUBSCRIBER";
+      return 'SUBSCRIBER';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -66,13 +66,13 @@ export enum StreamState {
 export function streamStateFromJSON(object: any): StreamState {
   switch (object) {
     case 0:
-    case "ACTIVE":
+    case 'ACTIVE':
       return StreamState.ACTIVE;
     case 1:
-    case "PAUSED":
+    case 'PAUSED':
       return StreamState.PAUSED;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return StreamState.UNRECOGNIZED;
   }
@@ -81,11 +81,11 @@ export function streamStateFromJSON(object: any): StreamState {
 export function streamStateToJSON(object: StreamState): string {
   switch (object) {
     case StreamState.ACTIVE:
-      return "ACTIVE";
+      return 'ACTIVE';
     case StreamState.PAUSED:
-      return "PAUSED";
+      return 'PAUSED';
     default:
-      return "UNKNOWN";
+      return 'UNKNOWN';
   }
 }
 
@@ -352,69 +352,45 @@ function createBaseSignalRequest(): SignalRequest {
 }
 
 export const SignalRequest = {
-  encode(
-    message: SignalRequest,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: SignalRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.offer !== undefined) {
-      SessionDescription.encode(
-        message.offer,
-        writer.uint32(10).fork()
-      ).ldelim();
+      SessionDescription.encode(message.offer, writer.uint32(10).fork()).ldelim();
     }
     if (message.answer !== undefined) {
-      SessionDescription.encode(
-        message.answer,
-        writer.uint32(18).fork()
-      ).ldelim();
+      SessionDescription.encode(message.answer, writer.uint32(18).fork()).ldelim();
     }
     if (message.trickle !== undefined) {
       TrickleRequest.encode(message.trickle, writer.uint32(26).fork()).ldelim();
     }
     if (message.addTrack !== undefined) {
-      AddTrackRequest.encode(
-        message.addTrack,
-        writer.uint32(34).fork()
-      ).ldelim();
+      AddTrackRequest.encode(message.addTrack, writer.uint32(34).fork()).ldelim();
     }
     if (message.mute !== undefined) {
       MuteTrackRequest.encode(message.mute, writer.uint32(42).fork()).ldelim();
     }
     if (message.subscription !== undefined) {
-      UpdateSubscription.encode(
-        message.subscription,
-        writer.uint32(50).fork()
-      ).ldelim();
+      UpdateSubscription.encode(message.subscription, writer.uint32(50).fork()).ldelim();
     }
     if (message.trackSetting !== undefined) {
-      UpdateTrackSettings.encode(
-        message.trackSetting,
-        writer.uint32(58).fork()
-      ).ldelim();
+      UpdateTrackSettings.encode(message.trackSetting, writer.uint32(58).fork()).ldelim();
     }
     if (message.leave !== undefined) {
       LeaveRequest.encode(message.leave, writer.uint32(66).fork()).ldelim();
     }
     if (message.updateLayers !== undefined) {
-      UpdateVideoLayers.encode(
-        message.updateLayers,
-        writer.uint32(82).fork()
-      ).ldelim();
+      UpdateVideoLayers.encode(message.updateLayers, writer.uint32(82).fork()).ldelim();
     }
     if (message.subscriptionPermission !== undefined) {
       SubscriptionPermission.encode(
         message.subscriptionPermission,
-        writer.uint32(90).fork()
+        writer.uint32(90).fork(),
       ).ldelim();
     }
     if (message.syncState !== undefined) {
       SyncState.encode(message.syncState, writer.uint32(98).fork()).ldelim();
     }
     if (message.simulate !== undefined) {
-      SimulateScenario.encode(
-        message.simulate,
-        writer.uint32(106).fork()
-      ).ldelim();
+      SimulateScenario.encode(message.simulate, writer.uint32(106).fork()).ldelim();
     }
     return writer;
   },
@@ -442,31 +418,19 @@ export const SignalRequest = {
           message.mute = MuteTrackRequest.decode(reader, reader.uint32());
           break;
         case 6:
-          message.subscription = UpdateSubscription.decode(
-            reader,
-            reader.uint32()
-          );
+          message.subscription = UpdateSubscription.decode(reader, reader.uint32());
           break;
         case 7:
-          message.trackSetting = UpdateTrackSettings.decode(
-            reader,
-            reader.uint32()
-          );
+          message.trackSetting = UpdateTrackSettings.decode(reader, reader.uint32());
           break;
         case 8:
           message.leave = LeaveRequest.decode(reader, reader.uint32());
           break;
         case 10:
-          message.updateLayers = UpdateVideoLayers.decode(
-            reader,
-            reader.uint32()
-          );
+          message.updateLayers = UpdateVideoLayers.decode(reader, reader.uint32());
           break;
         case 11:
-          message.subscriptionPermission = SubscriptionPermission.decode(
-            reader,
-            reader.uint32()
-          );
+          message.subscriptionPermission = SubscriptionPermission.decode(reader, reader.uint32());
           break;
         case 12:
           message.syncState = SyncState.decode(reader, reader.uint32());
@@ -484,67 +448,41 @@ export const SignalRequest = {
 
   fromJSON(object: any): SignalRequest {
     return {
-      offer: isSet(object.offer)
-        ? SessionDescription.fromJSON(object.offer)
-        : undefined,
-      answer: isSet(object.answer)
-        ? SessionDescription.fromJSON(object.answer)
-        : undefined,
-      trickle: isSet(object.trickle)
-        ? TrickleRequest.fromJSON(object.trickle)
-        : undefined,
-      addTrack: isSet(object.addTrack)
-        ? AddTrackRequest.fromJSON(object.addTrack)
-        : undefined,
-      mute: isSet(object.mute)
-        ? MuteTrackRequest.fromJSON(object.mute)
-        : undefined,
+      offer: isSet(object.offer) ? SessionDescription.fromJSON(object.offer) : undefined,
+      answer: isSet(object.answer) ? SessionDescription.fromJSON(object.answer) : undefined,
+      trickle: isSet(object.trickle) ? TrickleRequest.fromJSON(object.trickle) : undefined,
+      addTrack: isSet(object.addTrack) ? AddTrackRequest.fromJSON(object.addTrack) : undefined,
+      mute: isSet(object.mute) ? MuteTrackRequest.fromJSON(object.mute) : undefined,
       subscription: isSet(object.subscription)
         ? UpdateSubscription.fromJSON(object.subscription)
         : undefined,
       trackSetting: isSet(object.trackSetting)
         ? UpdateTrackSettings.fromJSON(object.trackSetting)
         : undefined,
-      leave: isSet(object.leave)
-        ? LeaveRequest.fromJSON(object.leave)
-        : undefined,
+      leave: isSet(object.leave) ? LeaveRequest.fromJSON(object.leave) : undefined,
       updateLayers: isSet(object.updateLayers)
         ? UpdateVideoLayers.fromJSON(object.updateLayers)
         : undefined,
       subscriptionPermission: isSet(object.subscriptionPermission)
         ? SubscriptionPermission.fromJSON(object.subscriptionPermission)
         : undefined,
-      syncState: isSet(object.syncState)
-        ? SyncState.fromJSON(object.syncState)
-        : undefined,
-      simulate: isSet(object.simulate)
-        ? SimulateScenario.fromJSON(object.simulate)
-        : undefined,
+      syncState: isSet(object.syncState) ? SyncState.fromJSON(object.syncState) : undefined,
+      simulate: isSet(object.simulate) ? SimulateScenario.fromJSON(object.simulate) : undefined,
     };
   },
 
   toJSON(message: SignalRequest): unknown {
     const obj: any = {};
     message.offer !== undefined &&
-      (obj.offer = message.offer
-        ? SessionDescription.toJSON(message.offer)
-        : undefined);
+      (obj.offer = message.offer ? SessionDescription.toJSON(message.offer) : undefined);
     message.answer !== undefined &&
-      (obj.answer = message.answer
-        ? SessionDescription.toJSON(message.answer)
-        : undefined);
+      (obj.answer = message.answer ? SessionDescription.toJSON(message.answer) : undefined);
     message.trickle !== undefined &&
-      (obj.trickle = message.trickle
-        ? TrickleRequest.toJSON(message.trickle)
-        : undefined);
+      (obj.trickle = message.trickle ? TrickleRequest.toJSON(message.trickle) : undefined);
     message.addTrack !== undefined &&
-      (obj.addTrack = message.addTrack
-        ? AddTrackRequest.toJSON(message.addTrack)
-        : undefined);
+      (obj.addTrack = message.addTrack ? AddTrackRequest.toJSON(message.addTrack) : undefined);
     message.mute !== undefined &&
-      (obj.mute = message.mute
-        ? MuteTrackRequest.toJSON(message.mute)
-        : undefined);
+      (obj.mute = message.mute ? MuteTrackRequest.toJSON(message.mute) : undefined);
     message.subscription !== undefined &&
       (obj.subscription = message.subscription
         ? UpdateSubscription.toJSON(message.subscription)
@@ -554,9 +492,7 @@ export const SignalRequest = {
         ? UpdateTrackSettings.toJSON(message.trackSetting)
         : undefined);
     message.leave !== undefined &&
-      (obj.leave = message.leave
-        ? LeaveRequest.toJSON(message.leave)
-        : undefined);
+      (obj.leave = message.leave ? LeaveRequest.toJSON(message.leave) : undefined);
     message.updateLayers !== undefined &&
       (obj.updateLayers = message.updateLayers
         ? UpdateVideoLayers.toJSON(message.updateLayers)
@@ -566,19 +502,13 @@ export const SignalRequest = {
         ? SubscriptionPermission.toJSON(message.subscriptionPermission)
         : undefined);
     message.syncState !== undefined &&
-      (obj.syncState = message.syncState
-        ? SyncState.toJSON(message.syncState)
-        : undefined);
+      (obj.syncState = message.syncState ? SyncState.toJSON(message.syncState) : undefined);
     message.simulate !== undefined &&
-      (obj.simulate = message.simulate
-        ? SimulateScenario.toJSON(message.simulate)
-        : undefined);
+      (obj.simulate = message.simulate ? SimulateScenario.toJSON(message.simulate) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SignalRequest>, I>>(
-    object: I
-  ): SignalRequest {
+  fromPartial<I extends Exact<DeepPartial<SignalRequest>, I>>(object: I): SignalRequest {
     const message = createBaseSignalRequest();
     message.offer =
       object.offer !== undefined && object.offer !== null
@@ -617,8 +547,7 @@ export const SignalRequest = {
         ? UpdateVideoLayers.fromPartial(object.updateLayers)
         : undefined;
     message.subscriptionPermission =
-      object.subscriptionPermission !== undefined &&
-      object.subscriptionPermission !== null
+      object.subscriptionPermission !== undefined && object.subscriptionPermission !== null
         ? SubscriptionPermission.fromPartial(object.subscriptionPermission)
         : undefined;
     message.syncState =
@@ -655,39 +584,24 @@ function createBaseSignalResponse(): SignalResponse {
 }
 
 export const SignalResponse = {
-  encode(
-    message: SignalResponse,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: SignalResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.join !== undefined) {
       JoinResponse.encode(message.join, writer.uint32(10).fork()).ldelim();
     }
     if (message.answer !== undefined) {
-      SessionDescription.encode(
-        message.answer,
-        writer.uint32(18).fork()
-      ).ldelim();
+      SessionDescription.encode(message.answer, writer.uint32(18).fork()).ldelim();
     }
     if (message.offer !== undefined) {
-      SessionDescription.encode(
-        message.offer,
-        writer.uint32(26).fork()
-      ).ldelim();
+      SessionDescription.encode(message.offer, writer.uint32(26).fork()).ldelim();
     }
     if (message.trickle !== undefined) {
       TrickleRequest.encode(message.trickle, writer.uint32(34).fork()).ldelim();
     }
     if (message.update !== undefined) {
-      ParticipantUpdate.encode(
-        message.update,
-        writer.uint32(42).fork()
-      ).ldelim();
+      ParticipantUpdate.encode(message.update, writer.uint32(42).fork()).ldelim();
     }
     if (message.trackPublished !== undefined) {
-      TrackPublishedResponse.encode(
-        message.trackPublished,
-        writer.uint32(50).fork()
-      ).ldelim();
+      TrackPublishedResponse.encode(message.trackPublished, writer.uint32(50).fork()).ldelim();
     }
     if (message.leave !== undefined) {
       LeaveRequest.encode(message.leave, writer.uint32(66).fork()).ldelim();
@@ -696,46 +610,34 @@ export const SignalResponse = {
       MuteTrackRequest.encode(message.mute, writer.uint32(74).fork()).ldelim();
     }
     if (message.speakersChanged !== undefined) {
-      SpeakersChanged.encode(
-        message.speakersChanged,
-        writer.uint32(82).fork()
-      ).ldelim();
+      SpeakersChanged.encode(message.speakersChanged, writer.uint32(82).fork()).ldelim();
     }
     if (message.roomUpdate !== undefined) {
       RoomUpdate.encode(message.roomUpdate, writer.uint32(90).fork()).ldelim();
     }
     if (message.connectionQuality !== undefined) {
-      ConnectionQualityUpdate.encode(
-        message.connectionQuality,
-        writer.uint32(98).fork()
-      ).ldelim();
+      ConnectionQualityUpdate.encode(message.connectionQuality, writer.uint32(98).fork()).ldelim();
     }
     if (message.streamStateUpdate !== undefined) {
-      StreamStateUpdate.encode(
-        message.streamStateUpdate,
-        writer.uint32(106).fork()
-      ).ldelim();
+      StreamStateUpdate.encode(message.streamStateUpdate, writer.uint32(106).fork()).ldelim();
     }
     if (message.subscribedQualityUpdate !== undefined) {
       SubscribedQualityUpdate.encode(
         message.subscribedQualityUpdate,
-        writer.uint32(114).fork()
+        writer.uint32(114).fork(),
       ).ldelim();
     }
     if (message.subscriptionPermissionUpdate !== undefined) {
       SubscriptionPermissionUpdate.encode(
         message.subscriptionPermissionUpdate,
-        writer.uint32(122).fork()
+        writer.uint32(122).fork(),
       ).ldelim();
     }
     if (message.refreshToken !== undefined) {
       writer.uint32(130).string(message.refreshToken);
     }
     if (message.trackUnpublished !== undefined) {
-      TrackUnpublishedResponse.encode(
-        message.trackUnpublished,
-        writer.uint32(138).fork()
-      ).ldelim();
+      TrackUnpublishedResponse.encode(message.trackUnpublished, writer.uint32(138).fork()).ldelim();
     }
     return writer;
   },
@@ -763,10 +665,7 @@ export const SignalResponse = {
           message.update = ParticipantUpdate.decode(reader, reader.uint32());
           break;
         case 6:
-          message.trackPublished = TrackPublishedResponse.decode(
-            reader,
-            reader.uint32()
-          );
+          message.trackPublished = TrackPublishedResponse.decode(reader, reader.uint32());
           break;
         case 8:
           message.leave = LeaveRequest.decode(reader, reader.uint32());
@@ -775,44 +674,31 @@ export const SignalResponse = {
           message.mute = MuteTrackRequest.decode(reader, reader.uint32());
           break;
         case 10:
-          message.speakersChanged = SpeakersChanged.decode(
-            reader,
-            reader.uint32()
-          );
+          message.speakersChanged = SpeakersChanged.decode(reader, reader.uint32());
           break;
         case 11:
           message.roomUpdate = RoomUpdate.decode(reader, reader.uint32());
           break;
         case 12:
-          message.connectionQuality = ConnectionQualityUpdate.decode(
-            reader,
-            reader.uint32()
-          );
+          message.connectionQuality = ConnectionQualityUpdate.decode(reader, reader.uint32());
           break;
         case 13:
-          message.streamStateUpdate = StreamStateUpdate.decode(
-            reader,
-            reader.uint32()
-          );
+          message.streamStateUpdate = StreamStateUpdate.decode(reader, reader.uint32());
           break;
         case 14:
-          message.subscribedQualityUpdate = SubscribedQualityUpdate.decode(
-            reader,
-            reader.uint32()
-          );
+          message.subscribedQualityUpdate = SubscribedQualityUpdate.decode(reader, reader.uint32());
           break;
         case 15:
-          message.subscriptionPermissionUpdate =
-            SubscriptionPermissionUpdate.decode(reader, reader.uint32());
+          message.subscriptionPermissionUpdate = SubscriptionPermissionUpdate.decode(
+            reader,
+            reader.uint32(),
+          );
           break;
         case 16:
           message.refreshToken = reader.string();
           break;
         case 17:
-          message.trackUnpublished = TrackUnpublishedResponse.decode(
-            reader,
-            reader.uint32()
-          );
+          message.trackUnpublished = TrackUnpublishedResponse.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -825,33 +711,19 @@ export const SignalResponse = {
   fromJSON(object: any): SignalResponse {
     return {
       join: isSet(object.join) ? JoinResponse.fromJSON(object.join) : undefined,
-      answer: isSet(object.answer)
-        ? SessionDescription.fromJSON(object.answer)
-        : undefined,
-      offer: isSet(object.offer)
-        ? SessionDescription.fromJSON(object.offer)
-        : undefined,
-      trickle: isSet(object.trickle)
-        ? TrickleRequest.fromJSON(object.trickle)
-        : undefined,
-      update: isSet(object.update)
-        ? ParticipantUpdate.fromJSON(object.update)
-        : undefined,
+      answer: isSet(object.answer) ? SessionDescription.fromJSON(object.answer) : undefined,
+      offer: isSet(object.offer) ? SessionDescription.fromJSON(object.offer) : undefined,
+      trickle: isSet(object.trickle) ? TrickleRequest.fromJSON(object.trickle) : undefined,
+      update: isSet(object.update) ? ParticipantUpdate.fromJSON(object.update) : undefined,
       trackPublished: isSet(object.trackPublished)
         ? TrackPublishedResponse.fromJSON(object.trackPublished)
         : undefined,
-      leave: isSet(object.leave)
-        ? LeaveRequest.fromJSON(object.leave)
-        : undefined,
-      mute: isSet(object.mute)
-        ? MuteTrackRequest.fromJSON(object.mute)
-        : undefined,
+      leave: isSet(object.leave) ? LeaveRequest.fromJSON(object.leave) : undefined,
+      mute: isSet(object.mute) ? MuteTrackRequest.fromJSON(object.mute) : undefined,
       speakersChanged: isSet(object.speakersChanged)
         ? SpeakersChanged.fromJSON(object.speakersChanged)
         : undefined,
-      roomUpdate: isSet(object.roomUpdate)
-        ? RoomUpdate.fromJSON(object.roomUpdate)
-        : undefined,
+      roomUpdate: isSet(object.roomUpdate) ? RoomUpdate.fromJSON(object.roomUpdate) : undefined,
       connectionQuality: isSet(object.connectionQuality)
         ? ConnectionQualityUpdate.fromJSON(object.connectionQuality)
         : undefined,
@@ -862,13 +734,9 @@ export const SignalResponse = {
         ? SubscribedQualityUpdate.fromJSON(object.subscribedQualityUpdate)
         : undefined,
       subscriptionPermissionUpdate: isSet(object.subscriptionPermissionUpdate)
-        ? SubscriptionPermissionUpdate.fromJSON(
-            object.subscriptionPermissionUpdate
-          )
+        ? SubscriptionPermissionUpdate.fromJSON(object.subscriptionPermissionUpdate)
         : undefined,
-      refreshToken: isSet(object.refreshToken)
-        ? String(object.refreshToken)
-        : undefined,
+      refreshToken: isSet(object.refreshToken) ? String(object.refreshToken) : undefined,
       trackUnpublished: isSet(object.trackUnpublished)
         ? TrackUnpublishedResponse.fromJSON(object.trackUnpublished)
         : undefined,
@@ -880,41 +748,27 @@ export const SignalResponse = {
     message.join !== undefined &&
       (obj.join = message.join ? JoinResponse.toJSON(message.join) : undefined);
     message.answer !== undefined &&
-      (obj.answer = message.answer
-        ? SessionDescription.toJSON(message.answer)
-        : undefined);
+      (obj.answer = message.answer ? SessionDescription.toJSON(message.answer) : undefined);
     message.offer !== undefined &&
-      (obj.offer = message.offer
-        ? SessionDescription.toJSON(message.offer)
-        : undefined);
+      (obj.offer = message.offer ? SessionDescription.toJSON(message.offer) : undefined);
     message.trickle !== undefined &&
-      (obj.trickle = message.trickle
-        ? TrickleRequest.toJSON(message.trickle)
-        : undefined);
+      (obj.trickle = message.trickle ? TrickleRequest.toJSON(message.trickle) : undefined);
     message.update !== undefined &&
-      (obj.update = message.update
-        ? ParticipantUpdate.toJSON(message.update)
-        : undefined);
+      (obj.update = message.update ? ParticipantUpdate.toJSON(message.update) : undefined);
     message.trackPublished !== undefined &&
       (obj.trackPublished = message.trackPublished
         ? TrackPublishedResponse.toJSON(message.trackPublished)
         : undefined);
     message.leave !== undefined &&
-      (obj.leave = message.leave
-        ? LeaveRequest.toJSON(message.leave)
-        : undefined);
+      (obj.leave = message.leave ? LeaveRequest.toJSON(message.leave) : undefined);
     message.mute !== undefined &&
-      (obj.mute = message.mute
-        ? MuteTrackRequest.toJSON(message.mute)
-        : undefined);
+      (obj.mute = message.mute ? MuteTrackRequest.toJSON(message.mute) : undefined);
     message.speakersChanged !== undefined &&
       (obj.speakersChanged = message.speakersChanged
         ? SpeakersChanged.toJSON(message.speakersChanged)
         : undefined);
     message.roomUpdate !== undefined &&
-      (obj.roomUpdate = message.roomUpdate
-        ? RoomUpdate.toJSON(message.roomUpdate)
-        : undefined);
+      (obj.roomUpdate = message.roomUpdate ? RoomUpdate.toJSON(message.roomUpdate) : undefined);
     message.connectionQuality !== undefined &&
       (obj.connectionQuality = message.connectionQuality
         ? ConnectionQualityUpdate.toJSON(message.connectionQuality)
@@ -929,12 +783,9 @@ export const SignalResponse = {
         : undefined);
     message.subscriptionPermissionUpdate !== undefined &&
       (obj.subscriptionPermissionUpdate = message.subscriptionPermissionUpdate
-        ? SubscriptionPermissionUpdate.toJSON(
-            message.subscriptionPermissionUpdate
-          )
+        ? SubscriptionPermissionUpdate.toJSON(message.subscriptionPermissionUpdate)
         : undefined);
-    message.refreshToken !== undefined &&
-      (obj.refreshToken = message.refreshToken);
+    message.refreshToken !== undefined && (obj.refreshToken = message.refreshToken);
     message.trackUnpublished !== undefined &&
       (obj.trackUnpublished = message.trackUnpublished
         ? TrackUnpublishedResponse.toJSON(message.trackUnpublished)
@@ -942,9 +793,7 @@ export const SignalResponse = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SignalResponse>, I>>(
-    object: I
-  ): SignalResponse {
+  fromPartial<I extends Exact<DeepPartial<SignalResponse>, I>>(object: I): SignalResponse {
     const message = createBaseSignalResponse();
     message.join =
       object.join !== undefined && object.join !== null
@@ -987,26 +836,21 @@ export const SignalResponse = {
         ? RoomUpdate.fromPartial(object.roomUpdate)
         : undefined;
     message.connectionQuality =
-      object.connectionQuality !== undefined &&
-      object.connectionQuality !== null
+      object.connectionQuality !== undefined && object.connectionQuality !== null
         ? ConnectionQualityUpdate.fromPartial(object.connectionQuality)
         : undefined;
     message.streamStateUpdate =
-      object.streamStateUpdate !== undefined &&
-      object.streamStateUpdate !== null
+      object.streamStateUpdate !== undefined && object.streamStateUpdate !== null
         ? StreamStateUpdate.fromPartial(object.streamStateUpdate)
         : undefined;
     message.subscribedQualityUpdate =
-      object.subscribedQualityUpdate !== undefined &&
-      object.subscribedQualityUpdate !== null
+      object.subscribedQualityUpdate !== undefined && object.subscribedQualityUpdate !== null
         ? SubscribedQualityUpdate.fromPartial(object.subscribedQualityUpdate)
         : undefined;
     message.subscriptionPermissionUpdate =
       object.subscriptionPermissionUpdate !== undefined &&
       object.subscriptionPermissionUpdate !== null
-        ? SubscriptionPermissionUpdate.fromPartial(
-            object.subscriptionPermissionUpdate
-          )
+        ? SubscriptionPermissionUpdate.fromPartial(object.subscriptionPermissionUpdate)
         : undefined;
     message.refreshToken = object.refreshToken ?? undefined;
     message.trackUnpublished =
@@ -1019,8 +863,8 @@ export const SignalResponse = {
 
 function createBaseAddTrackRequest(): AddTrackRequest {
   return {
-    cid: "",
-    name: "",
+    cid: '',
+    name: '',
     type: 0,
     width: 0,
     height: 0,
@@ -1032,14 +876,11 @@ function createBaseAddTrackRequest(): AddTrackRequest {
 }
 
 export const AddTrackRequest = {
-  encode(
-    message: AddTrackRequest,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.cid !== "") {
+  encode(message: AddTrackRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.cid !== '') {
       writer.uint32(10).string(message.cid);
     }
-    if (message.name !== "") {
+    if (message.name !== '') {
       writer.uint32(18).string(message.name);
     }
     if (message.type !== 0) {
@@ -1110,8 +951,8 @@ export const AddTrackRequest = {
 
   fromJSON(object: any): AddTrackRequest {
     return {
-      cid: isSet(object.cid) ? String(object.cid) : "",
-      name: isSet(object.name) ? String(object.name) : "",
+      cid: isSet(object.cid) ? String(object.cid) : '',
+      name: isSet(object.name) ? String(object.name) : '',
       type: isSet(object.type) ? trackTypeFromJSON(object.type) : 0,
       width: isSet(object.width) ? Number(object.width) : 0,
       height: isSet(object.height) ? Number(object.height) : 0,
@@ -1133,24 +974,19 @@ export const AddTrackRequest = {
     message.height !== undefined && (obj.height = Math.round(message.height));
     message.muted !== undefined && (obj.muted = message.muted);
     message.disableDtx !== undefined && (obj.disableDtx = message.disableDtx);
-    message.source !== undefined &&
-      (obj.source = trackSourceToJSON(message.source));
+    message.source !== undefined && (obj.source = trackSourceToJSON(message.source));
     if (message.layers) {
-      obj.layers = message.layers.map((e) =>
-        e ? VideoLayer.toJSON(e) : undefined
-      );
+      obj.layers = message.layers.map((e) => (e ? VideoLayer.toJSON(e) : undefined));
     } else {
       obj.layers = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<AddTrackRequest>, I>>(
-    object: I
-  ): AddTrackRequest {
+  fromPartial<I extends Exact<DeepPartial<AddTrackRequest>, I>>(object: I): AddTrackRequest {
     const message = createBaseAddTrackRequest();
-    message.cid = object.cid ?? "";
-    message.name = object.name ?? "";
+    message.cid = object.cid ?? '';
+    message.name = object.name ?? '';
     message.type = object.type ?? 0;
     message.width = object.width ?? 0;
     message.height = object.height ?? 0;
@@ -1163,15 +999,12 @@ export const AddTrackRequest = {
 };
 
 function createBaseTrickleRequest(): TrickleRequest {
-  return { candidateInit: "", target: 0 };
+  return { candidateInit: '', target: 0 };
 }
 
 export const TrickleRequest = {
-  encode(
-    message: TrickleRequest,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.candidateInit !== "") {
+  encode(message: TrickleRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.candidateInit !== '') {
       writer.uint32(10).string(message.candidateInit);
     }
     if (message.target !== 0) {
@@ -1203,42 +1036,33 @@ export const TrickleRequest = {
 
   fromJSON(object: any): TrickleRequest {
     return {
-      candidateInit: isSet(object.candidateInit)
-        ? String(object.candidateInit)
-        : "",
+      candidateInit: isSet(object.candidateInit) ? String(object.candidateInit) : '',
       target: isSet(object.target) ? signalTargetFromJSON(object.target) : 0,
     };
   },
 
   toJSON(message: TrickleRequest): unknown {
     const obj: any = {};
-    message.candidateInit !== undefined &&
-      (obj.candidateInit = message.candidateInit);
-    message.target !== undefined &&
-      (obj.target = signalTargetToJSON(message.target));
+    message.candidateInit !== undefined && (obj.candidateInit = message.candidateInit);
+    message.target !== undefined && (obj.target = signalTargetToJSON(message.target));
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<TrickleRequest>, I>>(
-    object: I
-  ): TrickleRequest {
+  fromPartial<I extends Exact<DeepPartial<TrickleRequest>, I>>(object: I): TrickleRequest {
     const message = createBaseTrickleRequest();
-    message.candidateInit = object.candidateInit ?? "";
+    message.candidateInit = object.candidateInit ?? '';
     message.target = object.target ?? 0;
     return message;
   },
 };
 
 function createBaseMuteTrackRequest(): MuteTrackRequest {
-  return { sid: "", muted: false };
+  return { sid: '', muted: false };
 }
 
 export const MuteTrackRequest = {
-  encode(
-    message: MuteTrackRequest,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.sid !== "") {
+  encode(message: MuteTrackRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.sid !== '') {
       writer.uint32(10).string(message.sid);
     }
     if (message.muted === true) {
@@ -1270,7 +1094,7 @@ export const MuteTrackRequest = {
 
   fromJSON(object: any): MuteTrackRequest {
     return {
-      sid: isSet(object.sid) ? String(object.sid) : "",
+      sid: isSet(object.sid) ? String(object.sid) : '',
       muted: isSet(object.muted) ? Boolean(object.muted) : false,
     };
   },
@@ -1282,11 +1106,9 @@ export const MuteTrackRequest = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<MuteTrackRequest>, I>>(
-    object: I
-  ): MuteTrackRequest {
+  fromPartial<I extends Exact<DeepPartial<MuteTrackRequest>, I>>(object: I): MuteTrackRequest {
     const message = createBaseMuteTrackRequest();
-    message.sid = object.sid ?? "";
+    message.sid = object.sid ?? '';
     message.muted = object.muted ?? false;
     return message;
   },
@@ -1297,33 +1119,27 @@ function createBaseJoinResponse(): JoinResponse {
     room: undefined,
     participant: undefined,
     otherParticipants: [],
-    serverVersion: "",
+    serverVersion: '',
     iceServers: [],
     subscriberPrimary: false,
-    alternativeUrl: "",
+    alternativeUrl: '',
     clientConfiguration: undefined,
-    serverRegion: "",
+    serverRegion: '',
   };
 }
 
 export const JoinResponse = {
-  encode(
-    message: JoinResponse,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: JoinResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.room !== undefined) {
       Room.encode(message.room, writer.uint32(10).fork()).ldelim();
     }
     if (message.participant !== undefined) {
-      ParticipantInfo.encode(
-        message.participant,
-        writer.uint32(18).fork()
-      ).ldelim();
+      ParticipantInfo.encode(message.participant, writer.uint32(18).fork()).ldelim();
     }
     for (const v of message.otherParticipants) {
       ParticipantInfo.encode(v!, writer.uint32(26).fork()).ldelim();
     }
-    if (message.serverVersion !== "") {
+    if (message.serverVersion !== '') {
       writer.uint32(34).string(message.serverVersion);
     }
     for (const v of message.iceServers) {
@@ -1332,16 +1148,13 @@ export const JoinResponse = {
     if (message.subscriberPrimary === true) {
       writer.uint32(48).bool(message.subscriberPrimary);
     }
-    if (message.alternativeUrl !== "") {
+    if (message.alternativeUrl !== '') {
       writer.uint32(58).string(message.alternativeUrl);
     }
     if (message.clientConfiguration !== undefined) {
-      ClientConfiguration.encode(
-        message.clientConfiguration,
-        writer.uint32(66).fork()
-      ).ldelim();
+      ClientConfiguration.encode(message.clientConfiguration, writer.uint32(66).fork()).ldelim();
     }
-    if (message.serverRegion !== "") {
+    if (message.serverRegion !== '') {
       writer.uint32(74).string(message.serverRegion);
     }
     return writer;
@@ -1361,9 +1174,7 @@ export const JoinResponse = {
           message.participant = ParticipantInfo.decode(reader, reader.uint32());
           break;
         case 3:
-          message.otherParticipants.push(
-            ParticipantInfo.decode(reader, reader.uint32())
-          );
+          message.otherParticipants.push(ParticipantInfo.decode(reader, reader.uint32()));
           break;
         case 4:
           message.serverVersion = reader.string();
@@ -1378,10 +1189,7 @@ export const JoinResponse = {
           message.alternativeUrl = reader.string();
           break;
         case 8:
-          message.clientConfiguration = ClientConfiguration.decode(
-            reader,
-            reader.uint32()
-          );
+          message.clientConfiguration = ClientConfiguration.decode(reader, reader.uint32());
           break;
         case 9:
           message.serverRegion = reader.string();
@@ -1403,104 +1211,81 @@ export const JoinResponse = {
       otherParticipants: Array.isArray(object?.otherParticipants)
         ? object.otherParticipants.map((e: any) => ParticipantInfo.fromJSON(e))
         : [],
-      serverVersion: isSet(object.serverVersion)
-        ? String(object.serverVersion)
-        : "",
+      serverVersion: isSet(object.serverVersion) ? String(object.serverVersion) : '',
       iceServers: Array.isArray(object?.iceServers)
         ? object.iceServers.map((e: any) => ICEServer.fromJSON(e))
         : [],
       subscriberPrimary: isSet(object.subscriberPrimary)
         ? Boolean(object.subscriberPrimary)
         : false,
-      alternativeUrl: isSet(object.alternativeUrl)
-        ? String(object.alternativeUrl)
-        : "",
+      alternativeUrl: isSet(object.alternativeUrl) ? String(object.alternativeUrl) : '',
       clientConfiguration: isSet(object.clientConfiguration)
         ? ClientConfiguration.fromJSON(object.clientConfiguration)
         : undefined,
-      serverRegion: isSet(object.serverRegion)
-        ? String(object.serverRegion)
-        : "",
+      serverRegion: isSet(object.serverRegion) ? String(object.serverRegion) : '',
     };
   },
 
   toJSON(message: JoinResponse): unknown {
     const obj: any = {};
-    message.room !== undefined &&
-      (obj.room = message.room ? Room.toJSON(message.room) : undefined);
+    message.room !== undefined && (obj.room = message.room ? Room.toJSON(message.room) : undefined);
     message.participant !== undefined &&
       (obj.participant = message.participant
         ? ParticipantInfo.toJSON(message.participant)
         : undefined);
     if (message.otherParticipants) {
       obj.otherParticipants = message.otherParticipants.map((e) =>
-        e ? ParticipantInfo.toJSON(e) : undefined
+        e ? ParticipantInfo.toJSON(e) : undefined,
       );
     } else {
       obj.otherParticipants = [];
     }
-    message.serverVersion !== undefined &&
-      (obj.serverVersion = message.serverVersion);
+    message.serverVersion !== undefined && (obj.serverVersion = message.serverVersion);
     if (message.iceServers) {
-      obj.iceServers = message.iceServers.map((e) =>
-        e ? ICEServer.toJSON(e) : undefined
-      );
+      obj.iceServers = message.iceServers.map((e) => (e ? ICEServer.toJSON(e) : undefined));
     } else {
       obj.iceServers = [];
     }
-    message.subscriberPrimary !== undefined &&
-      (obj.subscriberPrimary = message.subscriberPrimary);
-    message.alternativeUrl !== undefined &&
-      (obj.alternativeUrl = message.alternativeUrl);
+    message.subscriberPrimary !== undefined && (obj.subscriberPrimary = message.subscriberPrimary);
+    message.alternativeUrl !== undefined && (obj.alternativeUrl = message.alternativeUrl);
     message.clientConfiguration !== undefined &&
       (obj.clientConfiguration = message.clientConfiguration
         ? ClientConfiguration.toJSON(message.clientConfiguration)
         : undefined);
-    message.serverRegion !== undefined &&
-      (obj.serverRegion = message.serverRegion);
+    message.serverRegion !== undefined && (obj.serverRegion = message.serverRegion);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<JoinResponse>, I>>(
-    object: I
-  ): JoinResponse {
+  fromPartial<I extends Exact<DeepPartial<JoinResponse>, I>>(object: I): JoinResponse {
     const message = createBaseJoinResponse();
     message.room =
-      object.room !== undefined && object.room !== null
-        ? Room.fromPartial(object.room)
-        : undefined;
+      object.room !== undefined && object.room !== null ? Room.fromPartial(object.room) : undefined;
     message.participant =
       object.participant !== undefined && object.participant !== null
         ? ParticipantInfo.fromPartial(object.participant)
         : undefined;
     message.otherParticipants =
-      object.otherParticipants?.map((e) => ParticipantInfo.fromPartial(e)) ||
-      [];
-    message.serverVersion = object.serverVersion ?? "";
-    message.iceServers =
-      object.iceServers?.map((e) => ICEServer.fromPartial(e)) || [];
+      object.otherParticipants?.map((e) => ParticipantInfo.fromPartial(e)) || [];
+    message.serverVersion = object.serverVersion ?? '';
+    message.iceServers = object.iceServers?.map((e) => ICEServer.fromPartial(e)) || [];
     message.subscriberPrimary = object.subscriberPrimary ?? false;
-    message.alternativeUrl = object.alternativeUrl ?? "";
+    message.alternativeUrl = object.alternativeUrl ?? '';
     message.clientConfiguration =
-      object.clientConfiguration !== undefined &&
-      object.clientConfiguration !== null
+      object.clientConfiguration !== undefined && object.clientConfiguration !== null
         ? ClientConfiguration.fromPartial(object.clientConfiguration)
         : undefined;
-    message.serverRegion = object.serverRegion ?? "";
+    message.serverRegion = object.serverRegion ?? '';
     return message;
   },
 };
 
 function createBaseTrackPublishedResponse(): TrackPublishedResponse {
-  return { cid: "", track: undefined };
+  return { cid: '', track: undefined };
 }
 
 export const TrackPublishedResponse = {
-  encode(
-    message: TrackPublishedResponse,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.cid !== "") {
+  encode(message: TrackPublishedResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.cid !== '') {
       writer.uint32(10).string(message.cid);
     }
     if (message.track !== undefined) {
@@ -1509,10 +1294,7 @@ export const TrackPublishedResponse = {
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): TrackPublishedResponse {
+  decode(input: _m0.Reader | Uint8Array, length?: number): TrackPublishedResponse {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTrackPublishedResponse();
@@ -1535,7 +1317,7 @@ export const TrackPublishedResponse = {
 
   fromJSON(object: any): TrackPublishedResponse {
     return {
-      cid: isSet(object.cid) ? String(object.cid) : "",
+      cid: isSet(object.cid) ? String(object.cid) : '',
       track: isSet(object.track) ? TrackInfo.fromJSON(object.track) : undefined,
     };
   },
@@ -1549,10 +1331,10 @@ export const TrackPublishedResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<TrackPublishedResponse>, I>>(
-    object: I
+    object: I,
   ): TrackPublishedResponse {
     const message = createBaseTrackPublishedResponse();
-    message.cid = object.cid ?? "";
+    message.cid = object.cid ?? '';
     message.track =
       object.track !== undefined && object.track !== null
         ? TrackInfo.fromPartial(object.track)
@@ -1562,24 +1344,18 @@ export const TrackPublishedResponse = {
 };
 
 function createBaseTrackUnpublishedResponse(): TrackUnpublishedResponse {
-  return { trackSid: "" };
+  return { trackSid: '' };
 }
 
 export const TrackUnpublishedResponse = {
-  encode(
-    message: TrackUnpublishedResponse,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.trackSid !== "") {
+  encode(message: TrackUnpublishedResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.trackSid !== '') {
       writer.uint32(10).string(message.trackSid);
     }
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): TrackUnpublishedResponse {
+  decode(input: _m0.Reader | Uint8Array, length?: number): TrackUnpublishedResponse {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTrackUnpublishedResponse();
@@ -1599,7 +1375,7 @@ export const TrackUnpublishedResponse = {
 
   fromJSON(object: any): TrackUnpublishedResponse {
     return {
-      trackSid: isSet(object.trackSid) ? String(object.trackSid) : "",
+      trackSid: isSet(object.trackSid) ? String(object.trackSid) : '',
     };
   },
 
@@ -1610,27 +1386,24 @@ export const TrackUnpublishedResponse = {
   },
 
   fromPartial<I extends Exact<DeepPartial<TrackUnpublishedResponse>, I>>(
-    object: I
+    object: I,
   ): TrackUnpublishedResponse {
     const message = createBaseTrackUnpublishedResponse();
-    message.trackSid = object.trackSid ?? "";
+    message.trackSid = object.trackSid ?? '';
     return message;
   },
 };
 
 function createBaseSessionDescription(): SessionDescription {
-  return { type: "", sdp: "" };
+  return { type: '', sdp: '' };
 }
 
 export const SessionDescription = {
-  encode(
-    message: SessionDescription,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.type !== "") {
+  encode(message: SessionDescription, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.type !== '') {
       writer.uint32(10).string(message.type);
     }
-    if (message.sdp !== "") {
+    if (message.sdp !== '') {
       writer.uint32(18).string(message.sdp);
     }
     return writer;
@@ -1659,8 +1432,8 @@ export const SessionDescription = {
 
   fromJSON(object: any): SessionDescription {
     return {
-      type: isSet(object.type) ? String(object.type) : "",
-      sdp: isSet(object.sdp) ? String(object.sdp) : "",
+      type: isSet(object.type) ? String(object.type) : '',
+      sdp: isSet(object.sdp) ? String(object.sdp) : '',
     };
   },
 
@@ -1671,12 +1444,10 @@ export const SessionDescription = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SessionDescription>, I>>(
-    object: I
-  ): SessionDescription {
+  fromPartial<I extends Exact<DeepPartial<SessionDescription>, I>>(object: I): SessionDescription {
     const message = createBaseSessionDescription();
-    message.type = object.type ?? "";
-    message.sdp = object.sdp ?? "";
+    message.type = object.type ?? '';
+    message.sdp = object.sdp ?? '';
     return message;
   },
 };
@@ -1686,10 +1457,7 @@ function createBaseParticipantUpdate(): ParticipantUpdate {
 }
 
 export const ParticipantUpdate = {
-  encode(
-    message: ParticipantUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: ParticipantUpdate, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.participants) {
       ParticipantInfo.encode(v!, writer.uint32(10).fork()).ldelim();
     }
@@ -1704,9 +1472,7 @@ export const ParticipantUpdate = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.participants.push(
-            ParticipantInfo.decode(reader, reader.uint32())
-          );
+          message.participants.push(ParticipantInfo.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -1728,7 +1494,7 @@ export const ParticipantUpdate = {
     const obj: any = {};
     if (message.participants) {
       obj.participants = message.participants.map((e) =>
-        e ? ParticipantInfo.toJSON(e) : undefined
+        e ? ParticipantInfo.toJSON(e) : undefined,
       );
     } else {
       obj.participants = [];
@@ -1736,12 +1502,9 @@ export const ParticipantUpdate = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ParticipantUpdate>, I>>(
-    object: I
-  ): ParticipantUpdate {
+  fromPartial<I extends Exact<DeepPartial<ParticipantUpdate>, I>>(object: I): ParticipantUpdate {
     const message = createBaseParticipantUpdate();
-    message.participants =
-      object.participants?.map((e) => ParticipantInfo.fromPartial(e)) || [];
+    message.participants = object.participants?.map((e) => ParticipantInfo.fromPartial(e)) || [];
     return message;
   },
 };
@@ -1751,10 +1514,7 @@ function createBaseUpdateSubscription(): UpdateSubscription {
 }
 
 export const UpdateSubscription = {
-  encode(
-    message: UpdateSubscription,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: UpdateSubscription, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.trackSids) {
       writer.uint32(10).string(v!);
     }
@@ -1781,9 +1541,7 @@ export const UpdateSubscription = {
           message.subscribe = reader.bool();
           break;
         case 3:
-          message.participantTracks.push(
-            ParticipantTracks.decode(reader, reader.uint32())
-          );
+          message.participantTracks.push(ParticipantTracks.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -1800,9 +1558,7 @@ export const UpdateSubscription = {
         : [],
       subscribe: isSet(object.subscribe) ? Boolean(object.subscribe) : false,
       participantTracks: Array.isArray(object?.participantTracks)
-        ? object.participantTracks.map((e: any) =>
-            ParticipantTracks.fromJSON(e)
-          )
+        ? object.participantTracks.map((e: any) => ParticipantTracks.fromJSON(e))
         : [],
     };
   },
@@ -1817,7 +1573,7 @@ export const UpdateSubscription = {
     message.subscribe !== undefined && (obj.subscribe = message.subscribe);
     if (message.participantTracks) {
       obj.participantTracks = message.participantTracks.map((e) =>
-        e ? ParticipantTracks.toJSON(e) : undefined
+        e ? ParticipantTracks.toJSON(e) : undefined,
       );
     } else {
       obj.participantTracks = [];
@@ -1825,15 +1581,12 @@ export const UpdateSubscription = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateSubscription>, I>>(
-    object: I
-  ): UpdateSubscription {
+  fromPartial<I extends Exact<DeepPartial<UpdateSubscription>, I>>(object: I): UpdateSubscription {
     const message = createBaseUpdateSubscription();
     message.trackSids = object.trackSids?.map((e) => e) || [];
     message.subscribe = object.subscribe ?? false;
     message.participantTracks =
-      object.participantTracks?.map((e) => ParticipantTracks.fromPartial(e)) ||
-      [];
+      object.participantTracks?.map((e) => ParticipantTracks.fromPartial(e)) || [];
     return message;
   },
 };
@@ -1843,10 +1596,7 @@ function createBaseUpdateTrackSettings(): UpdateTrackSettings {
 }
 
 export const UpdateTrackSettings = {
-  encode(
-    message: UpdateTrackSettings,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: UpdateTrackSettings, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.trackSids) {
       writer.uint32(10).string(v!);
     }
@@ -1915,15 +1665,14 @@ export const UpdateTrackSettings = {
       obj.trackSids = [];
     }
     message.disabled !== undefined && (obj.disabled = message.disabled);
-    message.quality !== undefined &&
-      (obj.quality = videoQualityToJSON(message.quality));
+    message.quality !== undefined && (obj.quality = videoQualityToJSON(message.quality));
     message.width !== undefined && (obj.width = Math.round(message.width));
     message.height !== undefined && (obj.height = Math.round(message.height));
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<UpdateTrackSettings>, I>>(
-    object: I
+    object: I,
   ): UpdateTrackSettings {
     const message = createBaseUpdateTrackSettings();
     message.trackSids = object.trackSids?.map((e) => e) || [];
@@ -1940,10 +1689,7 @@ function createBaseLeaveRequest(): LeaveRequest {
 }
 
 export const LeaveRequest = {
-  encode(
-    message: LeaveRequest,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: LeaveRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.canReconnect === true) {
       writer.uint32(8).bool(message.canReconnect);
     }
@@ -1970,22 +1716,17 @@ export const LeaveRequest = {
 
   fromJSON(object: any): LeaveRequest {
     return {
-      canReconnect: isSet(object.canReconnect)
-        ? Boolean(object.canReconnect)
-        : false,
+      canReconnect: isSet(object.canReconnect) ? Boolean(object.canReconnect) : false,
     };
   },
 
   toJSON(message: LeaveRequest): unknown {
     const obj: any = {};
-    message.canReconnect !== undefined &&
-      (obj.canReconnect = message.canReconnect);
+    message.canReconnect !== undefined && (obj.canReconnect = message.canReconnect);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<LeaveRequest>, I>>(
-    object: I
-  ): LeaveRequest {
+  fromPartial<I extends Exact<DeepPartial<LeaveRequest>, I>>(object: I): LeaveRequest {
     const message = createBaseLeaveRequest();
     message.canReconnect = object.canReconnect ?? false;
     return message;
@@ -1993,15 +1734,12 @@ export const LeaveRequest = {
 };
 
 function createBaseUpdateVideoLayers(): UpdateVideoLayers {
-  return { trackSid: "", layers: [] };
+  return { trackSid: '', layers: [] };
 }
 
 export const UpdateVideoLayers = {
-  encode(
-    message: UpdateVideoLayers,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.trackSid !== "") {
+  encode(message: UpdateVideoLayers, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.trackSid !== '') {
       writer.uint32(10).string(message.trackSid);
     }
     for (const v of message.layers) {
@@ -2033,7 +1771,7 @@ export const UpdateVideoLayers = {
 
   fromJSON(object: any): UpdateVideoLayers {
     return {
-      trackSid: isSet(object.trackSid) ? String(object.trackSid) : "",
+      trackSid: isSet(object.trackSid) ? String(object.trackSid) : '',
       layers: Array.isArray(object?.layers)
         ? object.layers.map((e: any) => VideoLayer.fromJSON(e))
         : [],
@@ -2044,41 +1782,34 @@ export const UpdateVideoLayers = {
     const obj: any = {};
     message.trackSid !== undefined && (obj.trackSid = message.trackSid);
     if (message.layers) {
-      obj.layers = message.layers.map((e) =>
-        e ? VideoLayer.toJSON(e) : undefined
-      );
+      obj.layers = message.layers.map((e) => (e ? VideoLayer.toJSON(e) : undefined));
     } else {
       obj.layers = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<UpdateVideoLayers>, I>>(
-    object: I
-  ): UpdateVideoLayers {
+  fromPartial<I extends Exact<DeepPartial<UpdateVideoLayers>, I>>(object: I): UpdateVideoLayers {
     const message = createBaseUpdateVideoLayers();
-    message.trackSid = object.trackSid ?? "";
+    message.trackSid = object.trackSid ?? '';
     message.layers = object.layers?.map((e) => VideoLayer.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseICEServer(): ICEServer {
-  return { urls: [], username: "", credential: "" };
+  return { urls: [], username: '', credential: '' };
 }
 
 export const ICEServer = {
-  encode(
-    message: ICEServer,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: ICEServer, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.urls) {
       writer.uint32(10).string(v!);
     }
-    if (message.username !== "") {
+    if (message.username !== '') {
       writer.uint32(18).string(message.username);
     }
-    if (message.credential !== "") {
+    if (message.credential !== '') {
       writer.uint32(26).string(message.credential);
     }
     return writer;
@@ -2110,11 +1841,9 @@ export const ICEServer = {
 
   fromJSON(object: any): ICEServer {
     return {
-      urls: Array.isArray(object?.urls)
-        ? object.urls.map((e: any) => String(e))
-        : [],
-      username: isSet(object.username) ? String(object.username) : "",
-      credential: isSet(object.credential) ? String(object.credential) : "",
+      urls: Array.isArray(object?.urls) ? object.urls.map((e: any) => String(e)) : [],
+      username: isSet(object.username) ? String(object.username) : '',
+      credential: isSet(object.credential) ? String(object.credential) : '',
     };
   },
 
@@ -2130,13 +1859,11 @@ export const ICEServer = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ICEServer>, I>>(
-    object: I
-  ): ICEServer {
+  fromPartial<I extends Exact<DeepPartial<ICEServer>, I>>(object: I): ICEServer {
     const message = createBaseICEServer();
     message.urls = object.urls?.map((e) => e) || [];
-    message.username = object.username ?? "";
-    message.credential = object.credential ?? "";
+    message.username = object.username ?? '';
+    message.credential = object.credential ?? '';
     return message;
   },
 };
@@ -2146,10 +1873,7 @@ function createBaseSpeakersChanged(): SpeakersChanged {
 }
 
 export const SpeakersChanged = {
-  encode(
-    message: SpeakersChanged,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: SpeakersChanged, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.speakers) {
       SpeakerInfo.encode(v!, writer.uint32(10).fork()).ldelim();
     }
@@ -2185,21 +1909,16 @@ export const SpeakersChanged = {
   toJSON(message: SpeakersChanged): unknown {
     const obj: any = {};
     if (message.speakers) {
-      obj.speakers = message.speakers.map((e) =>
-        e ? SpeakerInfo.toJSON(e) : undefined
-      );
+      obj.speakers = message.speakers.map((e) => (e ? SpeakerInfo.toJSON(e) : undefined));
     } else {
       obj.speakers = [];
     }
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SpeakersChanged>, I>>(
-    object: I
-  ): SpeakersChanged {
+  fromPartial<I extends Exact<DeepPartial<SpeakersChanged>, I>>(object: I): SpeakersChanged {
     const message = createBaseSpeakersChanged();
-    message.speakers =
-      object.speakers?.map((e) => SpeakerInfo.fromPartial(e)) || [];
+    message.speakers = object.speakers?.map((e) => SpeakerInfo.fromPartial(e)) || [];
     return message;
   },
 };
@@ -2209,10 +1928,7 @@ function createBaseRoomUpdate(): RoomUpdate {
 }
 
 export const RoomUpdate = {
-  encode(
-    message: RoomUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: RoomUpdate, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.room !== undefined) {
       Room.encode(message.room, writer.uint32(10).fork()).ldelim();
     }
@@ -2245,33 +1961,25 @@ export const RoomUpdate = {
 
   toJSON(message: RoomUpdate): unknown {
     const obj: any = {};
-    message.room !== undefined &&
-      (obj.room = message.room ? Room.toJSON(message.room) : undefined);
+    message.room !== undefined && (obj.room = message.room ? Room.toJSON(message.room) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<RoomUpdate>, I>>(
-    object: I
-  ): RoomUpdate {
+  fromPartial<I extends Exact<DeepPartial<RoomUpdate>, I>>(object: I): RoomUpdate {
     const message = createBaseRoomUpdate();
     message.room =
-      object.room !== undefined && object.room !== null
-        ? Room.fromPartial(object.room)
-        : undefined;
+      object.room !== undefined && object.room !== null ? Room.fromPartial(object.room) : undefined;
     return message;
   },
 };
 
 function createBaseConnectionQualityInfo(): ConnectionQualityInfo {
-  return { participantSid: "", quality: 0, score: 0 };
+  return { participantSid: '', quality: 0, score: 0 };
 }
 
 export const ConnectionQualityInfo = {
-  encode(
-    message: ConnectionQualityInfo,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.participantSid !== "") {
+  encode(message: ConnectionQualityInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.participantSid !== '') {
       writer.uint32(10).string(message.participantSid);
     }
     if (message.quality !== 0) {
@@ -2283,10 +1991,7 @@ export const ConnectionQualityInfo = {
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): ConnectionQualityInfo {
+  decode(input: _m0.Reader | Uint8Array, length?: number): ConnectionQualityInfo {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseConnectionQualityInfo();
@@ -2312,31 +2017,25 @@ export const ConnectionQualityInfo = {
 
   fromJSON(object: any): ConnectionQualityInfo {
     return {
-      participantSid: isSet(object.participantSid)
-        ? String(object.participantSid)
-        : "",
-      quality: isSet(object.quality)
-        ? connectionQualityFromJSON(object.quality)
-        : 0,
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
+      quality: isSet(object.quality) ? connectionQualityFromJSON(object.quality) : 0,
       score: isSet(object.score) ? Number(object.score) : 0,
     };
   },
 
   toJSON(message: ConnectionQualityInfo): unknown {
     const obj: any = {};
-    message.participantSid !== undefined &&
-      (obj.participantSid = message.participantSid);
-    message.quality !== undefined &&
-      (obj.quality = connectionQualityToJSON(message.quality));
+    message.participantSid !== undefined && (obj.participantSid = message.participantSid);
+    message.quality !== undefined && (obj.quality = connectionQualityToJSON(message.quality));
     message.score !== undefined && (obj.score = message.score);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<ConnectionQualityInfo>, I>>(
-    object: I
+    object: I,
   ): ConnectionQualityInfo {
     const message = createBaseConnectionQualityInfo();
-    message.participantSid = object.participantSid ?? "";
+    message.participantSid = object.participantSid ?? '';
     message.quality = object.quality ?? 0;
     message.score = object.score ?? 0;
     return message;
@@ -2348,20 +2047,14 @@ function createBaseConnectionQualityUpdate(): ConnectionQualityUpdate {
 }
 
 export const ConnectionQualityUpdate = {
-  encode(
-    message: ConnectionQualityUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: ConnectionQualityUpdate, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.updates) {
       ConnectionQualityInfo.encode(v!, writer.uint32(10).fork()).ldelim();
     }
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): ConnectionQualityUpdate {
+  decode(input: _m0.Reader | Uint8Array, length?: number): ConnectionQualityUpdate {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseConnectionQualityUpdate();
@@ -2369,9 +2062,7 @@ export const ConnectionQualityUpdate = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.updates.push(
-            ConnectionQualityInfo.decode(reader, reader.uint32())
-          );
+          message.updates.push(ConnectionQualityInfo.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -2392,9 +2083,7 @@ export const ConnectionQualityUpdate = {
   toJSON(message: ConnectionQualityUpdate): unknown {
     const obj: any = {};
     if (message.updates) {
-      obj.updates = message.updates.map((e) =>
-        e ? ConnectionQualityInfo.toJSON(e) : undefined
-      );
+      obj.updates = message.updates.map((e) => (e ? ConnectionQualityInfo.toJSON(e) : undefined));
     } else {
       obj.updates = [];
     }
@@ -2402,28 +2091,24 @@ export const ConnectionQualityUpdate = {
   },
 
   fromPartial<I extends Exact<DeepPartial<ConnectionQualityUpdate>, I>>(
-    object: I
+    object: I,
   ): ConnectionQualityUpdate {
     const message = createBaseConnectionQualityUpdate();
-    message.updates =
-      object.updates?.map((e) => ConnectionQualityInfo.fromPartial(e)) || [];
+    message.updates = object.updates?.map((e) => ConnectionQualityInfo.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseStreamStateInfo(): StreamStateInfo {
-  return { participantSid: "", trackSid: "", state: 0 };
+  return { participantSid: '', trackSid: '', state: 0 };
 }
 
 export const StreamStateInfo = {
-  encode(
-    message: StreamStateInfo,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.participantSid !== "") {
+  encode(message: StreamStateInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.participantSid !== '') {
       writer.uint32(10).string(message.participantSid);
     }
-    if (message.trackSid !== "") {
+    if (message.trackSid !== '') {
       writer.uint32(18).string(message.trackSid);
     }
     if (message.state !== 0) {
@@ -2458,30 +2143,24 @@ export const StreamStateInfo = {
 
   fromJSON(object: any): StreamStateInfo {
     return {
-      participantSid: isSet(object.participantSid)
-        ? String(object.participantSid)
-        : "",
-      trackSid: isSet(object.trackSid) ? String(object.trackSid) : "",
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
+      trackSid: isSet(object.trackSid) ? String(object.trackSid) : '',
       state: isSet(object.state) ? streamStateFromJSON(object.state) : 0,
     };
   },
 
   toJSON(message: StreamStateInfo): unknown {
     const obj: any = {};
-    message.participantSid !== undefined &&
-      (obj.participantSid = message.participantSid);
+    message.participantSid !== undefined && (obj.participantSid = message.participantSid);
     message.trackSid !== undefined && (obj.trackSid = message.trackSid);
-    message.state !== undefined &&
-      (obj.state = streamStateToJSON(message.state));
+    message.state !== undefined && (obj.state = streamStateToJSON(message.state));
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<StreamStateInfo>, I>>(
-    object: I
-  ): StreamStateInfo {
+  fromPartial<I extends Exact<DeepPartial<StreamStateInfo>, I>>(object: I): StreamStateInfo {
     const message = createBaseStreamStateInfo();
-    message.participantSid = object.participantSid ?? "";
-    message.trackSid = object.trackSid ?? "";
+    message.participantSid = object.participantSid ?? '';
+    message.trackSid = object.trackSid ?? '';
     message.state = object.state ?? 0;
     return message;
   },
@@ -2492,10 +2171,7 @@ function createBaseStreamStateUpdate(): StreamStateUpdate {
 }
 
 export const StreamStateUpdate = {
-  encode(
-    message: StreamStateUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: StreamStateUpdate, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.streamStates) {
       StreamStateInfo.encode(v!, writer.uint32(10).fork()).ldelim();
     }
@@ -2510,9 +2186,7 @@ export const StreamStateUpdate = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.streamStates.push(
-            StreamStateInfo.decode(reader, reader.uint32())
-          );
+          message.streamStates.push(StreamStateInfo.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -2534,7 +2208,7 @@ export const StreamStateUpdate = {
     const obj: any = {};
     if (message.streamStates) {
       obj.streamStates = message.streamStates.map((e) =>
-        e ? StreamStateInfo.toJSON(e) : undefined
+        e ? StreamStateInfo.toJSON(e) : undefined,
       );
     } else {
       obj.streamStates = [];
@@ -2542,12 +2216,9 @@ export const StreamStateUpdate = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<StreamStateUpdate>, I>>(
-    object: I
-  ): StreamStateUpdate {
+  fromPartial<I extends Exact<DeepPartial<StreamStateUpdate>, I>>(object: I): StreamStateUpdate {
     const message = createBaseStreamStateUpdate();
-    message.streamStates =
-      object.streamStates?.map((e) => StreamStateInfo.fromPartial(e)) || [];
+    message.streamStates = object.streamStates?.map((e) => StreamStateInfo.fromPartial(e)) || [];
     return message;
   },
 };
@@ -2557,10 +2228,7 @@ function createBaseSubscribedQuality(): SubscribedQuality {
 }
 
 export const SubscribedQuality = {
-  encode(
-    message: SubscribedQuality,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: SubscribedQuality, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.quality !== 0) {
       writer.uint32(8).int32(message.quality);
     }
@@ -2600,15 +2268,12 @@ export const SubscribedQuality = {
 
   toJSON(message: SubscribedQuality): unknown {
     const obj: any = {};
-    message.quality !== undefined &&
-      (obj.quality = videoQualityToJSON(message.quality));
+    message.quality !== undefined && (obj.quality = videoQualityToJSON(message.quality));
     message.enabled !== undefined && (obj.enabled = message.enabled);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SubscribedQuality>, I>>(
-    object: I
-  ): SubscribedQuality {
+  fromPartial<I extends Exact<DeepPartial<SubscribedQuality>, I>>(object: I): SubscribedQuality {
     const message = createBaseSubscribedQuality();
     message.quality = object.quality ?? 0;
     message.enabled = object.enabled ?? false;
@@ -2617,15 +2282,12 @@ export const SubscribedQuality = {
 };
 
 function createBaseSubscribedQualityUpdate(): SubscribedQualityUpdate {
-  return { trackSid: "", subscribedQualities: [] };
+  return { trackSid: '', subscribedQualities: [] };
 }
 
 export const SubscribedQualityUpdate = {
-  encode(
-    message: SubscribedQualityUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.trackSid !== "") {
+  encode(message: SubscribedQualityUpdate, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.trackSid !== '') {
       writer.uint32(10).string(message.trackSid);
     }
     for (const v of message.subscribedQualities) {
@@ -2634,10 +2296,7 @@ export const SubscribedQualityUpdate = {
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): SubscribedQualityUpdate {
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubscribedQualityUpdate {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSubscribedQualityUpdate();
@@ -2648,9 +2307,7 @@ export const SubscribedQualityUpdate = {
           message.trackSid = reader.string();
           break;
         case 2:
-          message.subscribedQualities.push(
-            SubscribedQuality.decode(reader, reader.uint32())
-          );
+          message.subscribedQualities.push(SubscribedQuality.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -2662,11 +2319,9 @@ export const SubscribedQualityUpdate = {
 
   fromJSON(object: any): SubscribedQualityUpdate {
     return {
-      trackSid: isSet(object.trackSid) ? String(object.trackSid) : "",
+      trackSid: isSet(object.trackSid) ? String(object.trackSid) : '',
       subscribedQualities: Array.isArray(object?.subscribedQualities)
-        ? object.subscribedQualities.map((e: any) =>
-            SubscribedQuality.fromJSON(e)
-          )
+        ? object.subscribedQualities.map((e: any) => SubscribedQuality.fromJSON(e))
         : [],
     };
   },
@@ -2676,7 +2331,7 @@ export const SubscribedQualityUpdate = {
     message.trackSid !== undefined && (obj.trackSid = message.trackSid);
     if (message.subscribedQualities) {
       obj.subscribedQualities = message.subscribedQualities.map((e) =>
-        e ? SubscribedQuality.toJSON(e) : undefined
+        e ? SubscribedQuality.toJSON(e) : undefined,
       );
     } else {
       obj.subscribedQualities = [];
@@ -2685,28 +2340,23 @@ export const SubscribedQualityUpdate = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SubscribedQualityUpdate>, I>>(
-    object: I
+    object: I,
   ): SubscribedQualityUpdate {
     const message = createBaseSubscribedQualityUpdate();
-    message.trackSid = object.trackSid ?? "";
+    message.trackSid = object.trackSid ?? '';
     message.subscribedQualities =
-      object.subscribedQualities?.map((e) =>
-        SubscribedQuality.fromPartial(e)
-      ) || [];
+      object.subscribedQualities?.map((e) => SubscribedQuality.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseTrackPermission(): TrackPermission {
-  return { participantSid: "", allTracks: false, trackSids: [] };
+  return { participantSid: '', allTracks: false, trackSids: [] };
 }
 
 export const TrackPermission = {
-  encode(
-    message: TrackPermission,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.participantSid !== "") {
+  encode(message: TrackPermission, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.participantSid !== '') {
       writer.uint32(10).string(message.participantSid);
     }
     if (message.allTracks === true) {
@@ -2744,9 +2394,7 @@ export const TrackPermission = {
 
   fromJSON(object: any): TrackPermission {
     return {
-      participantSid: isSet(object.participantSid)
-        ? String(object.participantSid)
-        : "",
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
       allTracks: isSet(object.allTracks) ? Boolean(object.allTracks) : false,
       trackSids: Array.isArray(object?.trackSids)
         ? object.trackSids.map((e: any) => String(e))
@@ -2756,8 +2404,7 @@ export const TrackPermission = {
 
   toJSON(message: TrackPermission): unknown {
     const obj: any = {};
-    message.participantSid !== undefined &&
-      (obj.participantSid = message.participantSid);
+    message.participantSid !== undefined && (obj.participantSid = message.participantSid);
     message.allTracks !== undefined && (obj.allTracks = message.allTracks);
     if (message.trackSids) {
       obj.trackSids = message.trackSids.map((e) => e);
@@ -2767,11 +2414,9 @@ export const TrackPermission = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<TrackPermission>, I>>(
-    object: I
-  ): TrackPermission {
+  fromPartial<I extends Exact<DeepPartial<TrackPermission>, I>>(object: I): TrackPermission {
     const message = createBaseTrackPermission();
-    message.participantSid = object.participantSid ?? "";
+    message.participantSid = object.participantSid ?? '';
     message.allTracks = object.allTracks ?? false;
     message.trackSids = object.trackSids?.map((e) => e) || [];
     return message;
@@ -2783,10 +2428,7 @@ function createBaseSubscriptionPermission(): SubscriptionPermission {
 }
 
 export const SubscriptionPermission = {
-  encode(
-    message: SubscriptionPermission,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: SubscriptionPermission, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.allParticipants === true) {
       writer.uint32(8).bool(message.allParticipants);
     }
@@ -2796,10 +2438,7 @@ export const SubscriptionPermission = {
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): SubscriptionPermission {
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubscriptionPermission {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSubscriptionPermission();
@@ -2810,9 +2449,7 @@ export const SubscriptionPermission = {
           message.allParticipants = reader.bool();
           break;
         case 2:
-          message.trackPermissions.push(
-            TrackPermission.decode(reader, reader.uint32())
-          );
+          message.trackPermissions.push(TrackPermission.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -2824,9 +2461,7 @@ export const SubscriptionPermission = {
 
   fromJSON(object: any): SubscriptionPermission {
     return {
-      allParticipants: isSet(object.allParticipants)
-        ? Boolean(object.allParticipants)
-        : false,
+      allParticipants: isSet(object.allParticipants) ? Boolean(object.allParticipants) : false,
       trackPermissions: Array.isArray(object?.trackPermissions)
         ? object.trackPermissions.map((e: any) => TrackPermission.fromJSON(e))
         : [],
@@ -2835,11 +2470,10 @@ export const SubscriptionPermission = {
 
   toJSON(message: SubscriptionPermission): unknown {
     const obj: any = {};
-    message.allParticipants !== undefined &&
-      (obj.allParticipants = message.allParticipants);
+    message.allParticipants !== undefined && (obj.allParticipants = message.allParticipants);
     if (message.trackPermissions) {
       obj.trackPermissions = message.trackPermissions.map((e) =>
-        e ? TrackPermission.toJSON(e) : undefined
+        e ? TrackPermission.toJSON(e) : undefined,
       );
     } else {
       obj.trackPermissions = [];
@@ -2848,7 +2482,7 @@ export const SubscriptionPermission = {
   },
 
   fromPartial<I extends Exact<DeepPartial<SubscriptionPermission>, I>>(
-    object: I
+    object: I,
   ): SubscriptionPermission {
     const message = createBaseSubscriptionPermission();
     message.allParticipants = object.allParticipants ?? false;
@@ -2859,18 +2493,18 @@ export const SubscriptionPermission = {
 };
 
 function createBaseSubscriptionPermissionUpdate(): SubscriptionPermissionUpdate {
-  return { participantSid: "", trackSid: "", allowed: false };
+  return { participantSid: '', trackSid: '', allowed: false };
 }
 
 export const SubscriptionPermissionUpdate = {
   encode(
     message: SubscriptionPermissionUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
-    if (message.participantSid !== "") {
+    if (message.participantSid !== '') {
       writer.uint32(10).string(message.participantSid);
     }
-    if (message.trackSid !== "") {
+    if (message.trackSid !== '') {
       writer.uint32(18).string(message.trackSid);
     }
     if (message.allowed === true) {
@@ -2879,10 +2513,7 @@ export const SubscriptionPermissionUpdate = {
     return writer;
   },
 
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): SubscriptionPermissionUpdate {
+  decode(input: _m0.Reader | Uint8Array, length?: number): SubscriptionPermissionUpdate {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSubscriptionPermissionUpdate();
@@ -2908,29 +2539,26 @@ export const SubscriptionPermissionUpdate = {
 
   fromJSON(object: any): SubscriptionPermissionUpdate {
     return {
-      participantSid: isSet(object.participantSid)
-        ? String(object.participantSid)
-        : "",
-      trackSid: isSet(object.trackSid) ? String(object.trackSid) : "",
+      participantSid: isSet(object.participantSid) ? String(object.participantSid) : '',
+      trackSid: isSet(object.trackSid) ? String(object.trackSid) : '',
       allowed: isSet(object.allowed) ? Boolean(object.allowed) : false,
     };
   },
 
   toJSON(message: SubscriptionPermissionUpdate): unknown {
     const obj: any = {};
-    message.participantSid !== undefined &&
-      (obj.participantSid = message.participantSid);
+    message.participantSid !== undefined && (obj.participantSid = message.participantSid);
     message.trackSid !== undefined && (obj.trackSid = message.trackSid);
     message.allowed !== undefined && (obj.allowed = message.allowed);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<SubscriptionPermissionUpdate>, I>>(
-    object: I
+    object: I,
   ): SubscriptionPermissionUpdate {
     const message = createBaseSubscriptionPermissionUpdate();
-    message.participantSid = object.participantSid ?? "";
-    message.trackSid = object.trackSid ?? "";
+    message.participantSid = object.participantSid ?? '';
+    message.trackSid = object.trackSid ?? '';
     message.allowed = object.allowed ?? false;
     return message;
   },
@@ -2946,21 +2574,12 @@ function createBaseSyncState(): SyncState {
 }
 
 export const SyncState = {
-  encode(
-    message: SyncState,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: SyncState, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.answer !== undefined) {
-      SessionDescription.encode(
-        message.answer,
-        writer.uint32(10).fork()
-      ).ldelim();
+      SessionDescription.encode(message.answer, writer.uint32(10).fork()).ldelim();
     }
     if (message.subscription !== undefined) {
-      UpdateSubscription.encode(
-        message.subscription,
-        writer.uint32(18).fork()
-      ).ldelim();
+      UpdateSubscription.encode(message.subscription, writer.uint32(18).fork()).ldelim();
     }
     for (const v of message.publishTracks) {
       TrackPublishedResponse.encode(v!, writer.uint32(26).fork()).ldelim();
@@ -2982,20 +2601,13 @@ export const SyncState = {
           message.answer = SessionDescription.decode(reader, reader.uint32());
           break;
         case 2:
-          message.subscription = UpdateSubscription.decode(
-            reader,
-            reader.uint32()
-          );
+          message.subscription = UpdateSubscription.decode(reader, reader.uint32());
           break;
         case 3:
-          message.publishTracks.push(
-            TrackPublishedResponse.decode(reader, reader.uint32())
-          );
+          message.publishTracks.push(TrackPublishedResponse.decode(reader, reader.uint32()));
           break;
         case 4:
-          message.dataChannels.push(
-            DataChannelInfo.decode(reader, reader.uint32())
-          );
+          message.dataChannels.push(DataChannelInfo.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -3007,16 +2619,12 @@ export const SyncState = {
 
   fromJSON(object: any): SyncState {
     return {
-      answer: isSet(object.answer)
-        ? SessionDescription.fromJSON(object.answer)
-        : undefined,
+      answer: isSet(object.answer) ? SessionDescription.fromJSON(object.answer) : undefined,
       subscription: isSet(object.subscription)
         ? UpdateSubscription.fromJSON(object.subscription)
         : undefined,
       publishTracks: Array.isArray(object?.publishTracks)
-        ? object.publishTracks.map((e: any) =>
-            TrackPublishedResponse.fromJSON(e)
-          )
+        ? object.publishTracks.map((e: any) => TrackPublishedResponse.fromJSON(e))
         : [],
       dataChannels: Array.isArray(object?.dataChannels)
         ? object.dataChannels.map((e: any) => DataChannelInfo.fromJSON(e))
@@ -3027,23 +2635,21 @@ export const SyncState = {
   toJSON(message: SyncState): unknown {
     const obj: any = {};
     message.answer !== undefined &&
-      (obj.answer = message.answer
-        ? SessionDescription.toJSON(message.answer)
-        : undefined);
+      (obj.answer = message.answer ? SessionDescription.toJSON(message.answer) : undefined);
     message.subscription !== undefined &&
       (obj.subscription = message.subscription
         ? UpdateSubscription.toJSON(message.subscription)
         : undefined);
     if (message.publishTracks) {
       obj.publishTracks = message.publishTracks.map((e) =>
-        e ? TrackPublishedResponse.toJSON(e) : undefined
+        e ? TrackPublishedResponse.toJSON(e) : undefined,
       );
     } else {
       obj.publishTracks = [];
     }
     if (message.dataChannels) {
       obj.dataChannels = message.dataChannels.map((e) =>
-        e ? DataChannelInfo.toJSON(e) : undefined
+        e ? DataChannelInfo.toJSON(e) : undefined,
       );
     } else {
       obj.dataChannels = [];
@@ -3051,9 +2657,7 @@ export const SyncState = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SyncState>, I>>(
-    object: I
-  ): SyncState {
+  fromPartial<I extends Exact<DeepPartial<SyncState>, I>>(object: I): SyncState {
     const message = createBaseSyncState();
     message.answer =
       object.answer !== undefined && object.answer !== null
@@ -3064,24 +2668,19 @@ export const SyncState = {
         ? UpdateSubscription.fromPartial(object.subscription)
         : undefined;
     message.publishTracks =
-      object.publishTracks?.map((e) => TrackPublishedResponse.fromPartial(e)) ||
-      [];
-    message.dataChannels =
-      object.dataChannels?.map((e) => DataChannelInfo.fromPartial(e)) || [];
+      object.publishTracks?.map((e) => TrackPublishedResponse.fromPartial(e)) || [];
+    message.dataChannels = object.dataChannels?.map((e) => DataChannelInfo.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseDataChannelInfo(): DataChannelInfo {
-  return { label: "", id: 0 };
+  return { label: '', id: 0 };
 }
 
 export const DataChannelInfo = {
-  encode(
-    message: DataChannelInfo,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.label !== "") {
+  encode(message: DataChannelInfo, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.label !== '') {
       writer.uint32(10).string(message.label);
     }
     if (message.id !== 0) {
@@ -3113,7 +2712,7 @@ export const DataChannelInfo = {
 
   fromJSON(object: any): DataChannelInfo {
     return {
-      label: isSet(object.label) ? String(object.label) : "",
+      label: isSet(object.label) ? String(object.label) : '',
       id: isSet(object.id) ? Number(object.id) : 0,
     };
   },
@@ -3125,11 +2724,9 @@ export const DataChannelInfo = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<DataChannelInfo>, I>>(
-    object: I
-  ): DataChannelInfo {
+  fromPartial<I extends Exact<DeepPartial<DataChannelInfo>, I>>(object: I): DataChannelInfo {
     const message = createBaseDataChannelInfo();
-    message.label = object.label ?? "";
+    message.label = object.label ?? '';
     message.id = object.id ?? 0;
     return message;
   },
@@ -3145,10 +2742,7 @@ function createBaseSimulateScenario(): SimulateScenario {
 }
 
 export const SimulateScenario = {
-  encode(
-    message: SimulateScenario,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
+  encode(message: SimulateScenario, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     if (message.speakerUpdate !== undefined) {
       writer.uint32(8).int32(message.speakerUpdate);
     }
@@ -3193,36 +2787,23 @@ export const SimulateScenario = {
 
   fromJSON(object: any): SimulateScenario {
     return {
-      speakerUpdate: isSet(object.speakerUpdate)
-        ? Number(object.speakerUpdate)
-        : undefined,
-      nodeFailure: isSet(object.nodeFailure)
-        ? Boolean(object.nodeFailure)
-        : undefined,
-      migration: isSet(object.migration)
-        ? Boolean(object.migration)
-        : undefined,
-      serverLeave: isSet(object.serverLeave)
-        ? Boolean(object.serverLeave)
-        : undefined,
+      speakerUpdate: isSet(object.speakerUpdate) ? Number(object.speakerUpdate) : undefined,
+      nodeFailure: isSet(object.nodeFailure) ? Boolean(object.nodeFailure) : undefined,
+      migration: isSet(object.migration) ? Boolean(object.migration) : undefined,
+      serverLeave: isSet(object.serverLeave) ? Boolean(object.serverLeave) : undefined,
     };
   },
 
   toJSON(message: SimulateScenario): unknown {
     const obj: any = {};
-    message.speakerUpdate !== undefined &&
-      (obj.speakerUpdate = Math.round(message.speakerUpdate));
-    message.nodeFailure !== undefined &&
-      (obj.nodeFailure = message.nodeFailure);
+    message.speakerUpdate !== undefined && (obj.speakerUpdate = Math.round(message.speakerUpdate));
+    message.nodeFailure !== undefined && (obj.nodeFailure = message.nodeFailure);
     message.migration !== undefined && (obj.migration = message.migration);
-    message.serverLeave !== undefined &&
-      (obj.serverLeave = message.serverLeave);
+    message.serverLeave !== undefined && (obj.serverLeave = message.serverLeave);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SimulateScenario>, I>>(
-    object: I
-  ): SimulateScenario {
+  fromPartial<I extends Exact<DeepPartial<SimulateScenario>, I>>(object: I): SimulateScenario {
     const message = createBaseSimulateScenario();
     message.speakerUpdate = object.speakerUpdate ?? undefined;
     message.nodeFailure = object.nodeFailure ?? undefined;
@@ -3232,14 +2813,7 @@ export const SimulateScenario = {
   },
 };
 
-type Builtin =
-  | Date
-  | Function
-  | Uint8Array
-  | string
-  | number
-  | boolean
-  | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
 export type DeepPartial<T> = T extends Builtin
   ? T
@@ -3254,10 +2828,7 @@ export type DeepPartial<T> = T extends Builtin
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
-        never
-      >;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;

--- a/src/room/DeviceManager.ts
+++ b/src/room/DeviceManager.ts
@@ -3,11 +3,7 @@ const defaultId = 'default';
 export default class DeviceManager {
   private static instance?: DeviceManager;
 
-  static mediaDeviceKinds: MediaDeviceKind[] = [
-    'audioinput',
-    'audiooutput',
-    'videoinput',
-  ];
+  static mediaDeviceKinds: MediaDeviceKind[] = ['audioinput', 'audiooutput', 'videoinput'];
 
   static getInstance(): DeviceManager {
     if (this.instance === undefined) {
@@ -40,7 +36,9 @@ export default class DeviceManager {
   }
 
   async normalizeDeviceId(
-    kind: MediaDeviceKind, deviceId?: string, groupId?: string,
+    kind: MediaDeviceKind,
+    deviceId?: string,
+    groupId?: string,
   ): Promise<string | undefined> {
     if (deviceId !== defaultId) {
       return deviceId;

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -44,7 +44,9 @@ export default class PCTransport {
   }
 
   // debounced negotiate interface
-  negotiate = debounce(() => { this.createAndSendOffer(); }, 100);
+  negotiate = debounce(() => {
+    this.createAndSendOffer();
+  }, 100);
 
   async createAndSendOffer(options?: RTCOfferOptions) {
     if (this.onOffer === undefined) {

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -415,7 +415,7 @@ export enum TrackEvent {
   /**
    * @internal
    * Only fires on LocalAudioTrack instances
-  */
+   */
   AudioSilenceDetected = 'audioSilenceDetected',
   /** @internal */
   VisibilityChanged = 'visibilityChanged',

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1,16 +1,14 @@
 import log from '../../logger';
 import { RoomOptions } from '../../options';
+import { DataPacket, DataPacket_Kind, ParticipantPermission } from '../../proto/livekit_models';
 import {
-  DataPacket, DataPacket_Kind, ParticipantPermission,
-} from '../../proto/livekit_models';
-import {
-  AddTrackRequest, DataChannelInfo,
-  SubscribedQualityUpdate, TrackPublishedResponse, TrackUnpublishedResponse,
+  AddTrackRequest,
+  DataChannelInfo,
+  SubscribedQualityUpdate,
+  TrackPublishedResponse,
+  TrackUnpublishedResponse,
 } from '../../proto/livekit_rtc';
-import {
-  TrackInvalidError,
-  UnexpectedConnectionState,
-} from '../errors';
+import { TrackInvalidError, UnexpectedConnectionState } from '../errors';
 import { ParticipantEvent, TrackEvent } from '../events';
 import RTCEngine from '../RTCEngine';
 import LocalAudioTrack from '../track/LocalAudioTrack';
@@ -21,7 +19,8 @@ import {
   CreateLocalTracksOptions,
   ScreenShareCaptureOptions,
   ScreenSharePresets,
-  TrackPublishOptions, VideoCodec,
+  TrackPublishOptions,
+  VideoCodec,
 } from '../track/options';
 import { Track } from '../track/Track';
 import { constraintsForOptions, mergeDefaultOptions } from '../track/utils';
@@ -195,8 +194,10 @@ export default class LocalParticipant extends Participant {
    * displaying a single Permission Dialog box to the end user.
    */
   async enableCameraAndMicrophone() {
-    if (this.pendingPublishing.has(Track.Source.Camera)
-        || this.pendingPublishing.has(Track.Source.Microphone)) {
+    if (
+      this.pendingPublishing.has(Track.Source.Camera) ||
+      this.pendingPublishing.has(Track.Source.Microphone)
+    ) {
       // no-op it's already been requested
       return;
     }
@@ -221,9 +222,7 @@ export default class LocalParticipant extends Participant {
    * @param options
    * @returns
    */
-  async createTracks(
-    options?: CreateLocalTracksOptions,
-  ): Promise<LocalTrack[]> {
+  async createTracks(options?: CreateLocalTracksOptions): Promise<LocalTrack[]> {
     const opts = mergeDefaultOptions(
       options,
       this.roomOptions?.audioCaptureDefaults,
@@ -233,9 +232,7 @@ export default class LocalParticipant extends Participant {
     const constraints = constraintsForOptions(opts);
     let stream: MediaStream | undefined;
     try {
-      stream = await navigator.mediaDevices.getUserMedia(
-        constraints,
-      );
+      stream = await navigator.mediaDevices.getUserMedia(constraints);
     } catch (err) {
       if (err instanceof Error) {
         if (constraints.audio) {
@@ -283,9 +280,7 @@ export default class LocalParticipant extends Participant {
    * A LocalVideoTrack is always created and returned.
    * If { audio: true }, and the browser supports audio capture, a LocalAudioTrack is also created.
    */
-  async createScreenTracks(
-    options?: ScreenShareCaptureOptions,
-  ): Promise<Array<LocalTrack>> {
+  async createScreenTracks(options?: ScreenShareCaptureOptions): Promise<Array<LocalTrack>> {
     if (options === undefined) {
       options = {};
     }
@@ -347,9 +342,7 @@ export default class LocalParticipant extends Participant {
           track = new LocalVideoTrack(track);
           break;
         default:
-          throw new TrackInvalidError(
-            `unsupported MediaStreamTrack kind ${track.kind}`,
-          );
+          throw new TrackInvalidError(`unsupported MediaStreamTrack kind ${track.kind}`);
       }
     }
 
@@ -433,7 +426,8 @@ export default class LocalParticipant extends Participant {
       transceiverInit.sendEncodings = encodings;
     }
     const transceiver = this.engine.publisher.pc.addTransceiver(
-      track.mediaStreamTrack, transceiverInit,
+      track.mediaStreamTrack,
+      transceiverInit,
     );
     this.engine.negotiate();
 
@@ -521,9 +515,7 @@ export default class LocalParticipant extends Participant {
     return publication;
   }
 
-  unpublishTracks(
-    tracks: LocalTrack[] | MediaStreamTrack[],
-  ): LocalTrackPublication[] {
+  unpublishTracks(tracks: LocalTrack[] | MediaStreamTrack[]): LocalTrackPublication[] {
     const publications: LocalTrackPublication[] = [];
     tracks.forEach((track: LocalTrack | MediaStreamTrack) => {
       const pub = this.unpublishTrack(track);
@@ -545,8 +537,11 @@ export default class LocalParticipant extends Participant {
    * packets, use Lossy.
    * @param destination the participants who will receive the message
    */
-  async publishData(data: Uint8Array, kind: DataPacket_Kind,
-    destination?: RemoteParticipant[] | string[]) {
+  async publishData(
+    data: Uint8Array,
+    kind: DataPacket_Kind,
+    destination?: RemoteParticipant[] | string[],
+  ) {
     const dest: string[] = [];
     if (destination !== undefined) {
       destination.forEach((val: any) => {
@@ -604,10 +599,7 @@ export default class LocalParticipant extends Participant {
 
   // when the local track changes in mute status, we'll notify server as such
   /** @internal */
-  private onTrackMuted = (
-    track: LocalTrack,
-    muted?: boolean,
-  ) => {
+  private onTrackMuted = (track: LocalTrack, muted?: boolean) => {
     if (muted === undefined) {
       muted = true;
     }
@@ -626,8 +618,11 @@ export default class LocalParticipant extends Participant {
     }
     const pub = this.videoTracks.get(update.trackSid);
     if (!pub) {
-      log.warn('handleSubscribedQualityUpdate',
-        'received subscribed quality update for unknown track', update.trackSid);
+      log.warn(
+        'handleSubscribedQualityUpdate',
+        'received subscribed quality update for unknown track',
+        update.trackSid,
+      );
       return;
     }
     pub.videoTrack?.setPublishingLayers(update.subscribedQualities);
@@ -636,8 +631,11 @@ export default class LocalParticipant extends Participant {
   private handleLocalTrackUnpublished = (unpublished: TrackUnpublishedResponse) => {
     const track = this.tracks.get(unpublished.trackSid);
     if (!track) {
-      log.warn('handleLocalTrackUnpublished',
-        'received unpublished event for unknown track', unpublished.trackSid);
+      log.warn(
+        'handleLocalTrackUnpublished',
+        'received unpublished event for unknown track',
+        unpublished.trackSid,
+      );
       return;
     }
     this.unpublishTrack(track.track!);
@@ -659,10 +657,7 @@ export default class LocalParticipant extends Participant {
 
       // this looks overly complicated due to this object tree
       if (track instanceof MediaStreamTrack) {
-        if (
-          localTrack instanceof LocalAudioTrack
-          || localTrack instanceof LocalVideoTrack
-        ) {
+        if (localTrack instanceof LocalAudioTrack || localTrack instanceof LocalVideoTrack) {
           if (localTrack.mediaStreamTrack === track) {
             publication = <LocalTrackPublication>pub;
           }

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from 'events';
 import type TypedEmitter from 'typed-emitter';
 import {
-  ConnectionQuality as ProtoQuality, DataPacket_Kind, ParticipantInfo, ParticipantPermission,
+  ConnectionQuality as ProtoQuality,
+  DataPacket_Kind,
+  ParticipantInfo,
+  ParticipantPermission,
 } from '../../proto/livekit_models';
 import { ParticipantEvent, TrackEvent } from '../events';
 import LocalTrackPublication from '../track/LocalTrackPublication';
@@ -30,9 +33,7 @@ function qualityFromProto(q: ProtoQuality): ConnectionQuality {
   }
 }
 
-export default class Participant extends (
-  EventEmitter as new () => TypedEmitter<ParticipantEventCallbacks>
-) {
+export default class Participant extends (EventEmitter as new () => TypedEmitter<ParticipantEventCallbacks>) {
   protected participantInfo?: ParticipantInfo;
 
   audioTracks: Map<string, TrackPublication>;
@@ -95,16 +96,32 @@ export default class Participant extends (
         return pub;
       }
       if (pub.source === Track.Source.Unknown) {
-        if (source === Track.Source.Microphone && pub.kind === Track.Kind.Audio && pub.trackName !== 'screen') {
+        if (
+          source === Track.Source.Microphone &&
+          pub.kind === Track.Kind.Audio &&
+          pub.trackName !== 'screen'
+        ) {
           return pub;
         }
-        if (source === Track.Source.Camera && pub.kind === Track.Kind.Video && pub.trackName !== 'screen') {
+        if (
+          source === Track.Source.Camera &&
+          pub.kind === Track.Kind.Video &&
+          pub.trackName !== 'screen'
+        ) {
           return pub;
         }
-        if (source === Track.Source.ScreenShare && pub.kind === Track.Kind.Video && pub.trackName === 'screen') {
+        if (
+          source === Track.Source.ScreenShare &&
+          pub.kind === Track.Kind.Video &&
+          pub.trackName === 'screen'
+        ) {
           return pub;
         }
-        if (source === Track.Source.ScreenShareAudio && pub.kind === Track.Kind.Audio && pub.trackName === 'screen') {
+        if (
+          source === Track.Source.ScreenShareAudio &&
+          pub.kind === Track.Kind.Audio &&
+          pub.trackName === 'screen'
+        ) {
           return pub;
         }
       }
@@ -178,11 +195,12 @@ export default class Participant extends (
 
   /** @internal */
   setPermissions(permissions: ParticipantPermission): boolean {
-    const changed = permissions.canPublish !== this.permissions?.canPublish
-      || permissions.canSubscribe !== this.permissions?.canSubscribe
-      || permissions.canPublishData !== this.permissions?.canPublishData
-      || permissions.hidden !== this.permissions?.hidden
-      || permissions.recorder !== this.permissions?.recorder;
+    const changed =
+      permissions.canPublish !== this.permissions?.canPublish ||
+      permissions.canSubscribe !== this.permissions?.canSubscribe ||
+      permissions.canPublishData !== this.permissions?.canPublishData ||
+      permissions.hidden !== this.permissions?.hidden ||
+      permissions.recorder !== this.permissions?.recorder;
     this.permissions = permissions;
 
     return changed;
@@ -239,31 +257,31 @@ export default class Participant extends (
 }
 
 export type ParticipantEventCallbacks = {
-  trackPublished: (publication: RemoteTrackPublication) => void,
-  trackSubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void,
-  trackSubscriptionFailed: (trackSid: string) => void,
-  trackUnpublished: (publication: RemoteTrackPublication) => void,
-  trackUnsubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void,
-  trackMuted: (publication: TrackPublication) => void,
-  trackUnmuted: (publication: TrackPublication) => void,
-  localTrackPublished: (publication: LocalTrackPublication) => void,
-  localTrackUnpublished: (publication: LocalTrackPublication) => void,
+  trackPublished: (publication: RemoteTrackPublication) => void;
+  trackSubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void;
+  trackSubscriptionFailed: (trackSid: string) => void;
+  trackUnpublished: (publication: RemoteTrackPublication) => void;
+  trackUnsubscribed: (track: RemoteTrack, publication: RemoteTrackPublication) => void;
+  trackMuted: (publication: TrackPublication) => void;
+  trackUnmuted: (publication: TrackPublication) => void;
+  localTrackPublished: (publication: LocalTrackPublication) => void;
+  localTrackUnpublished: (publication: LocalTrackPublication) => void;
   /**
    * @deprecated use [[participantMetadataChanged]] instead
    */
-  metadataChanged: (prevMetadata: string | undefined, participant?: any) => void,
-  participantMetadataChanged: (prevMetadata: string | undefined, participant?: any) => void,
-  dataReceived: (payload: Uint8Array, kind: DataPacket_Kind) => void,
-  isSpeakingChanged: (speaking: boolean) => void,
-  connectionQualityChanged: (connectionQuality: ConnectionQuality) => void,
+  metadataChanged: (prevMetadata: string | undefined, participant?: any) => void;
+  participantMetadataChanged: (prevMetadata: string | undefined, participant?: any) => void;
+  dataReceived: (payload: Uint8Array, kind: DataPacket_Kind) => void;
+  isSpeakingChanged: (speaking: boolean) => void;
+  connectionQualityChanged: (connectionQuality: ConnectionQuality) => void;
   trackStreamStateChanged: (
     publication: RemoteTrackPublication,
-    streamState: Track.StreamState
-  ) => void,
+    streamState: Track.StreamState,
+  ) => void;
   trackSubscriptionPermissionChanged: (
     publication: RemoteTrackPublication,
-    status: TrackPublication.SubscriptionStatus
-  ) => void,
-  mediaDevicesError: (error: Error) => void,
-  participantPermissionsChanged: (prevPermissions: ParticipantPermission) => void,
+    status: TrackPublication.SubscriptionStatus,
+  ) => void;
+  mediaDevicesError: (error: Error) => void;
+  participantPermissionsChanged: (prevPermissions: ParticipantPermission) => void;
 };

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -1,10 +1,7 @@
 import { SignalClient } from '../../api/SignalClient';
 import log from '../../logger';
 import { ParticipantInfo } from '../../proto/livekit_models';
-import {
-  UpdateSubscription,
-  UpdateTrackSettings,
-} from '../../proto/livekit_rtc';
+import { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc';
 import { ParticipantEvent, TrackEvent } from '../events';
 import RemoteAudioTrack from '../track/RemoteAudioTrack';
 import RemoteTrackPublication from '../track/RemoteTrackPublication';
@@ -23,10 +20,7 @@ export default class RemoteParticipant extends Participant {
   signalClient: SignalClient;
 
   /** @internal */
-  static fromParticipantInfo(
-    signalClient: SignalClient,
-    pi: ParticipantInfo,
-  ): RemoteParticipant {
+  static fromParticipantInfo(signalClient: SignalClient, pi: ParticipantInfo): RemoteParticipant {
     const rp = new RemoteParticipant(signalClient, pi.sid, pi.identity);
     rp.updateInfo(pi);
     return rp;
@@ -45,12 +39,9 @@ export default class RemoteParticipant extends Participant {
     super.addTrackPublication(publication);
 
     // register action events
-    publication.on(
-      TrackEvent.UpdateSettings,
-      (settings: UpdateTrackSettings) => {
-        this.signalClient.sendUpdateTrackSettings(settings);
-      },
-    );
+    publication.on(TrackEvent.UpdateSettings, (settings: UpdateTrackSettings) => {
+      this.signalClient.sendUpdateTrackSettings(settings);
+    });
     publication.on(TrackEvent.UpdateSubscription, (sub: UpdateSubscription) => {
       sub.participantTracks.forEach((pt) => {
         pt.participantSid = this.sid;
@@ -134,8 +125,14 @@ export default class RemoteParticipant extends Participant {
 
       if (triesLeft === undefined) triesLeft = 20;
       setTimeout(() => {
-        this.addSubscribedMediaTrack(mediaTrack, sid, mediaStream,
-          receiver, adaptiveStreamSettings, triesLeft! - 1);
+        this.addSubscribedMediaTrack(
+          mediaTrack,
+          sid,
+          mediaStream,
+          receiver,
+          adaptiveStreamSettings,
+          triesLeft! - 1,
+        );
       }, 150);
       return;
     }
@@ -220,7 +217,7 @@ export default class RemoteParticipant extends Participant {
 
   /** @internal */
   unpublishTrack(sid: Track.SID, sendUnpublish?: boolean) {
-    const publication = <RemoteTrackPublication> this.tracks.get(sid);
+    const publication = <RemoteTrackPublication>this.tracks.get(sid);
     if (!publication) {
       return;
     }
@@ -250,7 +247,9 @@ export default class RemoteParticipant extends Participant {
         this.emit(ParticipantEvent.TrackUnsubscribed, track, publication);
       }
     }
-    if (sendUnpublish) { this.emit(ParticipantEvent.TrackUnpublished, publication); }
+    if (sendUnpublish) {
+      this.emit(ParticipantEvent.TrackUnpublished, publication);
+    }
   }
 
   /** @internal */

--- a/src/room/participant/publishUtils.test.ts
+++ b/src/room/participant/publishUtils.test.ts
@@ -1,6 +1,4 @@
-import {
-  ScreenSharePresets, VideoPreset, VideoPresets, VideoPresets43,
-} from '../track/options';
+import { ScreenSharePresets, VideoPreset, VideoPresets, VideoPresets43 } from '../track/options';
 import {
   computeDefaultScreenShareSimulcastPresets,
   computeVideoEncodings,
@@ -30,13 +28,11 @@ describe('presetsForResolution', () => {
 
 describe('determineAppropriateEncoding', () => {
   it('uses higher encoding', () => {
-    expect(determineAppropriateEncoding(false, 600, 300))
-      .toEqual(VideoPresets.vga.encoding);
+    expect(determineAppropriateEncoding(false, 600, 300)).toEqual(VideoPresets.vga.encoding);
   });
 
   it('handles portrait', () => {
-    expect(determineAppropriateEncoding(false, 300, 600))
-      .toEqual(VideoPresets.vga.encoding);
+    expect(determineAppropriateEncoding(false, 300, 600)).toEqual(VideoPresets.vga.encoding);
   });
 });
 
@@ -110,9 +106,12 @@ describe('computeVideoEncodings', () => {
 
 describe('customSimulcastLayers', () => {
   it('sorts presets from lowest to highest', () => {
-    const sortedPresets = sortPresets(
-      [VideoPresets.h1440, VideoPresets.h360, VideoPresets.h1080, VideoPresets.h90],
-    ) as Array<VideoPreset>;
+    const sortedPresets = sortPresets([
+      VideoPresets.h1440,
+      VideoPresets.h360,
+      VideoPresets.h1080,
+      VideoPresets.h90,
+    ]) as Array<VideoPreset>;
     expect(sortPresets).not.toBeUndefined();
     expect(sortedPresets[0]).toBe(VideoPresets.h90);
     expect(sortedPresets[1]).toBe(VideoPresets.h360);

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -3,8 +3,11 @@ import { TrackInvalidError } from '../errors';
 import LocalAudioTrack from '../track/LocalAudioTrack';
 import LocalVideoTrack from '../track/LocalVideoTrack';
 import {
-  ScreenSharePresets, TrackPublishOptions,
-  VideoEncoding, VideoPreset, VideoPresets,
+  ScreenSharePresets,
+  TrackPublishOptions,
+  VideoEncoding,
+  VideoPreset,
+  VideoPresets,
   VideoPresets43,
 } from '../track/options';
 
@@ -19,9 +22,7 @@ export function mediaTrackToLocalTrack(
     case 'video':
       return new LocalVideoTrack(mediaStreamTrack, constraints);
     default:
-      throw new TrackInvalidError(
-        `unsupported track type: ${mediaStreamTrack.kind}`,
-      );
+      throw new TrackInvalidError(`unsupported track type: ${mediaStreamTrack.kind}`);
   }
 }
 
@@ -35,27 +36,29 @@ export const presets43 = Object.values(VideoPresets43);
 export const presetsScreenShare = Object.values(ScreenSharePresets);
 
 /* @internal */
-export const defaultSimulcastPresets169 = [
-  VideoPresets.h180,
-  VideoPresets.h360,
-];
+export const defaultSimulcastPresets169 = [VideoPresets.h180, VideoPresets.h360];
 
 /* @internal */
-export const defaultSimulcastPresets43 = [
-  VideoPresets43.h180,
-  VideoPresets43.h360,
-];
+export const defaultSimulcastPresets43 = [VideoPresets43.h180, VideoPresets43.h360];
 
 /* @internal */
 export const computeDefaultScreenShareSimulcastPresets = (fromPreset: VideoPreset) => {
   const layers = [{ scaleResolutionDownBy: 2, fps: 3 }];
-  return layers.map((t) => new VideoPreset(
-    Math.floor(fromPreset.width / t.scaleResolutionDownBy),
-    Math.floor(fromPreset.height / t.scaleResolutionDownBy),
-    Math.max(150_000, Math.floor(fromPreset.encoding.maxBitrate
-      / (t.scaleResolutionDownBy ** 2 * ((fromPreset.encoding.maxFramerate ?? 30) / t.fps)))),
-    t.fps,
-  ));
+  return layers.map(
+    (t) =>
+      new VideoPreset(
+        Math.floor(fromPreset.width / t.scaleResolutionDownBy),
+        Math.floor(fromPreset.height / t.scaleResolutionDownBy),
+        Math.max(
+          150_000,
+          Math.floor(
+            fromPreset.encoding.maxBitrate /
+              (t.scaleResolutionDownBy ** 2 * ((fromPreset.encoding.maxFramerate ?? 30) / t.fps)),
+          ),
+        ),
+        t.fps,
+      ),
+  );
 };
 
 const videoRids = ['q', 'h', 'f'];
@@ -89,15 +92,19 @@ export function computeVideoEncodings(
     return [videoEncoding];
   }
   const original = new VideoPreset(
-    width, height, videoEncoding.maxBitrate, videoEncoding.maxFramerate,
+    width,
+    height,
+    videoEncoding.maxBitrate,
+    videoEncoding.maxFramerate,
   );
   let presets: Array<VideoPreset> = [];
   if (isScreenShare) {
-    presets = sortPresets(options?.screenShareSimulcastLayers)
-      ?? defaultSimulcastLayers(isScreenShare, original);
+    presets =
+      sortPresets(options?.screenShareSimulcastLayers) ??
+      defaultSimulcastLayers(isScreenShare, original);
   } else {
-    presets = sortPresets(options?.videoSimulcastLayers)
-      ?? defaultSimulcastLayers(isScreenShare, original);
+    presets =
+      sortPresets(options?.videoSimulcastLayers) ?? defaultSimulcastLayers(isScreenShare, original);
   }
   let midPreset: VideoPreset | undefined;
   const lowPreset = presets[0];
@@ -116,18 +123,12 @@ export function computeVideoEncodings(
   //      based on other conditions.
   const size = Math.max(width, height);
   if (size >= 960 && midPreset) {
-    return encodingsFromPresets(width, height, [
-      lowPreset, midPreset, original,
-    ]);
+    return encodingsFromPresets(width, height, [lowPreset, midPreset, original]);
   }
   if (size >= 480) {
-    return encodingsFromPresets(width, height, [
-      lowPreset, original,
-    ]);
+    return encodingsFromPresets(width, height, [lowPreset, original]);
   }
-  return encodingsFromPresets(width, height, [
-    original,
-  ]);
+  return encodingsFromPresets(width, height, [original]);
 }
 
 /* @internal */
@@ -155,7 +156,9 @@ export function determineAppropriateEncoding(
 
 /* @internal */
 export function presetsForResolution(
-  isScreenShare: boolean, width: number, height: number,
+  isScreenShare: boolean,
+  width: number,
+  height: number,
 ): VideoPreset[] {
   if (isScreenShare) {
     return presetsScreenShare;
@@ -169,7 +172,8 @@ export function presetsForResolution(
 
 /* @internal */
 export function defaultSimulcastLayers(
-  isScreenShare: boolean, original: VideoPreset,
+  isScreenShare: boolean,
+  original: VideoPreset,
 ): VideoPreset[] {
   if (isScreenShare) {
     return computeDefaultScreenShareSimulcastPresets(original);

--- a/src/room/stats.ts
+++ b/src/room/stats.ts
@@ -122,8 +122,12 @@ export function computeBitrate<T extends ReceiverStats | SenderStats>(
     bytesNow = (currentStats as SenderStats).bytesSent;
     bytesPrev = (prevStats as SenderStats).bytesSent;
   }
-  if (bytesNow === undefined || bytesPrev === undefined
-    || currentStats.timestamp === undefined || prevStats.timestamp === undefined) {
+  if (
+    bytesNow === undefined ||
+    bytesPrev === undefined ||
+    currentStats.timestamp === undefined ||
+    prevStats.timestamp === undefined
+  ) {
     return 0;
   }
   return ((bytesNow - bytesPrev) * 8 * 1000) / (currentStats.timestamp - prevStats.timestamp);

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -14,10 +14,7 @@ export default class LocalAudioTrack extends LocalTrack {
 
   private prevStats?: AudioSenderStats;
 
-  constructor(
-    mediaTrack: MediaStreamTrack,
-    constraints?: MediaTrackConstraints,
-  ) {
+  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints) {
     super(mediaTrack, Track.Kind.Audio, constraints);
     this.checkForSilence();
   }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -16,7 +16,9 @@ export default class LocalTrack extends Track {
   protected reacquireTrack: boolean;
 
   protected constructor(
-    mediaTrack: MediaStreamTrack, kind: Track.Kind, constraints?: MediaTrackConstraints,
+    mediaTrack: MediaStreamTrack,
+    kind: Track.Kind,
+    constraints?: MediaTrackConstraints,
   ) {
     super(mediaTrack, kind);
     this.mediaStreamTrack.addEventListener('ended', this.handleEnded);
@@ -127,10 +129,12 @@ export default class LocalTrack extends Track {
   }
 
   protected get needsReAcquisition(): boolean {
-    return this.mediaStreamTrack.readyState !== 'live'
-      || this.mediaStreamTrack.muted
-      || !this.mediaStreamTrack.enabled
-      || this.reacquireTrack;
+    return (
+      this.mediaStreamTrack.readyState !== 'live' ||
+      this.mediaStreamTrack.muted ||
+      !this.mediaStreamTrack.enabled ||
+      this.reacquireTrack
+    );
   }
 
   protected async handleAppVisibilityChanged() {

--- a/src/room/track/LocalVideoTrack.test.ts
+++ b/src/room/track/LocalVideoTrack.test.ts
@@ -11,9 +11,11 @@ describe('videoLayersFromEncodings', () => {
   });
 
   it('returns single layer for explicit encoding', () => {
-    const layers = videoLayersFromEncodings(640, 360, [{
-      maxBitrate: 200_000,
-    }]);
+    const layers = videoLayersFromEncodings(640, 360, [
+      {
+        maxBitrate: 200_000,
+      },
+    ]);
     expect(layers).toHaveLength(1);
     expect(layers[0].quality).toBe(VideoQuality.HIGH);
     expect(layers[0].bitrate).toBe(200_000);

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -17,10 +17,7 @@ export default class LocalVideoTrack extends LocalTrack {
 
   private encodings?: RTCRtpEncodingParameters[];
 
-  constructor(
-    mediaTrack: MediaStreamTrack,
-    constraints?: MediaTrackConstraints,
-  ) {
+  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints) {
     super(mediaTrack, Track.Kind.Video, constraints);
   }
 
@@ -95,8 +92,7 @@ export default class LocalVideoTrack extends LocalTrack {
           rid: v.rid ?? '',
           retransmittedPacketsSent: v.retransmittedPacketsSent,
           qualityLimitationReason: v.qualityLimitationReason,
-          qualityLimitationResolutionChanges:
-            v.qualityLimitationResolutionChanges,
+          qualityLimitationResolutionChanges: v.qualityLimitationResolutionChanges,
         };
 
         // locate the appropriate remote-inbound-rtp item
@@ -183,7 +179,11 @@ export default class LocalVideoTrack extends LocalTrack {
       if (encoding.active !== subscribedQuality.enabled) {
         hasChanged = true;
         encoding.active = subscribedQuality.enabled;
-        log.debug(`setting layer ${subscribedQuality.quality} to ${encoding.active ? 'enabled' : 'disabled'}`);
+        log.debug(
+          `setting layer ${subscribedQuality.quality} to ${
+            encoding.active ? 'enabled' : 'disabled'
+          }`,
+        );
 
         // FireFox does not support setting encoding.active to false, so we
         // have a workaround of lowering its bitrate and resolution to the min.
@@ -268,13 +268,15 @@ export function videoLayersFromEncodings(
 ): VideoLayer[] {
   // default to a single layer, HQ
   if (!encodings) {
-    return [{
-      quality: VideoQuality.HIGH,
-      width,
-      height,
-      bitrate: 0,
-      ssrc: 0,
-    }];
+    return [
+      {
+        quality: VideoQuality.HIGH,
+        width,
+        height,
+        bitrate: 0,
+        ssrc: 0,
+      },
+    ];
   }
   return encodings.map((encoding) => {
     const scale = encoding.scaleResolutionDownBy ?? 1;

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -7,11 +7,7 @@ export default class RemoteAudioTrack extends RemoteTrack {
 
   private elementVolume: number;
 
-  constructor(
-    mediaTrack: MediaStreamTrack,
-    sid: string,
-    receiver?: RTCRtpReceiver,
-  ) {
+  constructor(mediaTrack: MediaStreamTrack, sid: string, receiver?: RTCRtpReceiver) {
     super(mediaTrack, sid, Track.Kind.Audio, receiver);
     this.elementVolume = 1;
   }
@@ -33,8 +29,8 @@ export default class RemoteAudioTrack extends RemoteTrack {
     return this.elementVolume;
   }
 
-  attach(): HTMLMediaElement
-  attach(element: HTMLMediaElement): HTMLMediaElement
+  attach(): HTMLMediaElement;
+  attach(element: HTMLMediaElement): HTMLMediaElement;
   attach(element?: HTMLMediaElement): HTMLMediaElement {
     if (!element) {
       element = super.attach();

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -1,9 +1,6 @@
 import log from '../../logger';
 import { TrackInfo, VideoQuality } from '../../proto/livekit_models';
-import {
-  UpdateSubscription,
-  UpdateTrackSettings,
-} from '../../proto/livekit_rtc';
+import { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc';
 import { TrackEvent } from '../events';
 import RemoteVideoTrack from './RemoteVideoTrack';
 import { Track } from './Track';
@@ -35,12 +32,14 @@ export default class RemoteTrackPublication extends TrackPublication {
     const sub: UpdateSubscription = {
       trackSids: [this.trackSid],
       subscribe: this.subscribed,
-      participantTracks: [{
-        // sending an empty participant id since TrackPublication doesn't keep it
-        // this is filled in by the participant that receives this message
-        participantSid: '',
-        trackSids: [this.trackSid],
-      }],
+      participantTracks: [
+        {
+          // sending an empty participant id since TrackPublication doesn't keep it
+          // this is filled in by the participant that receives this message
+          participantSid: '',
+          trackSids: [this.trackSid],
+        },
+      ],
     };
     this.emit(TrackEvent.UpdateSubscription, sub);
   }
@@ -108,11 +107,15 @@ export default class RemoteTrackPublication extends TrackPublication {
     if (!this.isManualOperationAllowed()) {
       return;
     }
-    if (this.videoDimensions?.width === dimensions.width
-        && this.videoDimensions?.height === dimensions.height) {
+    if (
+      this.videoDimensions?.width === dimensions.width &&
+      this.videoDimensions?.height === dimensions.height
+    ) {
       return;
     }
-    if (this.track instanceof RemoteVideoTrack) { this.videoDimensions = dimensions; }
+    if (this.track instanceof RemoteVideoTrack) {
+      this.videoDimensions = dimensions;
+    }
     this.currentVideoQuality = undefined;
 
     this.emitTrackUpdate();
@@ -172,7 +175,11 @@ export default class RemoteTrackPublication extends TrackPublication {
   };
 
   protected handleVideoDimensionsChange = (dimensions: Track.Dimensions) => {
-    log.debug('adaptivestream video dimensions', this.trackSid, `${dimensions.width}x${dimensions.height}`);
+    log.debug(
+      'adaptivestream video dimensions',
+      this.trackSid,
+      `${dimensions.width}x${dimensions.height}`,
+    );
     this.videoDimensions = dimensions;
     this.emitTrackUpdate();
   };

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -2,7 +2,10 @@ import { debounce } from 'ts-debounce';
 import { TrackEvent } from '../events';
 import { computeBitrate, monitorFrequency, VideoReceiverStats } from '../stats';
 import {
-  getIntersectionObserver, getResizeObserver, isMobile, ObservableMediaElement,
+  getIntersectionObserver,
+  getResizeObserver,
+  isMobile,
+  ObservableMediaElement,
 } from '../utils';
 import RemoteTrack from './RemoteTrack';
 import { attachToElement, detachTrack, Track } from './Track';
@@ -63,18 +66,17 @@ export default class RemoteVideoTrack extends RemoteTrack {
 
     // It's possible attach is called multiple times on an element. When that's
     // the case, we'd want to avoid adding duplicate elementInfos
-    if (this.adaptiveStreamSettings
-      && this.elementInfos.find((info) => info.element === element) === undefined
+    if (
+      this.adaptiveStreamSettings &&
+      this.elementInfos.find((info) => info.element === element) === undefined
     ) {
       this.elementInfos.push({
         element,
         visible: true, // default visible
       });
 
-      (element as ObservableMediaElement)
-        .handleResize = this.debouncedHandleResize;
-      (element as ObservableMediaElement)
-        .handleVisibilityChanged = this.handleVisibilityChanged;
+      (element as ObservableMediaElement).handleResize = this.debouncedHandleResize;
+      (element as ObservableMediaElement).handleVisibilityChanged = this.handleVisibilityChanged;
 
       getIntersectionObserver().observe(element);
       getResizeObserver().observe(element);

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -91,7 +91,8 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
     if (element instanceof HTMLAudioElement) {
       // manually play audio to detect audio playback status
-      element.play()
+      element
+        .play()
         .then(() => {
           this.emit(TrackEvent.AudioPlaybackStarted);
         })
@@ -154,7 +155,7 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
   private recycleElement(element: HTMLMediaElement) {
     if (element instanceof HTMLAudioElement) {
-    // we only need to re-use a single element
+      // we only need to re-use a single element
       let shouldCache = true;
       element.pause();
       recycledElements.forEach((e) => {
@@ -222,10 +223,7 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
 }
 
 /** @internal */
-export function detachTrack(
-  track: MediaStreamTrack,
-  element: HTMLMediaElement,
-) {
+export function detachTrack(track: MediaStreamTrack, element: HTMLMediaElement) {
   if (element.srcObject instanceof MediaStream) {
     const mediaStream = element.srcObject;
     mediaStream.removeTrack(track);
@@ -329,15 +327,15 @@ export namespace Track {
 }
 
 export type TrackEventCallbacks = {
-  message: () => void,
-  muted: (track?: any) => void,
-  unmuted: (track?: any) => void,
-  ended: (track?: any) => void,
-  updateSettings: () => void,
-  updateSubscription: () => void,
-  audioPlaybackStarted: () => void,
-  audioPlaybackFailed: (error: Error) => void,
-  audioSilenceDetected: () => void,
-  visibilityChanged: (visible: boolean, track?: any) => void,
-  videoDimensionsChanged: (dimensions: Track.Dimensions, track?: any) => void,
+  message: () => void;
+  muted: (track?: any) => void;
+  unmuted: (track?: any) => void;
+  ended: (track?: any) => void;
+  updateSettings: () => void;
+  updateSubscription: () => void;
+  audioPlaybackStarted: () => void;
+  audioPlaybackFailed: (error: Error) => void;
+  audioSilenceDetected: () => void;
+  visibilityChanged: (visible: boolean, track?: any) => void;
+  videoDimensionsChanged: (dimensions: Track.Dimensions, track?: any) => void;
 };

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -5,8 +5,11 @@ import LocalAudioTrack from './LocalAudioTrack';
 import LocalTrack from './LocalTrack';
 import LocalVideoTrack from './LocalVideoTrack';
 import {
-  AudioCaptureOptions, CreateLocalTracksOptions, ScreenShareCaptureOptions,
-  VideoCaptureOptions, VideoPresets,
+  AudioCaptureOptions,
+  CreateLocalTracksOptions,
+  ScreenShareCaptureOptions,
+  VideoCaptureOptions,
+  VideoPresets,
 } from './options';
 import { Track } from './Track';
 import { constraintsForOptions, mergeDefaultOptions } from './utils';
@@ -27,9 +30,7 @@ export async function createLocalTracks(
 
   const opts = mergeDefaultOptions(options, audioDefaults, videoDefaults);
   const constraints = constraintsForOptions(opts);
-  const stream = await navigator.mediaDevices.getUserMedia(
-    constraints,
-  );
+  const stream = await navigator.mediaDevices.getUserMedia(constraints);
   return stream.getTracks().map((mediaStreamTrack) => {
     const isAudio = mediaStreamTrack.kind === 'audio';
     let trackOptions = isAudio ? options!.audio : options!.video;

--- a/src/room/track/defaults.ts
+++ b/src/room/track/defaults.ts
@@ -1,6 +1,10 @@
 import {
-  AudioCaptureOptions, AudioPresets, ScreenSharePresets,
-  TrackPublishDefaults, VideoCaptureOptions, VideoPresets,
+  AudioCaptureOptions,
+  AudioPresets,
+  ScreenSharePresets,
+  TrackPublishDefaults,
+  VideoCaptureOptions,
+  VideoPresets,
 } from './options';
 
 export const publishDefaults: TrackPublishDefaults = {

--- a/src/room/track/types.ts
+++ b/src/room/track/types.ts
@@ -16,5 +16,5 @@ export type AdaptiveStreamSettings = {
    * Note: this might significantly increase the bandwidth consumed by people
    * streaming on high definition screens.
    */
-  pixelDensity?: number | 'screen'
+  pixelDensity?: number | 'screen';
 };

--- a/src/room/track/utils.test.ts
+++ b/src/room/track/utils.test.ts
@@ -1,6 +1,4 @@
-import {
-  AudioCaptureOptions, VideoCaptureOptions, VideoPresets,
-} from './options';
+import { AudioCaptureOptions, VideoCaptureOptions, VideoPresets } from './options';
 import { constraintsForOptions, mergeDefaultOptions } from './utils';
 
 describe('mergeDefaultOptions', () => {
@@ -28,26 +26,38 @@ describe('mergeDefaultOptions', () => {
   });
 
   it('accepts true for options', () => {
-    const opts = mergeDefaultOptions({
-      audio: true,
-    }, audioDefaults, videoDefaults);
+    const opts = mergeDefaultOptions(
+      {
+        audio: true,
+      },
+      audioDefaults,
+      videoDefaults,
+    );
     expect(opts.audio).toEqual(audioDefaults);
     expect(opts.video).toEqual(undefined);
   });
 
   it('enables overriding specific fields', () => {
-    const opts = mergeDefaultOptions({
-      audio: { channelCount: 1 },
-    }, audioDefaults, videoDefaults);
+    const opts = mergeDefaultOptions(
+      {
+        audio: { channelCount: 1 },
+      },
+      audioDefaults,
+      videoDefaults,
+    );
     const audioOpts = opts.audio as AudioCaptureOptions;
     expect(audioOpts.channelCount).toEqual(1);
     expect(audioOpts.autoGainControl).toEqual(true);
   });
 
   it('does not override explicit false', () => {
-    const opts = mergeDefaultOptions({
-      audio: { autoGainControl: false },
-    }, audioDefaults, videoDefaults);
+    const opts = mergeDefaultOptions(
+      {
+        audio: { autoGainControl: false },
+      },
+      audioDefaults,
+      videoDefaults,
+    );
     const audioOpts = opts.audio as AudioCaptureOptions;
     expect(audioOpts.autoGainControl).toEqual(false);
   });
@@ -84,7 +94,14 @@ describe('constraintsForOptions', () => {
       },
     });
     const videoOpts = constraints.video as MediaTrackConstraints;
-    expect(Object.keys(videoOpts)).toEqual(['width', 'height', 'frameRate', 'aspectRatio', 'facingMode', 'deviceId']);
+    expect(Object.keys(videoOpts)).toEqual([
+      'width',
+      'height',
+      'frameRate',
+      'aspectRatio',
+      'facingMode',
+      'deviceId',
+    ]);
     expect(videoOpts.width).toEqual(VideoPresets.hd.resolution.width);
     expect(videoOpts.height).toEqual(VideoPresets.hd.resolution.height);
     expect(videoOpts.frameRate).toEqual(VideoPresets.hd.resolution.frameRate);

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -1,8 +1,5 @@
 import { sleep } from '../utils';
-import {
-  AudioCaptureOptions, CreateLocalTracksOptions,
-  VideoCaptureOptions,
-} from './options';
+import { AudioCaptureOptions, CreateLocalTracksOptions, VideoCaptureOptions } from './options';
 import { AudioTrack } from './types';
 
 export function mergeDefaultOptions(
@@ -18,12 +15,16 @@ export function mergeDefaultOptions(
 
   // use defaults
   if (opts.audio) {
-    mergeObjectWithoutOverwriting(opts.audio as Record<string, unknown>,
-      audioDefaults as Record<string, unknown>);
+    mergeObjectWithoutOverwriting(
+      opts.audio as Record<string, unknown>,
+      audioDefaults as Record<string, unknown>,
+    );
   }
   if (opts.video) {
-    mergeObjectWithoutOverwriting(opts.video as Record<string, unknown>,
-      videoDefaults as Record<string, unknown>);
+    mergeObjectWithoutOverwriting(
+      opts.video as Record<string, unknown>,
+      videoDefaults as Record<string, unknown>,
+    );
   }
   return opts;
 }
@@ -80,10 +81,7 @@ export function constraintsForOptions(options: CreateLocalTracksOptions): MediaS
  * This function detects silence on a given [[Track]] instance.
  * Returns true if the track seems to be entirely silent.
  */
-export async function detectSilence(
-  track: AudioTrack,
-  timeOffset = 200,
-): Promise<boolean> {
+export async function detectSilence(track: AudioTrack, timeOffset = 200): Promise<boolean> {
   const ctx = getNewAudioContext();
   if (ctx) {
     const analyser = ctx.createAnalyser();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,6 +2033,11 @@ eslint-config-airbnb@^18.2.0:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4277,7 +4277,7 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.5.1:
+prettier@^2.5.1, prettier@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
   integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==


### PR DESCRIPTION
from https://prettier.io/docs/en/comparison.html

> Linters have two categories of rules:
> - Formatting rules: eg: [max-len](https://eslint.org/docs/rules/max-len), [no-mixed-spaces-and-tabs](https://eslint.org/docs/rules/no-mixed-spaces-and-tabs), [keyword-spacing](https://eslint.org/docs/rules/keyword-spacing), [comma-style](https://eslint.org/docs/rules/comma-style)…
> Prettier alleviates the need for this whole category of rules! Prettier is going to reprint the entire program from scratch in a consistent way, so it’s not possible for the programmer to make a mistake there anymore :)
> - Code-quality rules: eg [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars), [no-extra-bind](https://eslint.org/docs/rules/no-extra-bind), [no-implicit-globals](https://eslint.org/docs/rules/no-implicit-globals), [prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors)…
> Prettier does nothing to help with those kind of rules. They are also the most important ones provided by linters as they are likely to catch real bugs with your code!

> **In other words, use Prettier for formatting and linters for catching bugs!**