### PR TITLE
Fix missed TrackPublished events.

### DIFF
--- a/.changeset/famous-suits-matter.md
+++ b/.changeset/famous-suits-matter.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fixed TrackPublished events not firing correctly in some cases

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -571,7 +571,6 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
 function renderScreenShare(room: Room) {
   const div = $('screenshare-area')!;
   if (room.state !== ConnectionState.Connected) {
-    console.log('room not yet connected', room.state);
     div.style.display = 'none';
     return;
   }
@@ -587,7 +586,6 @@ function renderScreenShare(room: Room) {
       }
       participant = p;
       const pub = p.getTrack(Track.Source.ScreenShare);
-      console.log('found screen share from', p.identity, pub?.isSubscribed);
       if (pub?.isSubscribed) {
         screenSharePub = pub;
       }
@@ -597,7 +595,6 @@ function renderScreenShare(room: Room) {
       }
     });
   } else {
-    console.log('found local screen share');
     participant = room.localParticipant;
   }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -850,7 +850,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // and remote participant joined the room
     participant
       .on(ParticipantEvent.TrackPublished, (trackPublication: RemoteTrackPublication) => {
-        this.emit(RoomEvent.TrackPublished, trackPublication, participant);
+        if (this.state === ConnectionState.Connected) {
+          this.emit(RoomEvent.TrackPublished, trackPublication, participant);
+        }
       })
       .on(
         ParticipantEvent.TrackSubscribed,
@@ -893,6 +895,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           this.emit(RoomEvent.ParticipantPermissionsChanged, prevPermissions, participant);
         },
       );
+
+    // update info at the end after callbacks have been set up
+    if (info) {
+      participant.updateInfo(info);
+    }
     return participant;
   }
 

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -23,9 +23,7 @@ export default class RemoteParticipant extends Participant {
 
   /** @internal */
   static fromParticipantInfo(signalClient: SignalClient, pi: ParticipantInfo): RemoteParticipant {
-    const rp = new RemoteParticipant(signalClient, pi.sid, pi.identity);
-    rp.updateInfo(pi);
-    return rp;
+    return new RemoteParticipant(signalClient, pi.sid, pi.identity);
   }
 
   /** @internal */
@@ -182,8 +180,6 @@ export default class RemoteParticipant extends Participant {
 
   /** @internal */
   updateInfo(info: ParticipantInfo) {
-    const alreadyHasMetadata = this.hasMetadata;
-
     super.updateInfo(info);
 
     // we are getting a list of all available tracks, reconcile in here
@@ -212,12 +208,10 @@ export default class RemoteParticipant extends Participant {
       validTracks.set(ti.sid, publication);
     });
 
-    // send new tracks
-    if (alreadyHasMetadata) {
-      newTracks.forEach((publication) => {
-        this.emit(ParticipantEvent.TrackPublished, publication);
-      });
-    }
+    // always emit events for new publications, Room will not forward them unless it's ready
+    newTracks.forEach((publication) => {
+      this.emit(ParticipantEvent.TrackPublished, publication);
+    });
 
     // detect removed tracks
     this.tracks.forEach((publication) => {


### PR DESCRIPTION
When initial participant info is sent down along with tracks, we would
miss emitting TrackPublished events for them. This is due an incorrect
assumption that participants would first join without tracks.

Instead of relying on if it's the first update, we now use Room connection
state to determine if those TrackPublished events should be emitted or not.