### PR TITLE
Fixed issues with reconnecting to the same Room object

### DIFF
--- a/.changeset/twelve-fans-unite.md
+++ b/.changeset/twelve-fans-unite.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fixed reconnection with the same Room object

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -42,13 +42,14 @@ export default class LocalParticipant extends Participant {
   /** map of track sid => all published tracks */
   tracks: Map<string, LocalTrackPublication>;
 
+  /** @internal */
+  engine: RTCEngine;
+
   private pendingPublishing = new Set<Track.Source>();
 
   private cameraError: Error | undefined;
 
   private microphoneError: Error | undefined;
-
-  private engine: RTCEngine;
 
   private participantTrackPermissions: Array<ParticipantTrackPermission> = [];
 


### PR DESCRIPTION
Previously the old RTCEngine would have removed all of its listeners
after a failure, causing Room to miss all of the engine events.