### PR TITLE
refactor all log messages to use same format, overhaul logExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,16 @@ const room = new Room({
   // default capture settings
   videoCaptureDefaults: {
     resolution: VideoPresets.hd.resolution,
-  }
+  },
 });
 
 // set up event listeners
 room
-    .on(RoomEvent.TrackSubscribed, handleTrackSubscribed)
-    .on(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed)
-    .on(RoomEvent.ActiveSpeakersChanged, handleActiveSpeakerChange)
-    .on(RoomEvent.Disconnected, handleDisconnect)
-    .on(RoomEvent.LocalTrackUnpublished, handleLocalTrackUnpublished);
+  .on(RoomEvent.TrackSubscribed, handleTrackSubscribed)
+  .on(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed)
+  .on(RoomEvent.ActiveSpeakersChanged, handleActiveSpeakerChange)
+  .on(RoomEvent.Disconnected, handleDisconnect)
+  .on(RoomEvent.LocalTrackUnpublished, handleLocalTrackUnpublished);
 
 // connect to room
 await room.connect('ws://localhost:7800', token, {
@@ -80,7 +80,7 @@ await room.localParticipant.enableCameraAndMicrophone();
 function handleTrackSubscribed(
   track: RemoteTrack,
   publication: RemoteTrackPublication,
-  participant: RemoteParticipant
+  participant: RemoteParticipant,
 ) {
   if (track.kind === Track.Kind.Video || track.kind === Track.Kind.Audio) {
     // attach it to a new HTMLVideoElement or HTMLAudioElement
@@ -92,16 +92,13 @@ function handleTrackSubscribed(
 function handleTrackUnsubscribed(
   track: RemoteTrack,
   publication: RemoteTrackPublication,
-  participant: RemoteParticipant
+  participant: RemoteParticipant,
 ) {
   // remove tracks from all attached elements
   track.detach();
 }
 
-function handleLocalTrackUnpublished(
-  track: LocalTrackPublication,
-  participant: LocalParticipant,
-) {
+function handleLocalTrackUnpublished(track: LocalTrackPublication, participant: LocalParticipant) {
   // when local tracks are ended, update UI to remove them from rendering
   track.detach();
 }
@@ -148,7 +145,7 @@ if (p) {
   if (p.isCameraEnabled) {
     const track = p.getTrack(Track.Source.Camera);
     if (track?.isSubscribed) {
-      const videoElement = track.videoTrack?.attach()
+      const videoElement = track.videoTrack?.attach();
       // do something with the element
     }
   }
@@ -174,19 +171,18 @@ const tracks = await createLocalTracks({
 LiveKit lets you publish any track as long as it can be represented by a MediaStreamTrack. You can specify a name on the track in order to identify it later.
 
 ```typescript
-
 const pub = await room.localParticipant.publishTrack(mediaStreamTrack, {
   name: 'mytrack',
   simulcast: true,
   // if this should be treated like a camera feed, tag it as such
   // supported known sources are .Camera, .Microphone, .ScreenShare
   source: Track.Source.Camera,
-})
+});
 
 // you may mute or unpublish the track later
 pub.setMuted(true);
 
-room.localParticipant.unpublishTrack(mediaStreamTrack)
+room.localParticipant.unpublishTrack(mediaStreamTrack);
 ```
 
 ### Device management APIs
@@ -202,7 +198,7 @@ We use the same deviceId as one returned by [MediaDevices.enumerateDevices()](ht
 const devices = await Room.getLocalDevices('audioinput');
 
 // select last device
-const device = devices[devices.length-1];
+const device = devices[devices.length - 1];
 
 // in the current room, switch to the selected device and set
 // it as default audioinput in the future.
@@ -223,9 +219,9 @@ When creating tracks using LiveKit APIs (`connect`, `createLocalTracks`, `setCam
 
 You can use the helper `MediaDeviceFailure.getFailure(error)` to determine specific reason for the error.
 
-* `PermissionDenied` - the user disallowed capturing devices
-* `NotFound` - the particular device isn't available
-* `DeviceInUse` - device is in use by another process (happens on Windows)
+- `PermissionDenied` - the user disallowed capturing devices
+- `NotFound` - the particular device isn't available
+- `DeviceInUse` - device is in use by another process (happens on Windows)
 
 These distinctions enables you to provide more specific messaging to the user.
 
@@ -258,6 +254,16 @@ room.on(RoomEvent.AudioPlaybackStatusChanged, () => {
 ### Configuring logging
 
 This library uses [loglevel](https://github.com/pimterry/loglevel) for its internal logs. You can change the effective log level with the `logLevel` field in `ConnectOptions`.
+The method `setLogExtension` allows to hook into the livekit internal logs and send them to some third party logging service
+
+```ts
+setLogExtension((level: LogLevel, msg: string, context: object) => {
+  const enhancedContext = { ...context, timeStamp: Date.now() };
+  if (level >= LogLevel.debug) {
+    console.log(level, msg, enhancedContext);
+  }
+});
+```
 
 ## Examples
 

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -55,7 +55,7 @@ const appActions = {
     const shouldPublish = (<HTMLInputElement>$('publish-option')).checked;
     const preferredCodec = (<HTMLSelectElement>$('preferred-codec')).value as VideoCodec;
 
-    setLogLevel(LogLevel.DEBUG);
+    setLogLevel(LogLevel.debug);
     updateSearchParams(url, token);
 
     const roomOpts: RoomOptions = {

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -17,8 +17,8 @@ import {
   VideoCaptureOptions,
   VideoPresets,
   VideoCodec,
-  setLogExtension,
 } from '../src/index';
+import { LogLevel } from '../src/logger';
 
 const $ = (id: string) => document.getElementById(id);
 
@@ -54,11 +54,8 @@ const appActions = {
     const publishOnly = (<HTMLInputElement>$('publish-only')).checked;
     const shouldPublish = (<HTMLInputElement>$('publish-option')).checked;
     const preferredCodec = (<HTMLSelectElement>$('preferred-codec')).value as VideoCodec;
-    setLogExtension((level, ...msg) => {
-      // use this to send livekit logs to other logging services
-      // console.info(level, ...msg);
-    });
-    setLogLevel('debug');
+
+    setLogLevel(LogLevel.debug);
     updateSearchParams(url, token);
 
     const roomOpts: RoomOptions = {

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -55,7 +55,7 @@ const appActions = {
     const shouldPublish = (<HTMLInputElement>$('publish-option')).checked;
     const preferredCodec = (<HTMLSelectElement>$('preferred-codec')).value as VideoCodec;
 
-    setLogLevel(LogLevel.debug);
+    setLogLevel(LogLevel.DEBUG);
     updateSearchParams(url, token);
 
     const roomOpts: RoomOptions = {

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -62,7 +62,7 @@ function canPassThroughQueue(req: SignalRequest): boolean {
   const canPass =
     Object.keys(req).find((key) => passThroughQueueSignals.includes(key as keyof SignalRequest)) !==
     undefined;
-  log.trace('request allowed to bypass queue:', canPass, req);
+  log.trace('request allowed to bypass queue:', { canPass, req });
   return canPass;
 }
 
@@ -153,7 +153,7 @@ export class SignalClient {
     const params = createConnectionParams(token, clientInfo, opts);
 
     return new Promise<JoinResponse | void>((resolve, reject) => {
-      log.debug('connecting to', url + params);
+      log.debug(`connecting to ${url + params}`);
       this.ws = undefined;
       const ws = new WebSocket(url + params);
       ws.binaryType = 'arraybuffer';
@@ -195,7 +195,7 @@ export class SignalClient {
         } else if (ev.data instanceof ArrayBuffer) {
           msg = SignalResponse.decode(new Uint8Array(ev.data));
         } else {
-          log.error('could not decode websocket message', typeof ev.data);
+          log.error(`could not decode websocket message: ${typeof ev.data}`);
           return;
         }
 
@@ -219,7 +219,7 @@ export class SignalClient {
       ws.onclose = (ev: CloseEvent) => {
         if (!this.isConnected || this.ws !== ws) return;
 
-        log.debug('websocket connection closed', ev.reason);
+        log.debug(`websocket connection closed: ${ev.reason}`);
         this.isConnected = false;
         if (this.onClose) this.onClose(ev.reason);
         if (this.ws === ws) {
@@ -341,7 +341,7 @@ export class SignalClient {
         this.ws.send(SignalRequest.encode(req).finish());
       }
     } catch (e) {
-      log.error('error sending signal message', e);
+      log.error('error sending signal message', { error: e });
     }
   }
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -52,7 +52,7 @@ export async function connect(url: string, token: string, options?: ConnectOptio
           await room.localParticipant.enableCameraAndMicrophone();
         } catch (e) {
           const errKind = MediaDeviceFailure.getFailure(e);
-          log.warn('received error while creating media', errKind);
+          log.warn('received error while creating media', { error: errKind });
           if (e instanceof Error) {
             log.warn(e.message);
           }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,11 +1,12 @@
 import * as log from 'loglevel';
 
 export enum LogLevel {
-  trace = 0,
-  debug = 1,
-  info = 2,
-  warn = 3,
-  error = 4,
+  TRACE = 0,
+  DEBUG = 1,
+  INFO = 2,
+  WARN = 3,
+  ERROR = 4,
+  SILENT = 5,
 }
 
 type StructuredLogger = {
@@ -18,7 +19,7 @@ type StructuredLogger = {
 
 const livekitLogger = log.getLogger('livekit');
 
-livekitLogger.setLevel(LogLevel.info);
+livekitLogger.setLevel(LogLevel.INFO);
 
 export default livekitLogger as StructuredLogger;
 
@@ -39,7 +40,7 @@ export function setLogExtension(extension: LogExtension) {
     const rawMethod = originalFactory(methodName, logLevel, loggerName);
 
     const configLevel = livekitLogger.getLevel();
-    const needLog = logLevel >= configLevel;
+    const needLog = logLevel >= configLevel && logLevel < LogLevel.silent;
 
     return (msg, context?: [msg: string, context: object]) => {
       if (context) rawMethod(msg, context);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,12 +1,11 @@
 import * as log from 'loglevel';
 
 export enum LogLevel {
-  TRACE = 0,
-  DEBUG = 1,
-  INFO = 2,
-  WARN = 3,
-  ERROR = 4,
-  SILENT = 5,
+  trace = 0,
+  debug = 1,
+  info = 2,
+  warn = 3,
+  error = 4,
 }
 
 type StructuredLogger = {
@@ -19,7 +18,7 @@ type StructuredLogger = {
 
 const livekitLogger = log.getLogger('livekit');
 
-livekitLogger.setLevel(LogLevel.INFO);
+livekitLogger.setLevel(LogLevel.info);
 
 export default livekitLogger as StructuredLogger;
 
@@ -40,7 +39,7 @@ export function setLogExtension(extension: LogExtension) {
     const rawMethod = originalFactory(methodName, logLevel, loggerName);
 
     const configLevel = livekitLogger.getLevel();
-    const needLog = logLevel >= configLevel && logLevel < LogLevel.silent;
+    const needLog = logLevel >= configLevel;
 
     return (msg, context?: [msg: string, context: object]) => {
       if (context) rawMethod(msg, context);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,6 +6,7 @@ export enum LogLevel {
   info = 2,
   warn = 3,
   error = 4,
+  silent = 5,
 }
 
 type StructuredLogger = {
@@ -39,7 +40,7 @@ export function setLogExtension(extension: LogExtension) {
     const rawMethod = originalFactory(methodName, logLevel, loggerName);
 
     const configLevel = livekitLogger.getLevel();
-    const needLog = logLevel >= configLevel;
+    const needLog = logLevel >= configLevel && logLevel < LogLevel.silent;
 
     return (msg, context?: [msg: string, context: object]) => {
       if (context) rawMethod(msg, context);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,43 +1,51 @@
 import * as log from 'loglevel';
 
-export type LogLevelDesc = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent';
-
 export enum LogLevel {
-  trace = 'trace',
-  debug = 'debug',
-  info = 'info',
-  warn = 'warn',
-  error = 'error',
-  silent = 'silent',
+  trace = 0,
+  debug = 1,
+  info = 2,
+  warn = 3,
+  error = 4,
 }
+
+type StructuredLogger = {
+  trace: (msg: string, context?: object) => void;
+  debug: (msg: string, context?: object) => void;
+  info: (msg: string, context?: object) => void;
+  warn: (msg: string, context?: object) => void;
+  error: (msg: string, context?: object) => void;
+};
 
 const livekitLogger = log.getLogger('livekit');
 
 livekitLogger.setLevel(LogLevel.info);
 
-export default livekitLogger;
+export default livekitLogger as StructuredLogger;
 
-export function setLogLevel(level: LogLevel | LogLevelDesc) {
+export function setLogLevel(level: LogLevel) {
   livekitLogger.setLevel(level);
 }
 
-export type LogExtension = (level: log.LogLevelNumbers, ...msg: any[]) => void;
+export type LogExtension = (level: LogLevel, msg: string, context?: object) => void;
 
+/**
+ * use this to hook into the logging function to allow sending internal livekit logs to third party services
+ * if set, the browser logs will lose their stacktrace information (see https://github.com/pimterry/loglevel#writing-plugins)
+ */
 export function setLogExtension(extension: LogExtension) {
   const originalFactory = livekitLogger.methodFactory;
 
   livekitLogger.methodFactory = (methodName, logLevel, loggerName) => {
     const rawMethod = originalFactory(methodName, logLevel, loggerName);
 
-    // @ts-ignore
-    const levelVal = livekitLogger.levels[methodName.toUpperCase()];
     const configLevel = livekitLogger.getLevel();
-    const needLog = levelVal >= configLevel;
+    const needLog = logLevel >= configLevel;
 
-    return (...args) => {
-      rawMethod(...args);
+    return (msg, context?: [msg: string, context: object]) => {
+      if (context) rawMethod(msg, context);
+      else rawMethod(msg);
       if (needLog) {
-        extension(logLevel, ...args);
+        extension(logLevel, msg, context);
       }
     };
   };

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import { LogLevel, LogLevelDesc } from './logger';
+import { LogLevel } from './logger';
 import {
   AudioCaptureOptions,
   CreateLocalTracksOptions,
@@ -100,7 +100,7 @@ export interface ConnectOptions extends CreateLocalTracksOptions {
   dynacast?: boolean;
 
   /** configures LiveKit internal log level */
-  logLevel?: LogLevel | LogLevelDesc;
+  logLevel?: LogLevel;
 
   /**
    * set ICE servers. When deployed correctly, LiveKit automatically uses the built-in TURN servers

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -187,7 +187,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   connect = async (url: string, token: string, opts?: RoomConnectOptions) => {
     // guard against calling connect
     if (this.state !== RoomState.Disconnected) {
-      log.warn('already connected to room', this.name);
+      log.warn(`already connected to room ${this.name}`);
       return;
     }
 
@@ -488,7 +488,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private handleRestarted = async (joinResponse: JoinResponse) => {
-    log.debug('reconnected to server region', joinResponse.serverRegion);
+    log.debug(`reconnected to server region ${joinResponse.serverRegion}`);
     this.state = RoomState.Connected;
     this.emit(RoomEvent.Reconnected);
     this.emit(RoomEvent.StateChanged, this.state);
@@ -892,7 +892,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     event: E,
     ...args: Parameters<RoomEventCallbacks[E]>
   ): boolean {
-    log.debug('room event', event, ...args);
+    log.debug('room event', { event, args });
     return super.emit(event, ...args);
   }
 }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -137,7 +137,7 @@ export default class LocalParticipant extends Participant {
    * way to manage the common tracks (camera, mic, or screen share)
    */
   private async setTrackEnabled(source: Track.Source, enabled: boolean): Promise<void> {
-    log.debug('setTrackEnabled', source, enabled);
+    log.debug('setTrackEnabled', { source, enabled });
     const track = this.getTrack(source);
     if (enabled) {
       if (track) {
@@ -145,7 +145,7 @@ export default class LocalParticipant extends Participant {
       } else {
         let localTrack: LocalTrack | undefined;
         if (this.pendingPublishing.has(source)) {
-          log.info('skipping duplicate published source', source);
+          log.info('skipping duplicate published source', { source });
           // no-op it's already been requested
           return;
         }
@@ -420,7 +420,7 @@ export default class LocalParticipant extends Participant {
     if (!this.engine.publisher) {
       throw new UnexpectedConnectionState('publisher is closed');
     }
-    log.debug(`publishing ${track.kind} with encodings`, encodings, ti);
+    log.debug(`publishing ${track.kind} with encodings`, { encodings, ti });
     const transceiverInit: RTCRtpTransceiverInit = { direction: 'sendonly' };
     if (encodings) {
       transceiverInit.sendEncodings = encodings;
@@ -456,14 +456,10 @@ export default class LocalParticipant extends Participant {
     // look through all published tracks to find the right ones
     const publication = this.getPublicationForTrack(track);
 
-    log.debug('unpublishTrack', 'unpublishing track', track);
+    log.debug('unpublishing track', { track });
 
     if (!publication || !publication.track) {
-      log.warn(
-        'unpublishTrack',
-        'track was not unpublished because no publication was found',
-        track,
-      );
+      log.warn('track was not unpublished because no publication was found', { track });
       return null;
     }
 
@@ -490,7 +486,7 @@ export default class LocalParticipant extends Participant {
             this.engine.publisher?.pc.removeTrack(sender);
             this.engine.negotiate();
           } catch (e) {
-            log.warn('unpublishTrack', 'failed to remove track', e);
+            log.warn('failed to remove track', { error: e });
           }
         }
       });
@@ -618,11 +614,10 @@ export default class LocalParticipant extends Participant {
     }
     const pub = this.videoTracks.get(update.trackSid);
     if (!pub) {
-      log.warn(
-        'handleSubscribedQualityUpdate',
-        'received subscribed quality update for unknown track',
-        update.trackSid,
-      );
+      log.warn('received subscribed quality update for unknown track', {
+        method: 'handleSubscribedQualityUpdate',
+        sid: update.trackSid,
+      });
       return;
     }
     pub.videoTrack?.setPublishingLayers(update.subscribedQualities);
@@ -631,11 +626,10 @@ export default class LocalParticipant extends Participant {
   private handleLocalTrackUnpublished = (unpublished: TrackUnpublishedResponse) => {
     const track = this.tracks.get(unpublished.trackSid);
     if (!track) {
-      log.warn(
-        'handleLocalTrackUnpublished',
-        'received unpublished event for unknown track',
-        unpublished.trackSid,
-      );
+      log.warn('received unpublished event for unknown track', {
+        method: 'handleLocalTrackUnpublished',
+        trackSid: unpublished.trackSid,
+      });
       return;
     }
     this.unpublishTrack(track.track!);

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -420,7 +420,7 @@ export default class LocalParticipant extends Participant {
     if (!this.engine.publisher) {
       throw new UnexpectedConnectionState('publisher is closed');
     }
-    log.debug(`publishing ${track.kind} with encodings`, { encodings, ti });
+    log.debug(`publishing ${track.kind} with encodings`, { encodings, trackInfo: ti });
     const transceiverInit: RTCRtpTransceiverInit = { direction: 'sendonly' };
     if (encodings) {
       transceiverInit.sendEncodings = encodings;
@@ -456,10 +456,13 @@ export default class LocalParticipant extends Participant {
     // look through all published tracks to find the right ones
     const publication = this.getPublicationForTrack(track);
 
-    log.debug('unpublishing track', { track });
+    log.debug('unpublishing track', { track, method: 'unpublishTrack' });
 
     if (!publication || !publication.track) {
-      log.warn('track was not unpublished because no publication was found', { track });
+      log.warn('track was not unpublished because no publication was found', {
+        track,
+        method: 'unpublishTrack',
+      });
       return null;
     }
 
@@ -486,7 +489,7 @@ export default class LocalParticipant extends Participant {
             this.engine.publisher?.pc.removeTrack(sender);
             this.engine.negotiate();
           } catch (e) {
-            log.warn('failed to remove track', { error: e });
+            log.warn('failed to remove track', { error: e, method: 'unpublishTrack' });
           }
         }
       });

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -118,7 +118,7 @@ export default class RemoteParticipant extends Participant {
     // yet arrived. Wait a bit longer for it to arrive, or fire an error
     if (!publication) {
       if (triesLeft === 0) {
-        log.error('could not find published track', this.sid, sid);
+        log.error('could not find published track', { participant: this.sid, trackSid: sid });
         this.emit(ParticipantEvent.TrackSubscriptionFailed, sid);
         return;
       }
@@ -257,7 +257,7 @@ export default class RemoteParticipant extends Participant {
     event: E,
     ...args: Parameters<ParticipantEventCallbacks[E]>
   ): boolean {
-    log.trace('participant event', this.sid, event, ...args);
+    log.trace('participant event', { participant: this.sid, event, args });
     return super.emit(event, ...args);
   }
 }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -140,10 +140,10 @@ export default class LocalTrack extends Track {
   protected async handleAppVisibilityChanged() {
     await super.handleAppVisibilityChanged();
     if (!isMobile()) return;
-    log.debug('visibility changed, is in Background: ', this.isInBackground);
+    log.debug(`visibility changed, is in Background: ${this.isInBackground}`);
 
     if (!this.isInBackground && this.needsReAcquisition) {
-      log.debug('track needs to be reaquired, restarting', this.source);
+      log.debug(`track needs to be reaquired, restarting ${this.source}`);
       await this.restart();
       this.reacquireTrack = false;
       // Restore muted state if had to be restarted

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -118,7 +118,7 @@ export default class LocalVideoTrack extends LocalTrack {
         enabled: q <= maxQuality,
       });
     }
-    log.debug('setting publishing quality. max quality', maxQuality);
+    log.debug(`setting publishing quality. max quality ${maxQuality}`);
     this.setPublishingLayers(qualities);
   }
 
@@ -219,7 +219,7 @@ export default class LocalVideoTrack extends LocalTrack {
     try {
       stats = await this.getSenderStats();
     } catch (e) {
-      log.error('could not get audio sender stats', e);
+      log.error('could not get audio sender stats', { error: e });
       return;
     }
     const statsMap = new Map<string, VideoSenderStats>(stats.map((s) => [s.rid, s]));

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -150,11 +150,13 @@ export default class RemoteTrackPublication extends TrackPublication {
 
   private isManualOperationAllowed(): boolean {
     if (this.isAdaptiveStream) {
-      log.warn('adaptive stream is enabled, cannot change track settings', this.trackSid);
+      log.warn('adaptive stream is enabled, cannot change track settings', {
+        trackSid: this.trackSid,
+      });
       return false;
     }
     if (!this.isSubscribed) {
-      log.warn('cannot update track settings when not subscribed', this.trackSid);
+      log.warn('cannot update track settings when not subscribed', { trackSid: this.trackSid });
       return false;
     }
     return true;
@@ -169,17 +171,17 @@ export default class RemoteTrackPublication extends TrackPublication {
   }
 
   protected handleVisibilityChange = (visible: boolean) => {
-    log.debug('adaptivestream video visibility', this.trackSid, `visible=${visible}`);
+    log.debug(`adaptivestream video visibility ${this.trackSid}, visible=${visible}`, {
+      trackSid: this.trackSid,
+    });
     this.disabled = !visible;
     this.emitTrackUpdate();
   };
 
   protected handleVideoDimensionsChange = (dimensions: Track.Dimensions) => {
-    log.debug(
-      'adaptivestream video dimensions',
-      this.trackSid,
-      `${dimensions.width}x${dimensions.height}`,
-    );
+    log.debug(`adaptivestream video dimensions ${dimensions.width}x${dimensions.height}`, {
+      trackSid: this.trackSid,
+    });
     this.videoDimensions = dimensions;
     this.emitTrackUpdate();
   };


### PR DESCRIPTION
motivation: 
a more structured approach to logging in order to facilitate sending logs to third party services. 

structuring the logs with a message string and an optional context object turned out to be the most flexible approach while not forcing us to rewrite all messages. 
some logging implementations that utilize a similar structure: 
- https://github.com/pinojs/pino/blob/master/docs/api.md
- https://github.com/gajus/roarr
- https://github.com/DataDog/browser-sdk/blob/main/packages/logs/README.md

I opted to go for the ordering of arguments `(msg: string, context?: object)` instead of `(context?: object, msg: string)`, but not sure anymore if it's the right bet, as the implementations mentioned above seem to switch things around.