### PR TITLE
Add support for capture options on set-enabled APIs

### DIFF
--- a/.changeset/honest-pears-retire.md
+++ b/.changeset/honest-pears-retire.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+Add optional CaptureOptions for set-enabled methods

--- a/.changeset/quiet-bottles-press.md
+++ b/.changeset/quiet-bottles-press.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add support for screen share audio in setScreenShareEnabled method

--- a/.changeset/quiet-bottles-press.md
+++ b/.changeset/quiet-bottles-press.md
@@ -1,5 +1,0 @@
----
-'livekit-client': patch
----
-
-Add support for screen share audio in setScreenShareEnabled method

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -208,7 +208,6 @@ export default class LocalParticipant extends Participant {
               break;
             case Track.Source.Microphone:
               localTracks = await this.createTracks({
-                ...(options as AudioCaptureOptions),
                 audio: (options as AudioCaptureOptions | undefined) ?? true,
               });
               break;

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -225,7 +225,7 @@ export default class LocalParticipant extends Participant {
           }
           const publishedTracks = await Promise.all(publishPromises);
           // for screen share publications including audio, this will only return the screen share publication, not the screen share audio one
-          // revisit if we'd want to return an array of tracks instead for v2
+          // revisit if we want to return an array of tracks instead for v2
           [track] = publishedTracks;
         } catch (e) {
           if (e instanceof Error && !(e instanceof TrackInvalidError)) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -219,9 +219,14 @@ export default class LocalParticipant extends Participant {
             default:
               throw new TrackInvalidError(source);
           }
+          const publishPromises: Array<Promise<LocalTrackPublication>> = [];
           for (const localTrack of localTracks) {
-            track = await this.publishTrack(localTrack);
+            publishPromises.push(this.publishTrack(localTrack));
           }
+          const publishedTracks = await Promise.all(publishPromises);
+          // for screen share publications including audio, this will only return the screen share publication, not the screen share audio one
+          // revisit if we'd want to return an array of tracks instead for v2
+          [track] = publishedTracks;
         } catch (e) {
           if (e instanceof Error && !(e instanceof TrackInvalidError)) {
             this.emit(ParticipantEvent.MediaDevicesError, e);


### PR DESCRIPTION
Will tackle "mute instead of unpublish" for screenshare in a separate PR. 
Making the functionality available seems like higher priority for now than the internal handling of it. 