### PR TITLE
Remove usage of legacy typescript plugin in sample app

### DIFF
--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -1,7 +1,7 @@
 // @ts-check
 import glob from 'glob';
 import path from 'path';
-import typescript from '@rollup/plugin-typescript';
+import typescript from 'rollup-plugin-typescript2';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import serve from 'rollup-plugin-serve';


### PR DESCRIPTION
Forgot to update the dependency for the dev-rollup configuration in https://github.com/livekit/client-sdk-js/pull/219