### PR TITLE
Added generic type to the Room class so RoomEventCallbacks can be extended

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -55,7 +55,7 @@ export const RoomState = ConnectionState;
  *
  * @noInheritDoc
  */
-class Room<T = RoomEventCallbacks> extends (EventEmitter as { new<T>(): TypedEmitter<T> })<T> {
+class Room<RoomEventGeneric = RoomEventCallbacks> extends (EventEmitter as { new<RoomEventGeneric>(): TypedEmitter<RoomEventGeneric> })<RoomEventGeneric> {
   state: ConnectionState = ConnectionState.Disconnected;
 
   /** map of sid: [[RemoteParticipant]] */

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -55,7 +55,7 @@ export const RoomState = ConnectionState;
  *
  * @noInheritDoc
  */
-class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) {
+class Room<T = RoomEventCallbacks> extends (EventEmitter as { new<T>(): TypedEmitter<T> })<T> {
   state: ConnectionState = ConnectionState.Disconnected;
 
   /** map of sid: [[RemoteParticipant]] */

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -55,7 +55,7 @@ export const RoomState = ConnectionState;
  *
  * @noInheritDoc
  */
-class Room<RoomEventGeneric = RoomEventCallbacks> extends (EventEmitter as { new<RoomEventGeneric>(): TypedEmitter<RoomEventGeneric> })<RoomEventGeneric> {
+class Room<T = RoomEventCallbacks> extends (EventEmitter as { new<Tsub>(): TypedEmitter<Tsub> })<T> {
   state: ConnectionState = ConnectionState.Disconnected;
 
   /** map of sid: [[RemoteParticipant]] */


### PR DESCRIPTION
This change is for developers who want to extend Room and RoomEventCallbacks. RoomEventCallbacks cannot be extended with additional callbacks because the Room class is not a generic. 

It is not a breaking change.