### PR TITLE
Set initial stream state to paused when using adaptive stream

### DIFF
--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -35,6 +35,9 @@ export default class RemoteVideoTrack extends RemoteTrack {
   ) {
     super(mediaTrack, sid, Track.Kind.Video, receiver);
     this.adaptiveStreamSettings = adaptiveStreamSettings;
+    if (this.isAdaptiveStream) {
+      this.streamState = Track.StreamState.Paused;
+    }
   }
 
   get isAdaptiveStream(): boolean {


### PR DESCRIPTION
When using adaptive stream the server will start out tracks in a `paused` state. 
This PR reflects the initial state of remote video tracks set to `paused` on the client when adaptiveStream is enabled