### PR TITLE
Rename RoomState to ConnectionState

### DIFF
--- a/example/sample.ts
+++ b/example/sample.ts
@@ -10,7 +10,7 @@ import {
   RoomConnectOptions,
   RoomEvent,
   RoomOptions,
-  RoomState,
+  ConnectionState,
   setLogLevel,
   Track,
   TrackPublication,
@@ -555,7 +555,7 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
 
 function renderScreenShare() {
   const div = $('screenshare-area')!;
-  if (!currentRoom || currentRoom.state !== RoomState.Connected) {
+  if (!currentRoom || currentRoom.state !== ConnectionState.Connected) {
     div.style.display = 'none';
     return;
   }
@@ -593,7 +593,7 @@ function renderScreenShare() {
 }
 
 function renderBitrate() {
-  if (!currentRoom || currentRoom.state !== RoomState.Connected) {
+  if (!currentRoom || currentRoom.state !== ConnectionState.Connected) {
     return;
   }
   const participants: Participant[] = [...currentRoom.participants.values()];

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import LocalParticipant from './room/participant/LocalParticipant';
 import Participant, { ConnectionQuality } from './room/participant/Participant';
 import { ParticipantTrackPermission } from './room/participant/ParticipantTrackPermission';
 import RemoteParticipant from './room/participant/RemoteParticipant';
-import Room, { ConnectionState } from './room/Room';
+import Room, { ConnectionState, RoomState } from './room/Room';
 import LocalAudioTrack from './room/track/LocalAudioTrack';
 import LocalTrack from './room/track/LocalTrack';
 import LocalTrackPublication from './room/track/LocalTrackPublication';
@@ -28,7 +28,8 @@ export {
   setLogExtension,
   LogLevel,
   Room,
-  ConnectionState as RoomState,
+  ConnectionState,
+  RoomState,
   DataPacket_Kind,
   Participant,
   RemoteParticipant,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import LocalParticipant from './room/participant/LocalParticipant';
 import Participant, { ConnectionQuality } from './room/participant/Participant';
 import { ParticipantTrackPermission } from './room/participant/ParticipantTrackPermission';
 import RemoteParticipant from './room/participant/RemoteParticipant';
-import Room, { RoomState } from './room/Room';
+import Room, { ConnectionState } from './room/Room';
 import LocalAudioTrack from './room/track/LocalAudioTrack';
 import LocalTrack from './room/track/LocalTrack';
 import LocalTrackPublication from './room/track/LocalTrackPublication';
@@ -28,7 +28,7 @@ export {
   setLogExtension,
   LogLevel,
   Room,
-  RoomState,
+  ConnectionState as RoomState,
   DataPacket_Kind,
   Participant,
   RemoteParticipant,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -918,7 +918,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
     this.state = state;
-    this.emit(RoomEvent.StateChanged, this.state);
+    this.emit(RoomEvent.ConnectionStateChanged, this.state);
   }
 
   // /** @internal */
@@ -937,7 +937,9 @@ export type RoomEventCallbacks = {
   reconnecting: () => void;
   reconnected: () => void;
   disconnected: () => void;
+  /** @deprecated stateChanged has been renamed to connectionStateChanged */
   stateChanged: (state: ConnectionState) => void;
+  connectionStateChanged: (state: ConnectionState) => void;
   mediaDevicesChanged: () => void;
   participantConnected: (participant: RemoteParticipant) => void;
   participantDisconnected: (participant: RemoteParticipant) => void;

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -29,7 +29,7 @@ export enum RoomEvent {
   /**
    * Whenever the connection state of the room changes
    *
-   * args: ([[RoomState]])
+   * args: ([[ConnectionState]])
    */
   StateChanged = 'stateChanged',
 

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -31,7 +31,12 @@ export enum RoomEvent {
    *
    * args: ([[ConnectionState]])
    */
-  StateChanged = 'stateChanged',
+  ConnectionStateChanged = 'connectionStateChanged',
+
+  /**
+   * @deprecated StateChanged has been renamed to ConnectionStateChanged
+   */
+  StateChanged = 'connectionStateChanged',
 
   /**
    * When input or output devices on the machine have changed.


### PR DESCRIPTION
`ConnectionState` is more descriptive about what kind of state it actually holds and we already have a `RoomState` type in the livekit-react repo, so this additionally avoids confusion. 
Old name is just deprecated for now and not yet removed.