### PR TITLE
Only restart tracks if they are internally managed by the SDK

### DIFF
--- a/.changeset/shiny-eyes-clean.md
+++ b/.changeset/shiny-eyes-clean.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Only restart tracks if they are internally managed by the sdk

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -578,7 +578,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         if (!track.isMuted) {
           if (
             (track instanceof LocalAudioTrack || track instanceof LocalVideoTrack) &&
-            track.trackIsManaged
+            !track.isUserProvided
           ) {
             // we need to restart the track before publishing, often a full reconnect
             // is necessary because computer had gone to sleep.

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -576,7 +576,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         const track = pub.track!;
         this.localParticipant.unpublishTrack(track, false);
         if (!track.isMuted) {
-          if (track instanceof LocalAudioTrack || track instanceof LocalVideoTrack) {
+          if (
+            (track instanceof LocalAudioTrack || track instanceof LocalVideoTrack) &&
+            track.trackIsManaged
+          ) {
             // we need to restart the track before publishing, often a full reconnect
             // is necessary because computer had gone to sleep.
             log.debug('restarting existing track', {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -366,11 +366,11 @@ export default class LocalParticipant extends Participant {
     if (tracks.length === 0) {
       throw new TrackInvalidError('no video track found');
     }
-    const screenVideo = new LocalVideoTrack(tracks[0], undefined, true);
+    const screenVideo = new LocalVideoTrack(tracks[0], undefined, false);
     screenVideo.source = Track.Source.ScreenShare;
     const localTracks: Array<LocalTrack> = [screenVideo];
     if (stream.getAudioTracks().length > 0) {
-      const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0], undefined, true);
+      const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0], undefined, false);
       screenAudio.source = Track.Source.ScreenShareAudio;
       localTracks.push(screenAudio);
     }
@@ -395,10 +395,10 @@ export default class LocalParticipant extends Participant {
     if (track instanceof MediaStreamTrack) {
       switch (track.kind) {
         case 'audio':
-          track = new LocalAudioTrack(track, undefined, false);
+          track = new LocalAudioTrack(track, undefined, true);
           break;
         case 'video':
-          track = new LocalVideoTrack(track, undefined, false);
+          track = new LocalVideoTrack(track, undefined, true);
           break;
         default:
           throw new TrackInvalidError(`unsupported MediaStreamTrack kind ${track.kind}`);

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -370,7 +370,7 @@ export default class LocalParticipant extends Participant {
     screenVideo.source = Track.Source.ScreenShare;
     const localTracks: Array<LocalTrack> = [screenVideo];
     if (stream.getAudioTracks().length > 0) {
-      const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0]);
+      const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0], undefined, true);
       screenAudio.source = Track.Source.ScreenShareAudio;
       localTracks.push(screenAudio);
     }
@@ -395,10 +395,10 @@ export default class LocalParticipant extends Participant {
     if (track instanceof MediaStreamTrack) {
       switch (track.kind) {
         case 'audio':
-          track = new LocalAudioTrack(track);
+          track = new LocalAudioTrack(track, undefined, false);
           break;
         case 'video':
-          track = new LocalVideoTrack(track);
+          track = new LocalVideoTrack(track, undefined, false);
           break;
         default:
           throw new TrackInvalidError(`unsupported MediaStreamTrack kind ${track.kind}`);

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -366,7 +366,7 @@ export default class LocalParticipant extends Participant {
     if (tracks.length === 0) {
       throw new TrackInvalidError('no video track found');
     }
-    const screenVideo = new LocalVideoTrack(tracks[0]);
+    const screenVideo = new LocalVideoTrack(tracks[0], undefined, true);
     screenVideo.source = Track.Source.ScreenShare;
     const localTracks: Array<LocalTrack> = [screenVideo];
     if (stream.getAudioTracks().length > 0) {

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -18,9 +18,9 @@ export function mediaTrackToLocalTrack(
 ): LocalVideoTrack | LocalAudioTrack {
   switch (mediaStreamTrack.kind) {
     case 'audio':
-      return new LocalAudioTrack(mediaStreamTrack, constraints, true);
+      return new LocalAudioTrack(mediaStreamTrack, constraints, false);
     case 'video':
-      return new LocalVideoTrack(mediaStreamTrack, constraints, true);
+      return new LocalVideoTrack(mediaStreamTrack, constraints, false);
     default:
       throw new TrackInvalidError(`unsupported track type: ${mediaStreamTrack.kind}`);
   }

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -18,9 +18,9 @@ export function mediaTrackToLocalTrack(
 ): LocalVideoTrack | LocalAudioTrack {
   switch (mediaStreamTrack.kind) {
     case 'audio':
-      return new LocalAudioTrack(mediaStreamTrack, constraints);
+      return new LocalAudioTrack(mediaStreamTrack, constraints, true);
     case 'video':
-      return new LocalVideoTrack(mediaStreamTrack, constraints);
+      return new LocalVideoTrack(mediaStreamTrack, constraints, true);
     default:
       throw new TrackInvalidError(`unsupported track type: ${mediaStreamTrack.kind}`);
   }

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -15,8 +15,12 @@ export default class LocalAudioTrack extends LocalTrack {
 
   private prevStats?: AudioSenderStats;
 
-  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints, managed = false) {
-    super(mediaTrack, Track.Kind.Audio, constraints, managed);
+  constructor(
+    mediaTrack: MediaStreamTrack,
+    constraints?: MediaTrackConstraints,
+    userProvidedTrack = true,
+  ) {
+    super(mediaTrack, Track.Kind.Audio, constraints, userProvidedTrack);
     this.checkForSilence();
   }
 
@@ -42,7 +46,7 @@ export default class LocalAudioTrack extends LocalTrack {
   }
 
   async unmute(): Promise<LocalAudioTrack> {
-    if (this.source === Track.Source.Microphone && this.stopOnMute && this.trackIsManaged) {
+    if (this.source === Track.Source.Microphone && this.stopOnMute && !this.isUserProvided) {
       log.debug('reacquiring mic track');
       await this.restartTrack();
     }

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -15,8 +15,8 @@ export default class LocalAudioTrack extends LocalTrack {
 
   private prevStats?: AudioSenderStats;
 
-  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints) {
-    super(mediaTrack, Track.Kind.Audio, constraints);
+  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints, managed = false) {
+    super(mediaTrack, Track.Kind.Audio, constraints, managed);
     this.checkForSilence();
   }
 
@@ -42,7 +42,7 @@ export default class LocalAudioTrack extends LocalTrack {
   }
 
   async unmute(): Promise<LocalAudioTrack> {
-    if (this.source === Track.Source.Microphone && this.stopOnMute) {
+    if (this.source === Track.Source.Microphone && this.stopOnMute && this.trackIsManaged) {
       log.debug('reacquiring mic track');
       await this.restartTrack();
     }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -88,7 +88,7 @@ export default class LocalTrack extends Track {
     return this;
   }
 
-  async replaceTrack(track: MediaStreamTrack): Promise<LocalTrack> {
+  async replaceTrack(track: MediaStreamTrack, userProvidedTrack = true): Promise<LocalTrack> {
     if (!this.sender) {
       throw new TrackInvalidError('unable to replace an unpublished track');
     }
@@ -116,6 +116,7 @@ export default class LocalTrack extends Track {
     });
 
     this.mediaStream = new MediaStream([track]);
+    this.providedByUser = userProvidedTrack;
     return this;
   }
 

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -19,20 +19,20 @@ export default class LocalTrack extends Track {
 
   protected reacquireTrack: boolean;
 
-  protected managedTrack: boolean;
+  protected providedByUser: boolean;
 
   protected constructor(
     mediaTrack: MediaStreamTrack,
     kind: Track.Kind,
     constraints?: MediaTrackConstraints,
-    managed = false,
+    userProvidedTrack = false,
   ) {
     super(mediaTrack, kind);
     this._mediaStreamTrack.addEventListener('ended', this.handleEnded);
     this.constraints = constraints ?? mediaTrack.getConstraints();
     this.reacquireTrack = false;
     this.wasMuted = false;
-    this.managedTrack = managed;
+    this.providedByUser = userProvidedTrack;
   }
 
   get id(): string {
@@ -60,8 +60,8 @@ export default class LocalTrack extends Track {
     return this._isUpstreamPaused;
   }
 
-  get trackIsManaged() {
-    return this.managedTrack;
+  get isUserProvided() {
+    return this.providedByUser;
   }
 
   /**
@@ -192,7 +192,7 @@ export default class LocalTrack extends Track {
     if (!isMobile()) return;
     log.debug(`visibility changed, is in Background: ${this.isInBackground}`);
 
-    if (!this.isInBackground && this.needsReAcquisition && this.trackIsManaged) {
+    if (!this.isInBackground && this.needsReAcquisition && !this.isUserProvided) {
       log.debug(`track needs to be reaquired, restarting ${this.source}`);
       await this.restart();
       this.reacquireTrack = false;

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -19,16 +19,20 @@ export default class LocalTrack extends Track {
 
   protected reacquireTrack: boolean;
 
+  protected managedTrack: boolean;
+
   protected constructor(
     mediaTrack: MediaStreamTrack,
     kind: Track.Kind,
     constraints?: MediaTrackConstraints,
+    managed = false,
   ) {
     super(mediaTrack, kind);
     this._mediaStreamTrack.addEventListener('ended', this.handleEnded);
     this.constraints = constraints ?? mediaTrack.getConstraints();
     this.reacquireTrack = false;
     this.wasMuted = false;
+    this.managedTrack = managed;
   }
 
   get id(): string {
@@ -54,6 +58,10 @@ export default class LocalTrack extends Track {
 
   get isUpstreamPaused() {
     return this._isUpstreamPaused;
+  }
+
+  get trackIsManaged() {
+    return this.managedTrack;
   }
 
   /**
@@ -184,7 +192,7 @@ export default class LocalTrack extends Track {
     if (!isMobile()) return;
     log.debug(`visibility changed, is in Background: ${this.isInBackground}`);
 
-    if (!this.isInBackground && this.needsReAcquisition) {
+    if (!this.isInBackground && this.needsReAcquisition && this.trackIsManaged) {
       log.debug(`track needs to be reaquired, restarting ${this.source}`);
       await this.restart();
       this.reacquireTrack = false;

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -41,8 +41,8 @@ export default class LocalVideoTrack extends LocalTrack {
 
   private subscribedCodecs?: SubscribedCodec[];
 
-  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints) {
-    super(mediaTrack, Track.Kind.Video, constraints);
+  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints, managed = false) {
+    super(mediaTrack, Track.Kind.Video, constraints, managed);
   }
 
   get isSimulcast(): boolean {
@@ -92,7 +92,7 @@ export default class LocalVideoTrack extends LocalTrack {
   }
 
   async unmute(): Promise<LocalVideoTrack> {
-    if (this.source === Track.Source.Camera) {
+    if (this.source === Track.Source.Camera && this.trackIsManaged) {
       log.debug('reacquiring camera track');
       await this.restartTrack();
     }

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -41,8 +41,12 @@ export default class LocalVideoTrack extends LocalTrack {
 
   private subscribedCodecs?: SubscribedCodec[];
 
-  constructor(mediaTrack: MediaStreamTrack, constraints?: MediaTrackConstraints, managed = false) {
-    super(mediaTrack, Track.Kind.Video, constraints, managed);
+  constructor(
+    mediaTrack: MediaStreamTrack,
+    constraints?: MediaTrackConstraints,
+    userProvidedTrack = true,
+  ) {
+    super(mediaTrack, Track.Kind.Video, constraints, userProvidedTrack);
   }
 
   get isSimulcast(): boolean {
@@ -92,7 +96,7 @@ export default class LocalVideoTrack extends LocalTrack {
   }
 
   async unmute(): Promise<LocalVideoTrack> {
-    if (this.source === Track.Source.Camera && this.trackIsManaged) {
+    if (this.source === Track.Source.Camera && !this.isUserProvided) {
       log.debug('reacquiring camera track');
       await this.restartTrack();
     }

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -110,11 +110,11 @@ export async function createLocalScreenTracks(
   if (tracks.length === 0) {
     throw new TrackInvalidError('no video track found');
   }
-  const screenVideo = new LocalVideoTrack(tracks[0]);
+  const screenVideo = new LocalVideoTrack(tracks[0], undefined, true);
   screenVideo.source = Track.Source.ScreenShare;
   const localTracks: Array<LocalTrack> = [screenVideo];
   if (stream.getAudioTracks().length > 0) {
-    const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0]);
+    const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0], undefined, true);
     screenAudio.source = Track.Source.ScreenShareAudio;
     localTracks.push(screenAudio);
   }

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -110,11 +110,11 @@ export async function createLocalScreenTracks(
   if (tracks.length === 0) {
     throw new TrackInvalidError('no video track found');
   }
-  const screenVideo = new LocalVideoTrack(tracks[0], undefined, true);
+  const screenVideo = new LocalVideoTrack(tracks[0], undefined, false);
   screenVideo.source = Track.Source.ScreenShare;
   const localTracks: Array<LocalTrack> = [screenVideo];
   if (stream.getAudioTracks().length > 0) {
-    const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0], undefined, true);
+    const screenAudio = new LocalAudioTrack(stream.getAudioTracks()[0], undefined, false);
     screenAudio.source = Track.Source.ScreenShareAudio;
     localTracks.push(screenAudio);
   }


### PR DESCRIPTION
Not very happy about the naming with `managed` and `isTrackManaged` because it's quite ambiguous. Could mean both "externally managed" and "internally managed". 

