### PR TITLE
Moving StreamState to Track for improved usability

### DIFF
--- a/.changeset/chatty-lamps-kiss.md
+++ b/.changeset/chatty-lamps-kiss.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Moving StreamState to Track to improve usability

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -6,8 +6,6 @@ export default abstract class RemoteTrack extends Track {
   /** @internal */
   receiver?: RTCRtpReceiver;
 
-  streamState: Track.StreamState = Track.StreamState.Active;
-
   constructor(
     mediaTrack: MediaStreamTrack,
     sid: string,

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -30,6 +30,11 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
    */
   mediaStream?: MediaStream;
 
+  /**
+   * indicates current state of stream
+   */
+  streamState: Track.StreamState = Track.StreamState.Active;
+
   protected _mediaStreamTrack: MediaStreamTrack;
 
   protected isInBackground: boolean;


### PR DESCRIPTION
Similarly to `isSubscribed`, declaring StreamState on both local and
remote tracks to ensure application UI doesn't have to differentiate
between local and remote tracks.