### PR TITLE
Manually compute initial visibilty

### DIFF
--- a/.changeset/kind-radios-attend.md
+++ b/.changeset/kind-radios-attend.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+compute initial visible value for element infos manually

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -342,7 +342,7 @@ function isElementInViewport(el: HTMLElement) {
   const width = el.offsetWidth;
   const height = el.offsetHeight;
   const { hidden } = el;
-  const { opacity } = getComputedStyle(el);
+  const { opacity, display } = getComputedStyle(el);
 
   while (el.offsetParent) {
     el = el.offsetParent as HTMLElement;
@@ -356,6 +356,7 @@ function isElementInViewport(el: HTMLElement) {
     top + height > window.pageYOffset &&
     left + width > window.pageXOffset &&
     !hidden &&
-    (opacity !== '' ? parseFloat(opacity) > 0 : true)
+    (opacity !== '' ? parseFloat(opacity) > 0 : true) &&
+    display !== 'none'
   );
 }


### PR DESCRIPTION
After a reconnect, sometimes the resize observer does not trigger a visibility update after `observer.observe(element)` is called, so the `visible` value stays on the ElementInfo's default value (`false`).
To mitigate this, this PR computes the current visibility of the element manually in the constructor of `ElementInfo`.
