### PR TITLE
Explicitly stop temporary mediastreamtracks when getting devices

### DIFF
--- a/src/room/DeviceManager.ts
+++ b/src/room/DeviceManager.ts
@@ -32,8 +32,11 @@ export default class DeviceManager {
           video: kind !== 'audioinput' && kind !== 'audiooutput',
           audio: kind !== 'videoinput',
         };
-        await navigator.mediaDevices.getUserMedia(permissionsToAcquire);
+        const stream = await navigator.mediaDevices.getUserMedia(permissionsToAcquire);
         devices = await navigator.mediaDevices.enumerateDevices();
+        stream.getTracks().forEach(track => {
+          track.stop();
+        })
       }
     }
     if (kind) {


### PR DESCRIPTION
Fixes safari showing sustained camera/microphone usage, after `deviceManager.getDevices` has been called.