### PR TITLE
Fix robotic sounding audio for FF 100

### DIFF
--- a/src/room/track/defaults.ts
+++ b/src/room/track/defaults.ts
@@ -17,11 +17,10 @@ export const publishDefaults: TrackPublishDefaults = {
 
 export const audioDefaults: AudioCaptureOptions = {
   autoGainControl: true,
-  channelCount: 1,
   echoCancellation: true,
   noiseSuppression: true,
 };
 
 export const videoDefaults: VideoCaptureOptions = {
-  resolution: VideoPresets.h540.resolution,
+  resolution: VideoPresets.h720.resolution,
 };


### PR DESCRIPTION
With FF 100, if channelCount is set to 1, the resulting audio sounds
robotic. Leaving it to defaults resolves the issue.