### PR TITLE
Fixed local track bitrate computation for Firefox

### DIFF
--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -89,7 +89,7 @@ export default class LocalVideoTrack extends LocalTrack {
           bytesSent: v.bytesSent,
           framesSent: v.framesSent,
           timestamp: v.timestamp,
-          rid: v.rid ?? '',
+          rid: v.rid ?? v.id,
           retransmittedPacketsSent: v.retransmittedPacketsSent,
           qualityLimitationReason: v.qualityLimitationReason,
           qualityLimitationResolutionChanges: v.qualityLimitationResolutionChanges,


### PR DESCRIPTION
Firefox does not return an rid in its rtp stats. We were effectively only returning bandwidth stats for a single layer.