### PR TITLE
Reconnect policy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,5 +48,5 @@ export {
   VideoQuality,
   ConnectionQuality,
   ElementInfo,
-  DefaultReconnectPolicy
+  DefaultReconnectPolicy,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import Participant, { ConnectionQuality } from './room/participant/Participant';
 import { ParticipantTrackPermission } from './room/participant/ParticipantTrackPermission';
 import RemoteParticipant from './room/participant/RemoteParticipant';
 import Room, { ConnectionState, RoomState } from './room/Room';
+import DefaultReconnectPolicy from './room/DefaultReconnectPolicy';
 import LocalAudioTrack from './room/track/LocalAudioTrack';
 import LocalTrack from './room/track/LocalTrack';
 import LocalTrackPublication from './room/track/LocalTrackPublication';
@@ -47,4 +48,5 @@ export {
   VideoQuality,
   ConnectionQuality,
   ElementInfo,
+  DefaultReconnectPolicy
 };

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,7 +4,7 @@ import {
   VideoCaptureOptions,
 } from './room/track/options';
 import { AdaptiveStreamSettings } from './room/track/types';
-import { IReconnectPolicy } from './room/IReconnectPolicy';
+import { ReconnectPolicy } from './room/ReconnectPolicy';
 
 /**
  * Options for when creating a new room
@@ -58,7 +58,7 @@ export interface RoomOptions {
   /**
    * policy to use when attempting to reconnect
    */
-  reconnectPolicy?: IReconnectPolicy;
+  reconnectPolicy?: ReconnectPolicy;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,6 +4,7 @@ import {
   VideoCaptureOptions,
 } from './room/track/options';
 import { AdaptiveStreamSettings } from './room/track/types';
+import { IReconnectPolicy } from './room/IReconnectPolicy';
 
 /**
  * Options for when creating a new room
@@ -53,6 +54,11 @@ export interface RoomOptions {
    * experimental flag, introduce a delay before sending signaling messages
    */
   expSignalLatency?: number;
+
+  /**
+   * policy to use when attempting to reconnect
+   */
+  reconnectPolicy?: IReconnectPolicy;
 }
 
 /**

--- a/src/room/DefaultReconnectPolicy.ts
+++ b/src/room/DefaultReconnectPolicy.ts
@@ -1,0 +1,33 @@
+import { IReconnectPolicy, ReconnectContext } from './IReconnectPolicy';
+
+const DEFAULT_RETRY_DELAYS_IN_MS = [
+  0,
+  300,
+  2 * 2 * 300,
+  3 * 3 * 300,
+  4 * 4 * 300,
+  5 * 5 * 300,
+  6 * 6 * 300,
+  7 * 7 * 300,
+  8 * 8 * 300,
+  9 * 9 * 300,
+  null,
+];
+
+class DefaultReconnectPolicy implements IReconnectPolicy {
+  private readonly _retryDelays: (number | null)[];
+
+  constructor(retryDelays?: number[]) {
+    this._retryDelays =
+      retryDelays !== undefined ? [...retryDelays, null] : DEFAULT_RETRY_DELAYS_IN_MS;
+  }
+
+  public nextRetryDelayInMs(context: ReconnectContext): number | null {
+    const retryDelay = this._retryDelays[context.retryCount];
+    if (!retryDelay || context.retryCount <= 1) return retryDelay;
+
+    return retryDelay + Math.random() * 1_000;
+  }
+}
+
+export default DefaultReconnectPolicy;

--- a/src/room/DefaultReconnectPolicy.ts
+++ b/src/room/DefaultReconnectPolicy.ts
@@ -1,4 +1,4 @@
-import { IReconnectPolicy, ReconnectContext } from './IReconnectPolicy';
+import { IReconnectContext, IReconnectPolicy } from './IReconnectPolicy';
 
 const DEFAULT_RETRY_DELAYS_IN_MS = [
   0,
@@ -11,20 +11,20 @@ const DEFAULT_RETRY_DELAYS_IN_MS = [
   7 * 7 * 300,
   8 * 8 * 300,
   9 * 9 * 300,
-  null,
 ];
 
 class DefaultReconnectPolicy implements IReconnectPolicy {
-  private readonly _retryDelays: (number | null)[];
+  private readonly _retryDelays: number[];
 
   constructor(retryDelays?: number[]) {
-    this._retryDelays =
-      retryDelays !== undefined ? [...retryDelays, null] : DEFAULT_RETRY_DELAYS_IN_MS;
+    this._retryDelays = retryDelays !== undefined ? [...retryDelays] : DEFAULT_RETRY_DELAYS_IN_MS;
   }
 
-  public nextRetryDelayInMs(context: ReconnectContext): number | null {
+  public nextRetryDelayInMs(context: IReconnectContext): number | null {
+    if (context.retryCount === this._retryDelays.length) return null;
+
     const retryDelay = this._retryDelays[context.retryCount];
-    if (!retryDelay || context.retryCount <= 1) return retryDelay;
+    if (context.retryCount <= 1) return retryDelay;
 
     return retryDelay + Math.random() * 1_000;
   }

--- a/src/room/DefaultReconnectPolicy.ts
+++ b/src/room/DefaultReconnectPolicy.ts
@@ -1,4 +1,4 @@
-import { IReconnectContext, IReconnectPolicy } from './IReconnectPolicy';
+import { ReconnectContext, ReconnectPolicy } from './ReconnectPolicy';
 
 const DEFAULT_RETRY_DELAYS_IN_MS = [
   0,
@@ -13,14 +13,14 @@ const DEFAULT_RETRY_DELAYS_IN_MS = [
   9 * 9 * 300,
 ];
 
-class DefaultReconnectPolicy implements IReconnectPolicy {
+class DefaultReconnectPolicy implements ReconnectPolicy {
   private readonly _retryDelays: number[];
 
   constructor(retryDelays?: number[]) {
     this._retryDelays = retryDelays !== undefined ? [...retryDelays] : DEFAULT_RETRY_DELAYS_IN_MS;
   }
 
-  public nextRetryDelayInMs(context: IReconnectContext): number | null {
+  public nextRetryDelayInMs(context: ReconnectContext): number | null {
     if (context.retryCount === this._retryDelays.length) return null;
 
     const retryDelay = this._retryDelays[context.retryCount];

--- a/src/room/IReconnectPolicy.ts
+++ b/src/room/IReconnectPolicy.ts
@@ -23,17 +23,3 @@ export interface IReconnectContext {
    */
   readonly retryReason?: Error;
 }
