### PR TITLE
Use empty audio track when pausing audio upstream

### DIFF
--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -2,7 +2,7 @@ import log from '../../logger';
 import DeviceManager from '../DeviceManager';
 import { TrackInvalidError } from '../errors';
 import { TrackEvent } from '../events';
-import { getEmptyMediaStreamTrack, isMobile } from '../utils';
+import { getEmptyAudioStreamTrack, getEmptyVideoStreamTrack, isMobile } from '../utils';
 import { attachToElement, detachTrack, Track } from './Track';
 
 export default class LocalTrack extends Track {
@@ -208,8 +208,9 @@ export default class LocalTrack extends Track {
     }
     this._isUpstreamPaused = true;
     this.emit(TrackEvent.UpstreamPaused, this);
-
-    await this.sender.replaceTrack(getEmptyMediaStreamTrack());
+    const emptyTrack =
+      this.kind === Track.Kind.Audio ? getEmptyAudioStreamTrack() : getEmptyVideoStreamTrack();
+    await this.sender.replaceTrack(emptyTrack);
   }
 
   async resumeUpstream() {

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -99,6 +99,7 @@ let emptyAudioStreamTrack: MediaStreamTrack | undefined;
 
 export function getEmptyAudioStreamTrack() {
   if (!emptyAudioStreamTrack) {
+    // implementation adapted from https://blog.mozilla.org/webrtc/warm-up-with-replacetrack/
     const ctx = new AudioContext();
     const oscillator = ctx.createOscillator();
     const dst = ctx.createMediaStreamDestination();

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -76,20 +76,39 @@ export function getClientInfo(): ClientInfo {
   return info;
 }
 
-let emptyMediaStreamTrack: MediaStreamTrack | undefined;
+let emptyVideoStreamTrack: MediaStreamTrack | undefined;
 
-export function getEmptyMediaStreamTrack() {
-  if (!emptyMediaStreamTrack) {
+export function getEmptyVideoStreamTrack() {
+  if (!emptyVideoStreamTrack) {
     const canvas = document.createElement('canvas');
     canvas.width = 2;
     canvas.height = 2;
+    canvas.getContext('2d')?.fillRect(0, 0, canvas.width, canvas.height);
     // @ts-ignore
     const emptyStream = canvas.captureStream();
-    [emptyMediaStreamTrack] = emptyStream.getTracks();
-    if (!emptyMediaStreamTrack) {
-      throw Error('Could not get empty media stream track');
+    [emptyVideoStreamTrack] = emptyStream.getTracks();
+    if (!emptyVideoStreamTrack) {
+      throw Error('Could not get empty media stream video track');
     }
-    emptyMediaStreamTrack.enabled = false;
+    emptyVideoStreamTrack.enabled = false;
   }
-  return emptyMediaStreamTrack;
+  return emptyVideoStreamTrack;
+}
+
+let emptyAudioStreamTrack: MediaStreamTrack | undefined;
+
+export function getEmptyAudioStreamTrack() {
+  if (!emptyAudioStreamTrack) {
+    const ctx = new AudioContext();
+    const oscillator = ctx.createOscillator();
+    const dst = ctx.createMediaStreamDestination();
+    oscillator.connect(dst);
+    oscillator.start();
+    [emptyAudioStreamTrack] = dst.stream.getAudioTracks();
+    if (!emptyAudioStreamTrack) {
+      throw Error('Could not get empty media stream audio track');
+    }
+    emptyAudioStreamTrack.enabled = false;
+  }
+  return emptyAudioStreamTrack;
 }


### PR DESCRIPTION
Previously both track kinds (audio and video) used an empty video track.