### PR TITLE
Only signal leave if client is still connected

### DIFF
--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -339,8 +339,8 @@ export class SignalClient {
     });
   }
 
-  sendLeave() {
-    this.sendRequest(SignalRequest.fromPartial({ leave: {} }));
+  async sendLeave() {
+    await this.sendRequest(SignalRequest.fromPartial({ leave: {} }));
   }
 
   async sendRequest(req: SignalRequest, fromQueue: boolean = false) {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -339,10 +339,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
     // send leave
-    if (this.engine) {
+    if (this.engine?.client.isConnected) {
       this.engine.client.sendLeave();
+    }
+    // close engine (also closes client)
+    if (!this.engine.isClosed) {
       this.engine.close();
     }
+
     this.handleDisconnect(stopTracks);
     /* @ts-ignore */
     this.engine = undefined;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -343,7 +343,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       this.engine.client.sendLeave();
     }
     // close engine (also closes client)
-    if (!this.engine.isClosed) {
+    if (this.engine) {
       this.engine.close();
     }
 


### PR DESCRIPTION
Prevents `cannot send signal request before connected` error when trying to disconnect a room that is not connected. 