-
-export class ReconnectContext implements IReconnectContext {
-  public readonly elapsedMs: number;
-
-  public readonly retryCount: number;
-
-  public readonly retryReason?: Error;
-
-  constructor(elapsedMilliseconds: number, retryCount: number, retryReason?: Error) {
-    this.elapsedMs = elapsedMilliseconds;
-    this.retryCount = retryCount;
-    this.retryReason = retryReason;
-  }
-}

--- a/src/room/IReconnectPolicy.ts
+++ b/src/room/IReconnectPolicy.ts
@@ -1,0 +1,39 @@
+/** Controls reconnecting of the client */
+export interface IReconnectPolicy {
+  /** Called after disconnect was detected
+   *
+   * @returns {number | null} Amount of time in milliseconds to delay the next reconnect attempt, `null` signals to stop retrying.
+   */
+  nextRetryDelayInMs(context: IReconnectContext): number | null;
+}
+
+export interface IReconnectContext {
+  /**
+   * Number of failed reconnect attempts
+   */
+  readonly retryCount: number;
+
+  /**
+   * Elapsed amount of time in milliseconds since the disconnect.
+   */
+  readonly elapsedMs: number;
+
+  /**
+   * Reason for retrying
+   */
+  readonly retryReason?: Error;
+}
+
+export class ReconnectContext implements IReconnectContext {
+  public readonly elapsedMs: number;
+
+  public readonly retryCount: number;
+
+  public readonly retryReason?: Error;
+
+  constructor(elapsedMilliseconds: number, retryCount: number, retryReason?: Error) {
+    this.elapsedMs = elapsedMilliseconds;
+    this.retryCount = retryCount;
+    this.retryReason = retryReason;
+  }
+}

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -577,8 +577,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     let waitForPcCompleted = false;
     const waitForPc = this.waitForPCConnected()
