### PR TITLE
change loglevel import from default to wildcard with alias

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import log from 'loglevel';
+import * as log from 'loglevel';
 
 export type LogLevelDesc = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
 


### PR DESCRIPTION
supposed to address issues people were seeing when trying to build their apps with error logs like 

```
Uncaught TypeError: loglevel_1.default.getLogger is not a function
    js index.js:287
    __require index.js:10
    js index.js:15554
    __require index.js:10
    js index.js:15612
    js index.js:15677
 ```