### PR TITLE
Fix type declaration path

### DIFF
--- a/.changeset/hot-planes-check.md
+++ b/.changeset/hot-planes-check.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix typescript declaration location

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dist",
     "src"
   ],
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "repository": "git@github.com:livekit/client-sdk-js.git",
   "author": "David Zhao <david@davidzhao.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
For some reason, this commit https://github.com/livekit/client-sdk-js/pull/246/commits/bbc9239aa0f6031d04a21c7022621b1005b90aa4, changed the output location folder of the type declarations. They used to be at `dist/index.d.ts` and are now at `dist/src/index.d.ts`. 

This means type declarations are effectively missing in v1.0.2