-      .then(() => (waitForPcCompleted = true))
-      .catch((_) => Error('failed to wait for peer connection'));
+      .then(() => {
+        waitForPcCompleted = true;
+      })
+      .catch(() => Error('failed to wait for peer connection'));
 
     while (!waitForPcCompleted) {
       // TODO: this is a workaround to check if the socket was closed while we are reconnecting

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -22,12 +22,13 @@ import { ConnectionError, TrackInvalidError, UnexpectedConnectionState } from '.
 import { EngineEvent } from './events';
 import PCTransport from './PCTransport';
 import { isFireFox, isWeb, sleep } from './utils';
+import { RoomOptions } from '../options';
+import { IReconnectPolicy, ReconnectContext } from './IReconnectPolicy';
+import DefaultReconnectPolicy from './DefaultReconnectPolicy';
 
 const lossyDataChannel = '_lossy';
 const reliableDataChannel = '_reliable';
-const maxReconnectRetries = 10;
 const minReconnectWait = 2 * 1000;
-const maxReconnectDuration = 60 * 1000;
 export const maxICEConnectTimeout = 15 * 1000;
 
 enum PCState {
@@ -95,9 +96,13 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
   private attemptingReconnect: boolean = false;
 
-  constructor() {
+  private reconnectPolicy: IReconnectPolicy;
+
+  constructor(private options: RoomOptions) {
     super();
     this.client = new SignalClient();
+    this.client.signalLatency = this.options.expSignalLatency;
+    this.reconnectPolicy = this.options.reconnectPolicy ?? new DefaultReconnectPolicy();
   }
 
   async join(
@@ -416,17 +421,37 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   // websocket reconnect behavior. if websocket is interrupted, and the PeerConnection
   // continues to work, we can reconnect to websocket to continue the session
   // after a number of retries, we'll close and give up permanently
-  private handleDisconnect = (connection: string) => {
+  private handleDisconnect = (connection: string, signalEvents: boolean = false) => {
     if (this._isClosed) {
       return;
     }
+
     log.debug(`${connection} disconnected`);
     if (this.reconnectAttempts === 0) {
       // only reset start time on the first try
       this.reconnectStart = Date.now();
     }
 
-    const delay = this.reconnectAttempts * this.reconnectAttempts * 300;
+    const disconnect = (duration: number) => {
+      log.info(
+        `could not recover connection after ${this.reconnectAttempts} attempts, ${duration}ms. giving up`,
+      );
+      this.emit(EngineEvent.Disconnected);
+      this.close();
+    };
+
+    let duration = Date.now() - this.reconnectStart;
+    let reconnectContext = new ReconnectContext(duration, this.reconnectAttempts);
+
+    let delay = this.getNextRetryDelay(reconnectContext);
+
+    if (delay === null) {
+      disconnect(duration);
+      return;
+    }
+
+    log.debug(`reconnecting in ${delay}ms`);
+
     setTimeout(async () => {
       if (this._isClosed) {
         return;
@@ -448,45 +473,31 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       try {
         this.attemptingReconnect = true;
         if (this.fullReconnectOnNext) {
-          await this.restartConnection();
+          await this.restartConnection(signalEvents);
         } else {
-          await this.resumeConnection();
+          await this.resumeConnection(signalEvents);
         }
         this.reconnectAttempts = 0;
         this.fullReconnectOnNext = false;
       } catch (e) {
+        log.debug('received reconnect error', { error: e });
         this.reconnectAttempts += 1;
-        let reconnectRequired = false;
-        let recoverable = true;
-        if (e instanceof UnexpectedConnectionState) {
-          log.debug('received unrecoverable error', { error: e });
-          // unrecoverable
-          recoverable = false;
-        } else if (!(e instanceof SignalReconnectError)) {
-          // cannot resume
-          reconnectRequired = true;
+        let requireSignalEvents = false;
+        if (e instanceof UnexpectedConnectionState || !(e instanceof SignalReconnectError)) {
+          if (!this.fullReconnectOnNext) {
+            this.fullReconnectOnNext = true;
+            requireSignalEvents = true;
+          }
         }
 
-        // when we flip from resume to reconnect, we need to reset reconnectAttempts
-        // this is needed to fire the right reconnecting events
-        if (reconnectRequired && !this.fullReconnectOnNext) {
-          this.fullReconnectOnNext = true;
-          this.reconnectAttempts = 0;
-        }
+        duration = Date.now() - this.reconnectStart;
+        reconnectContext = new ReconnectContext(duration, this.reconnectAttempts, e);
+        delay = this.getNextRetryDelay(reconnectContext);
 
-        const duration = Date.now() - this.reconnectStart;
-        if (this.reconnectAttempts >= maxReconnectRetries || duration > maxReconnectDuration) {
-          recoverable = false;
-        }
-
-        if (recoverable) {
-          this.handleDisconnect('reconnect');
+        if (delay === null) {
+          disconnect(duration);
         } else {
-          log.info(
-            `could not recover connection after ${maxReconnectRetries} attempts, ${duration}ms. giving up`,
-          );
-          this.emit(EngineEvent.Disconnected);
-          this.close();
+          this.handleDisconnect('reconnect', requireSignalEvents);
         }
       } finally {
         this.attemptingReconnect = false;
@@ -494,14 +505,25 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }, delay);
   };
 
-  private async restartConnection() {
+  private getNextRetryDelay(context: ReconnectContext) {
+    try {
+      return this.reconnectPolicy.nextRetryDelayInMs(context);
+    } catch (e) {
+      log.warn('encountered error in reconnect policy', { error: e });
+    }
+
+    // error in user code with provided reconnect policy, stop reconnecting
+    return null;
+  }
+
+  private async restartConnection(emitRestarting: boolean = false) {
     if (!this.url || !this.token) {
       // permanent failure, don't attempt reconnection
       throw new UnexpectedConnectionState('could not reconnect, url or token not saved');
     }
 
     log.info(`reconnecting, attempt: ${this.reconnectAttempts}`);
-    if (this.reconnectAttempts === 0) {
+    if (emitRestarting || this.reconnectAttempts === 0) {
       this.emit(EngineEvent.Restarting);
     }
 
@@ -529,7 +551,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.emit(EngineEvent.Restarted, joinResponse);
   }
 
-  private async resumeConnection(): Promise<void> {
+  private async resumeConnection(emitResuming: boolean = false): Promise<void> {
     if (!this.url || !this.token) {
       // permanent failure, don't attempt reconnection
       throw new UnexpectedConnectionState('could not reconnect, url or token not saved');
@@ -540,25 +562,42 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
 
     log.info(`resuming signal connection, attempt ${this.reconnectAttempts}`);
-    if (this.reconnectAttempts === 0) {
+    if (emitResuming || this.reconnectAttempts === 0) {
       this.emit(EngineEvent.Resuming);
     }
 
     try {
       await this.client.reconnect(this.url, this.token);
     } catch (e) {
-      throw new SignalReconnectError();
+      throw new SignalReconnectError(e);
     }
-    this.emit(EngineEvent.SignalResumed);
 
+    this.emit(EngineEvent.SignalResumed);
     this.subscriber.restartingIce = true;
+
+    let waitForPcCompleted = false;
+    const waitForPc = this.waitForPCConnected()
+      .then(() => (waitForPcCompleted = true))
+      .catch((_) => Error('failed to wait for peer connection'));
+
+    while (!waitForPcCompleted) {
+      // TODO: this is a workaround to check if the socket was closed while we are reconnecting
+      // if signal client reconnects with ?reconnect=1 ws.onclose is almost immediately called after ws.onopen
+      if (!this.client.isConnected) {
+        this.fullReconnectOnNext = true;
+        throw new SignalReconnectError('socket closed after opening');
+      }
+
+      await sleep(50);
+    }
+
+    await waitForPc;
 
     // only restart publisher if it's needed
     if (this.hasPublished) {
       await this.publisher.createAndSendOffer({ iceRestart: true });
     }
 
-    await this.waitForPCConnected();
     this.client.setReconnected();
 
     // resume success

--- a/src/room/ReconnectPolicy.ts
+++ b/src/room/ReconnectPolicy.ts
@@ -1,13 +1,13 @@
 /** Controls reconnecting of the client */
-export interface IReconnectPolicy {
+export interface ReconnectPolicy {
   /** Called after disconnect was detected
    *
    * @returns {number | null} Amount of time in milliseconds to delay the next reconnect attempt, `null` signals to stop retrying.
    */
-  nextRetryDelayInMs(context: IReconnectContext): number | null;
+  nextRetryDelayInMs(context: ReconnectContext): number | null;
 }
 
-export interface IReconnectContext {
+export interface ReconnectContext {
   /**
    * Number of failed reconnect attempts
    */

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -139,9 +139,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
 
-    this.engine = new RTCEngine();
+    this.engine = new RTCEngine(this.options);
 
-    this.engine.client.signalLatency = this.options.expSignalLatency;
     this.engine.client.onParticipantUpdate = this.handleParticipantUpdates;
     this.engine.client.onRoomUpdate = this.handleRoomUpdate;
     this.engine.client.onSpeakersChanged = this.handleSpeakersChanged;


### PR DESCRIPTION
My motivation was that the existing reconnection logic gave up reconnecting after the LiveKit node was forcefully restarted.
Also in response to #261 I revisited the reconnection handling.

I run into an issue where the  websocket connection is being closed after trying to resume with `?reconnect=1` 
probably initiated on the server side.

I added a workaround [here](https://github.com/taskbit/client-sdk-js/blob/47ca91f95f2f325d9319cc9821fda3f1d1c0b7d1/src/room/RTCEngine.ts#L584)