### PR TITLE
add method for pausing and resuming track upstream (aka server-side-only-mute)

### DIFF
--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -425,4 +425,14 @@ export enum TrackEvent {
   ElementAttached = 'elementAttached',
   /** @internal */
   ElementDetached = 'elementDetached',
+  /**
+   * @internal
+   * Only fires on LocalTracks
+   */
+  UpstreamHalted = 'upstreamHalted',
+  /**
+   * @internal
+   * Only fires on LocalTracks
+   */
+  UpstreamResumed = 'upstreamResumed',
 }

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -429,7 +429,7 @@ export enum TrackEvent {
    * @internal
    * Only fires on LocalTracks
    */
-  UpstreamHalted = 'upstreamHalted',
+  UpstreamPaused = 'upstreamPaused',
   /**
    * @internal
    * Only fires on LocalTracks

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -625,12 +625,12 @@ export default class LocalParticipant extends Participant {
   };
 
   private onTrackUpstreamPaused = (track: LocalTrack) => {
-    log.info('upstream paused');
+    log.debug('upstream paused');
     this.onTrackMuted(track, true);
   };
 
   private onTrackUpstreamResumed = (track: LocalTrack) => {
-    log.info('upstream resumed');
+    log.debug('upstream resumed');
     this.onTrackMuted(track, track.isMuted);
   };
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -385,8 +385,8 @@ export default class LocalParticipant extends Participant {
     track.on(TrackEvent.Muted, this.onTrackMuted);
     track.on(TrackEvent.Unmuted, this.onTrackUnmuted);
     track.on(TrackEvent.Ended, this.onTrackUnpublish);
-    track.off(TrackEvent.UpstreamHalted, this.onTrackUpstreamHalted);
-    track.off(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
+    track.on(TrackEvent.UpstreamHalted, this.onTrackUpstreamHalted);
+    track.on(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
 
     // create track publication from track
     const req = AddTrackRequest.fromPartial({
@@ -606,7 +606,7 @@ export default class LocalParticipant extends Participant {
 
   /** @internal */
   private onTrackUnmuted = (track: LocalTrack) => {
-    this.onTrackMuted(track, false);
+    this.onTrackMuted(track, track.isUpstreamHalted);
   };
 
   // when the local track changes in mute status, we'll notify server as such
@@ -625,10 +625,12 @@ export default class LocalParticipant extends Participant {
   };
 
   private onTrackUpstreamHalted = (track: LocalTrack) => {
+    log.info('upstream halted');
     this.onTrackMuted(track, true);
   };
 
   private onTrackUpstreamResumed = (track: LocalTrack) => {
+    log.info('upstream resumed');
     this.onTrackMuted(track, track.isMuted);
   };
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -385,7 +385,7 @@ export default class LocalParticipant extends Participant {
     track.on(TrackEvent.Muted, this.onTrackMuted);
     track.on(TrackEvent.Unmuted, this.onTrackUnmuted);
     track.on(TrackEvent.Ended, this.onTrackUnpublish);
-    track.on(TrackEvent.UpstreamHalted, this.onTrackUpstreamHalted);
+    track.on(TrackEvent.UpstreamPaused, this.onTrackUpstreamPaused);
     track.on(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
 
     // create track publication from track
@@ -482,7 +482,7 @@ export default class LocalParticipant extends Participant {
     track.off(TrackEvent.Muted, this.onTrackMuted);
     track.off(TrackEvent.Unmuted, this.onTrackUnmuted);
     track.off(TrackEvent.Ended, this.onTrackUnpublish);
-    track.off(TrackEvent.UpstreamHalted, this.onTrackUpstreamHalted);
+    track.off(TrackEvent.UpstreamPaused, this.onTrackUpstreamPaused);
     track.off(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
 
     if (stopOnUnpublish === undefined) {
@@ -606,7 +606,7 @@ export default class LocalParticipant extends Participant {
 
   /** @internal */
   private onTrackUnmuted = (track: LocalTrack) => {
-    this.onTrackMuted(track, track.isUpstreamHalted);
+    this.onTrackMuted(track, track.isUpstreamPaused);
   };
 
   // when the local track changes in mute status, we'll notify server as such
@@ -624,8 +624,8 @@ export default class LocalParticipant extends Participant {
     this.engine.updateMuteStatus(track.sid, muted);
   };
 
-  private onTrackUpstreamHalted = (track: LocalTrack) => {
-    log.info('upstream halted');
+  private onTrackUpstreamPaused = (track: LocalTrack) => {
+    log.info('upstream paused');
     this.onTrackMuted(track, true);
   };
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -385,6 +385,8 @@ export default class LocalParticipant extends Participant {
     track.on(TrackEvent.Muted, this.onTrackMuted);
     track.on(TrackEvent.Unmuted, this.onTrackUnmuted);
     track.on(TrackEvent.Ended, this.onTrackUnpublish);
+    track.off(TrackEvent.UpstreamHalted, this.onTrackUpstreamHalted);
+    track.off(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
 
     // create track publication from track
     const req = AddTrackRequest.fromPartial({
@@ -480,6 +482,8 @@ export default class LocalParticipant extends Participant {
     track.off(TrackEvent.Muted, this.onTrackMuted);
     track.off(TrackEvent.Unmuted, this.onTrackUnmuted);
     track.off(TrackEvent.Ended, this.onTrackUnpublish);
+    track.off(TrackEvent.UpstreamHalted, this.onTrackUpstreamHalted);
+    track.off(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
 
     if (stopOnUnpublish === undefined) {
       stopOnUnpublish = this.roomOptions?.stopLocalTrackOnUnpublish ?? true;
@@ -618,6 +622,14 @@ export default class LocalParticipant extends Participant {
     }
 
     this.engine.updateMuteStatus(track.sid, muted);
+  };
+
+  private onTrackUpstreamHalted = (track: LocalTrack) => {
+    this.onTrackMuted(track, true);
+  };
+
+  private onTrackUpstreamResumed = (track: LocalTrack) => {
+    this.onTrackMuted(track, track.isMuted);
   };
 
   private handleSubscribedQualityUpdate = (update: SubscribedQualityUpdate) => {

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -2,7 +2,7 @@ import log from '../../logger';
 import DeviceManager from '../DeviceManager';
 import { TrackInvalidError } from '../errors';
 import { TrackEvent } from '../events';
-import { isMobile } from '../utils';
+import { getEmptyMediaStreamTrack, isMobile } from '../utils';
 import { attachToElement, detachTrack, Track } from './Track';
 
 export default class LocalTrack extends Track {
@@ -162,4 +162,18 @@ export default class LocalTrack extends Track {
     }
     this.emit(TrackEvent.Ended, this);
   };
+
+  async detachTrack() {
+    if (!this.sender) {
+      throw new TrackInvalidError('unable to detach an unpublished track');
+    }
+    await this.sender.replaceTrack(getEmptyMediaStreamTrack());
+  }
+
+  async attachTrack() {
+    if (!this.sender) {
+      throw new TrackInvalidError('unable to attach an unpublished track');
+    }
+    await this.sender.replaceTrack(this.mediaStreamTrack);
+  }
 }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -170,8 +170,11 @@ export default class LocalTrack extends Track {
   };
 
   async pauseUpstream() {
-    this.emit(TrackEvent.UpstreamPaused, this);
+    if (this._isUpstreamPaused === true) {
+      return;
+    }
     this._isUpstreamPaused = true;
+    this.emit(TrackEvent.UpstreamPaused, this);
     if (!this.sender) {
       throw new TrackInvalidError('unable to pause upstream for an unpublished track');
     }
@@ -179,8 +182,11 @@ export default class LocalTrack extends Track {
   }
 
   async resumeUpstream() {
-    this.emit(TrackEvent.UpstreamResumed, this);
+    if (this._isUpstreamPaused === false) {
+      return;
+    }
     this._isUpstreamPaused = false;
+    this.emit(TrackEvent.UpstreamResumed, this);
     if (!this.sender) {
       throw new TrackInvalidError('unable to resume upstream for an unpublished track');
     }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -46,10 +46,10 @@ export default class LocalTrack extends Track {
     return undefined;
   }
 
-  private _isUpstreamHalted: boolean = false;
+  private _isUpstreamPaused: boolean = false;
 
-  get isUpstreamHalted() {
-    return this._isUpstreamHalted;
+  get isUpstreamPaused() {
+    return this._isUpstreamPaused;
   }
 
   /**
@@ -169,18 +169,18 @@ export default class LocalTrack extends Track {
     this.emit(TrackEvent.Ended, this);
   };
 
-  async haltUpstream() {
-    this.emit(TrackEvent.UpstreamHalted, this);
-    this._isUpstreamHalted = true;
+  async pauseUpstream() {
+    this.emit(TrackEvent.UpstreamPaused, this);
+    this._isUpstreamPaused = true;
     if (!this.sender) {
-      throw new TrackInvalidError('unable to halt upstream for an unpublished track');
+      throw new TrackInvalidError('unable to pause upstream for an unpublished track');
     }
     await this.sender.replaceTrack(getEmptyMediaStreamTrack());
   }
 
   async resumeUpstream() {
     this.emit(TrackEvent.UpstreamResumed, this);
-    this._isUpstreamHalted = false;
+    this._isUpstreamPaused = false;
     if (!this.sender) {
       throw new TrackInvalidError('unable to resume upstream for an unpublished track');
     }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -173,7 +173,7 @@ export default class LocalTrack extends Track {
     this.emit(TrackEvent.UpstreamHalted, this);
     this._isUpstreamHalted = true;
     if (!this.sender) {
-      throw new TrackInvalidError('unable to detach an unpublished track');
+      throw new TrackInvalidError('unable to halt upstream for an unpublished track');
     }
     await this.sender.replaceTrack(getEmptyMediaStreamTrack());
   }
@@ -182,7 +182,7 @@ export default class LocalTrack extends Track {
     this.emit(TrackEvent.UpstreamResumed, this);
     this._isUpstreamHalted = false;
     if (!this.sender) {
-      throw new TrackInvalidError('unable to attach an unpublished track');
+      throw new TrackInvalidError('unable to resume upstream for an unpublished track');
     }
     await this.sender.replaceTrack(this.mediaStreamTrack);
   }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -46,6 +46,12 @@ export default class LocalTrack extends Track {
     return undefined;
   }
 
+  private _isUpstreamHalted: boolean = false;
+
+  get isUpstreamHalted() {
+    return this._isUpstreamHalted;
+  }
+
   /**
    * @returns DeviceID of the device that is currently being used for this track
    */
@@ -163,14 +169,18 @@ export default class LocalTrack extends Track {
     this.emit(TrackEvent.Ended, this);
   };
 
-  async detachTrack() {
+  async haltUpstream() {
+    this.emit(TrackEvent.UpstreamHalted, this);
+    this._isUpstreamHalted = true;
     if (!this.sender) {
       throw new TrackInvalidError('unable to detach an unpublished track');
     }
     await this.sender.replaceTrack(getEmptyMediaStreamTrack());
   }
 
-  async attachTrack() {
+  async resumeUpstream() {
+    this.emit(TrackEvent.UpstreamResumed, this);
+    this._isUpstreamHalted = false;
     if (!this.sender) {
       throw new TrackInvalidError('unable to attach an unpublished track');
     }

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -64,10 +64,19 @@ export default class LocalTrackPublication extends TrackPublication {
     return this.track?.unmute();
   }
 
+  /**
+   * Pauses the media stream track from being sent to the server
+   * and signals a muted stream to other participants
+   * Useful if you want to pause the stream without pausing the local media stream track
+   */
   pauseUpstream() {
     this.track?.pauseUpstream();
   }
 
+  /**
+   * Resumes sending the media stream track to the server after a call to [[pauseUpstream()]]
+   * and signals unmuted stream to other participants (unless the track is explicitly muted)
+   */
   resumeUpstream() {
     this.track?.resumeUpstream();
   }

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -12,8 +12,8 @@ export default class LocalTrackPublication extends TrackPublication {
 
   options?: TrackPublishOptions;
 
-  get isUpstreamHalted() {
-    return this.track?.isUpstreamHalted;
+  get isUpstreamPaused() {
+    return this.track?.isUpstreamPaused;
   }
 
   constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack) {
@@ -64,8 +64,8 @@ export default class LocalTrackPublication extends TrackPublication {
     return this.track?.unmute();
   }
 
-  haltUpstream() {
-    this.track?.haltUpstream();
+  pauseUpstream() {
+    this.track?.pauseUpstream();
   }
 
   resumeUpstream() {

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -60,6 +60,16 @@ export default class LocalTrackPublication extends TrackPublication {
     return this.track?.unmute();
   }
 
+  detachTrack() {
+    this.track?.detachTrack();
+    this.emit(TrackEvent.UpstreamHalted, this.track);
+  }
+
+  attachTrack(track: LocalTrack) {
+    this.track?.attachTrack();
+    this.emit(TrackEvent.UpstreamResumed, track);
+  }
+
   handleTrackEnded = (track: LocalTrack) => {
     this.emit(TrackEvent.Ended, track);
   };

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -8,11 +8,13 @@ import { Track } from './Track';
 import { TrackPublication } from './TrackPublication';
 
 export default class LocalTrackPublication extends TrackPublication {
-  track?: LocalTrack;
+  track?: LocalTrack = undefined;
 
   options?: TrackPublishOptions;
 
-  isDetached: boolean = false;
+  get isUpstreamHalted() {
+    return this.track?.isUpstreamHalted;
+  }
 
   constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack) {
     super(kind, ti.sid, ti.name);
@@ -62,16 +64,12 @@ export default class LocalTrackPublication extends TrackPublication {
     return this.track?.unmute();
   }
 
-  detachTrack() {
-    this.track?.detachTrack();
-    this.isDetached = true;
-    this.emit(TrackEvent.UpstreamHalted, this.track);
+  haltUpstream() {
+    this.track?.haltUpstream();
   }
 
-  attachTrack() {
-    this.track?.attachTrack();
-    this.isDetached = false;
-    this.emit(TrackEvent.UpstreamResumed);
+  resumeUpstream() {
+    this.track?.resumeUpstream();
   }
 
   handleTrackEnded = () => {

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -65,8 +65,8 @@ export default class LocalTrackPublication extends TrackPublication {
   }
 
   /**
-   * Pauses the media stream track from being sent to the server
-   * and signals a muted stream to other participants
+   * Pauses the media stream track associated with this publication from being sent to the server
+   * and signals "muted" event to other participants
    * Useful if you want to pause the stream without pausing the local media stream track
    */
   pauseUpstream() {
@@ -74,8 +74,8 @@ export default class LocalTrackPublication extends TrackPublication {
   }
 
   /**
-   * Resumes sending the media stream track to the server after a call to [[pauseUpstream()]]
-   * and signals unmuted stream to other participants (unless the track is explicitly muted)
+   * Resumes sending the media stream track associated with this publication to the server after a call to [[pauseUpstream()]]
+   * and signals "unmuted" event to other participants (unless the track is explicitly muted)
    */
   resumeUpstream() {
     this.track?.resumeUpstream();

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -12,6 +12,8 @@ export default class LocalTrackPublication extends TrackPublication {
 
   options?: TrackPublishOptions;
 
+  isDetached: boolean = false;
+
   constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack) {
     super(kind, ti.sid, ti.name);
 
@@ -62,15 +64,17 @@ export default class LocalTrackPublication extends TrackPublication {
 
   detachTrack() {
     this.track?.detachTrack();
+    this.isDetached = true;
     this.emit(TrackEvent.UpstreamHalted, this.track);
   }
 
-  attachTrack(track: LocalTrack) {
+  attachTrack() {
     this.track?.attachTrack();
-    this.emit(TrackEvent.UpstreamResumed, track);
+    this.isDetached = false;
+    this.emit(TrackEvent.UpstreamResumed);
   }
 
-  handleTrackEnded = (track: LocalTrack) => {
-    this.emit(TrackEvent.Ended, track);
+  handleTrackEnded = () => {
+    this.emit(TrackEvent.Ended);
   };
 }

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -349,6 +349,6 @@ export type TrackEventCallbacks = {
   videoDimensionsChanged: (dimensions: Track.Dimensions, track?: any) => void;
   elementAttached: (element: HTMLMediaElement) => void;
   elementDetached: (element: HTMLMediaElement) => void;
-  upstreamHalted: () => void;
-  upstreamResumed: () => void;
+  upstreamHalted: (track: any) => void;
+  upstreamResumed: (track: any) => void;
 };

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -349,6 +349,6 @@ export type TrackEventCallbacks = {
   videoDimensionsChanged: (dimensions: Track.Dimensions, track?: any) => void;
   elementAttached: (element: HTMLMediaElement) => void;
   elementDetached: (element: HTMLMediaElement) => void;
-  upstreamHalted: (track?: any) => void;
-  upstreamResumed: (track?: any) => void;
+  upstreamHalted: () => void;
+  upstreamResumed: () => void;
 };

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -349,6 +349,6 @@ export type TrackEventCallbacks = {
   videoDimensionsChanged: (dimensions: Track.Dimensions, track?: any) => void;
   elementAttached: (element: HTMLMediaElement) => void;
   elementDetached: (element: HTMLMediaElement) => void;
-  upstreamHalted: (track: any) => void;
+  upstreamPaused: (track: any) => void;
   upstreamResumed: (track: any) => void;
 };

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -349,4 +349,6 @@ export type TrackEventCallbacks = {
   videoDimensionsChanged: (dimensions: Track.Dimensions, track?: any) => void;
   elementAttached: (element: HTMLMediaElement) => void;
   elementDetached: (element: HTMLMediaElement) => void;
+  upstreamHalted: (track?: any) => void;
+  upstreamResumed: (track?: any) => void;
 };

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -75,3 +75,17 @@ export function getClientInfo(): ClientInfo {
   });
   return info;
 }
+
+let emptyMediaStreamTrack: MediaStreamTrack | undefined;
+
+export function getEmptyMediaStreamTrack() {
+  if (!emptyMediaStreamTrack) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 2;
+    canvas.height = 2;
+    const emptyStream = canvas.captureStream();
+    [emptyMediaStreamTrack] = emptyStream.getTracks();
+    emptyMediaStreamTrack.enabled = false;
+  }
+  return emptyMediaStreamTrack;
+}

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -83,8 +83,12 @@ export function getEmptyMediaStreamTrack() {
     const canvas = document.createElement('canvas');
     canvas.width = 2;
     canvas.height = 2;
+    // @ts-ignore
     const emptyStream = canvas.captureStream();
     [emptyMediaStreamTrack] = emptyStream.getTracks();
+    if (!emptyMediaStreamTrack) {
+      throw Error('Could not get empty media stream track');
+    }
     emptyMediaStreamTrack.enabled = false;
   }
   return emptyMediaStreamTrack;


### PR DESCRIPTION
Usecase: stop track from consuming upstream bandwidth, but keep it running locally (all with minimal time to resume).
Track gets paused for all other participants.

