### PR TITLE
Restrict access to mediaStreamTrack when using adaptiveStream

### DIFF
--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -34,7 +34,7 @@ export default class LocalAudioTrack extends LocalTrack {
     if (this.source === Track.Source.Microphone && this.stopOnMute) {
       log.debug('stopping mic track');
       // also stop the track, so that microphone indicator is turned off
-      this.mediaStreamTrack.stop();
+      this._mediaStreamTrack.stop();
     }
     await super.mute();
     return this;
@@ -83,7 +83,7 @@ export default class LocalAudioTrack extends LocalTrack {
     try {
       stats = await this.getSenderStats();
     } catch (e) {
-      log.error('could not get audio sender stats', e);
+      log.error('could not get audio sender stats', { error: e });
       return;
     }
 

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -44,7 +44,7 @@ export default class LocalVideoTrack extends LocalTrack {
 
   stop() {
     this.sender = undefined;
-    this.mediaStreamTrack.getConstraints();
+    this._mediaStreamTrack.getConstraints();
     super.stop();
   }
 
@@ -52,7 +52,7 @@ export default class LocalVideoTrack extends LocalTrack {
     if (this.source === Track.Source.Camera) {
       log.debug('stopping camera track');
       // also stop the track, so that camera indicator is turned off
-      this.mediaStreamTrack.stop();
+      this._mediaStreamTrack.stop();
     }
     await super.mute();
     return this;
@@ -243,7 +243,7 @@ export default class LocalVideoTrack extends LocalTrack {
     await super.handleAppVisibilityChanged();
     if (!isMobile()) return;
     if (this.isInBackground && this.source === Track.Source.Camera) {
-      this.mediaStreamTrack.enabled = false;
+      this._mediaStreamTrack.enabled = false;
     }
   }
 }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -44,6 +44,15 @@ export default class RemoteVideoTrack extends RemoteTrack {
     return this.adaptiveStreamSettings !== undefined;
   }
 
+  get mediaStreamTrack() {
+    if (this.isAdaptiveStream && this.attachedElements.length === 0) {
+      throw Error(
+        'When using adaptiveStream, you need to use remoteVideoTrack.attach() to add the track to a HTMLVideoElement, direct usage of mediaStreamTrack is unsupported in this case',
+      );
+    }
+    return this._mediaStreamTrack;
+  }
+
   /** @internal */
   setMuted(muted: boolean) {
     super.setMuted(muted);
@@ -51,9 +60,9 @@ export default class RemoteVideoTrack extends RemoteTrack {
     this.attachedElements.forEach((element) => {
       // detach or attach
       if (muted) {
-        detachTrack(this.mediaStreamTrack, element);
+        detachTrack(this._mediaStreamTrack, element);
       } else {
-        attachToElement(this.mediaStreamTrack, element);
+        attachToElement(this._mediaStreamTrack, element);
       }
     });
   }

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -12,29 +12,32 @@ const recycledElements: Array<HTMLAudioElement> = [];
 export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEventCallbacks>) {
   kind: Track.Kind;
 
-  mediaStream?: MediaStream;
-
-  mediaStreamTrack: MediaStreamTrack;
-
   attachedElements: HTMLMediaElement[] = [];
 
   isMuted: boolean = false;
 
   source: Track.Source;
 
-  protected isInBackground: boolean;
-
   /**
    * sid is set after track is published to server, or if it's a remote track
    */
   sid?: Track.SID;
+
+  /**
+   * @internal
+   */
+  mediaStream?: MediaStream;
+
+  protected _mediaStreamTrack: MediaStreamTrack;
+
+  protected isInBackground: boolean;
 
   protected _currentBitrate: number = 0;
 
   protected constructor(mediaTrack: MediaStreamTrack, kind: Track.Kind) {
     super();
     this.kind = kind;
-    this.mediaStreamTrack = mediaTrack;
+    this._mediaStreamTrack = mediaTrack;
     this.source = Track.Source.Unknown;
     if (isWeb()) {
       this.isInBackground = document.visibilityState === 'hidden';
@@ -47,6 +50,10 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
   /** current receive bits per second */
   get currentBitrate(): number {
     return this._currentBitrate;
+  }
+
+  get mediaStreamTrack() {
+    return this._mediaStreamTrack;
   }
 
   /**
@@ -87,7 +94,7 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
     // even if we believe it's already attached to the element, it's possible
     // the element's srcObject was set to something else out of band.
     // we'll want to re-attach it in that case
-    attachToElement(this.mediaStreamTrack, element);
+    attachToElement(this._mediaStreamTrack, element);
 
     if (element instanceof HTMLAudioElement) {
       // manually play audio to detect audio playback status
@@ -118,7 +125,7 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
   detach(element?: HTMLMediaElement): HTMLMediaElement | HTMLMediaElement[] {
     // detach from a single element
     if (element) {
-      detachTrack(this.mediaStreamTrack, element);
+      detachTrack(this._mediaStreamTrack, element);
       const idx = this.attachedElements.indexOf(element);
       if (idx >= 0) {
         this.attachedElements.splice(idx, 1);
@@ -130,7 +137,7 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
     const detached: HTMLMediaElement[] = [];
     this.attachedElements.forEach((elm) => {
-      detachTrack(this.mediaStreamTrack, elm);
+      detachTrack(this._mediaStreamTrack, elm);
       detached.push(elm);
       this.recycleElement(elm);
       this.emit(TrackEvent.ElementDetached, elm);
@@ -142,18 +149,18 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
   }
 
   stop() {
-    this.mediaStreamTrack.stop();
+    this._mediaStreamTrack.stop();
     if (isWeb()) {
       document.removeEventListener('visibilitychange', this.appVisibilityChangedListener);
     }
   }
 
   protected enable() {
-    this.mediaStreamTrack.enabled = true;
+    this._mediaStreamTrack.enabled = true;
   }
 
   protected disable() {
-    this.mediaStreamTrack.enabled = false;
+    this._mediaStreamTrack.enabled = false;
   }
 
   private recycleElement(element: HTMLMediaElement) {

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -83,13 +83,13 @@ export function constraintsForOptions(options: CreateLocalTracksOptions): MediaS
  */
 export async function detectSilence(track: AudioTrack, timeOffset = 200): Promise<boolean> {
   const ctx = getNewAudioContext();
-  if (ctx) {
+  if (ctx && track.mediaStream) {
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 2048;
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);
-    const source = ctx.createMediaStreamSource(new MediaStream([track.mediaStreamTrack]));
+    const source = ctx.createMediaStreamSource(track.mediaStream);
 
     source.connect(analyser);
     await sleep(timeOffset);

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -83,13 +83,13 @@ export function constraintsForOptions(options: CreateLocalTracksOptions): MediaS
  */
 export async function detectSilence(track: AudioTrack, timeOffset = 200): Promise<boolean> {
   const ctx = getNewAudioContext();
-  if (ctx && track.mediaStream) {
+  if (ctx) {
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 2048;
 
     const bufferLength = analyser.frequencyBinCount;
     const dataArray = new Uint8Array(bufferLength);
-    const source = ctx.createMediaStreamSource(track.mediaStream);
+    const source = ctx.createMediaStreamSource(new MediaStream([track.mediaStreamTrack]));
 
     source.connect(analyser);
     await sleep(timeOffset);


### PR DESCRIPTION
breaking change: track.mediaStreamTrack is now readonly and will throw an error when accessed on `RemoteVideoTrack`s without attached elements and adaptiveStream is being used.


unclear what to do about `track.mediaStream` which is there to support react native. I marked it as `internal`, but the footgun is still there, when doing something like `track.mediaStream.getVideoTracks()`. 
Should we do the same thing for `mediaStream` as this PR is doing for `mediaStreamTrack`? 
@davidliu does/will react-native support adaptiveStream? 
