### PR TITLE
revert dynamic import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livekit-client",
-  "version": "0.17.5",
+  "version": "0.17.6-rc2",
   "description": "JavaScript/TypeScript client SDK for LiveKit",
   "main": "./dist/livekit-client.umd.js",
   "unpkg": "./dist/livekit-client.umd.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,6 @@ export default {
       format: 'esm',
       strict: true,
       sourcemap: true,
-      inlineDynamicImports: true,
     },
     {
       file: `dist/${packageJson.name}.umd.js`,
@@ -30,7 +29,6 @@ export default {
       strict: true,
       sourcemap: true,
       name: kebabCaseToPascalCase(packageJson.name),
-      inlineDynamicImports: true,
       plugins: [terser()],
     },
   ],

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -27,12 +27,9 @@ import {
   UpdateTrackSettings,
 } from '../proto/livekit_rtc';
 import { ConnectionError } from '../room/errors';
-import { getClientInfo, isWeb, sleep } from '../room/utils';
+import { getClientInfo, sleep } from '../room/utils';
 import Queue from './RequestQueue';
-
-if (isWeb()) {
-  import('webrtc-adapter');
-}
+import 'webrtc-adapter';
 
 // internal options
 interface ConnectOpts {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { setLogLevel, setLogExtension } from './logger';
+import { setLogLevel, setLogExtension, LogLevel } from './logger';
 import { DataPacket_Kind, VideoQuality } from './proto/livekit_models';
 import LocalParticipant from './room/participant/LocalParticipant';
 import Participant, { ConnectionQuality } from './room/participant/Participant';
@@ -27,6 +27,7 @@ export * from './version';
 export {
   setLogLevel,
   setLogExtension,
+  LogLevel,
   Room,
   RoomState,
   DataPacket_Kind,

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -16,14 +16,17 @@ export async function sleep(duration: number): Promise<void> {
 }
 
 export function isFireFox(): boolean {
+  if (!isWeb()) return false;
   return navigator.userAgent.indexOf('Firefox') !== -1;
 }
 
 export function isSafari(): boolean {
+  if (!isWeb()) return false;
   return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 }
 
 export function isMobile(): boolean {
+  if (!isWeb()) return false;
   return /Tablet|iPad|Mobile|Android|BlackBerry/.test(navigator.userAgent);
 }
 


### PR DESCRIPTION
there are some caveats around tree-shaking and dynamic imports.

briefly discussed here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
> Use dynamic import only when necessary. The static form is preferable for loading initial dependencies, and can benefit more readily from static analysis tools and [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking).

this branch is published as rc2 under the `next` tag for easy testing