### PR TITLE
force video play when attaching

### DIFF
--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -212,6 +212,10 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
       // https://developer.apple.com/forums/thread/690523
       setTimeout(() => {
         element.srcObject = mediaStream;
+        // Safari 15 sometimes fails to start a video
+        // when the window is backgrounded before the first frame is drawn
+        // manually calling play here seems to fix that
+        element.play().catch(() => { /* do nothing */ });
       }, 0);
     }
   }


### PR DESCRIPTION
I'm not sure if this will fix all our Safari related problems, but it should mitigate the issues @ackermann reported. 

I was able to reproduce videos not starting when Safari was quickly switched to background shortly before rendering the first video frame. This PR fixes this specific problem.

Still wasn't able to reproduce a freeze frame in Safari.