### PR TITLE
specify document as root for intersection observer

### DIFF
--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -54,7 +54,11 @@ export const getResizeObserver = () => {
 
 let intersectionObserver: IntersectionObserver | null = null;
 export const getIntersectionObserver = () => {
-  if (!intersectionObserver) intersectionObserver = new IntersectionObserver(ioDispatchCallback);
+  if (!intersectionObserver)
+    intersectionObserver = new IntersectionObserver(ioDispatchCallback, {
+      root: document,
+      rootMargin: '0px',
+    });
   return intersectionObserver;
 };
 


### PR DESCRIPTION
addresses https://github.com/livekit/livekit-react/issues/41

here's an online reproduction for safari showcasing the fix in an isolated context: 
https://svelte.dev/repl/d1acaeee97f44b11bddff072ea3a6d5a?version=3.47.0

if you change `root: document` to `root: null` you can see that isIntersecting displays `false`. Setting it back to `document` shows `true` for isIntersecting.
Behaviour doesn't change in chrome.

unfortunately I couldn't reproduce https://github.com/livekit/livekit-react/issues/41 on my machine.
This fix feels like a good move regardless in order to get consistent behaviour for all browsers.



