### PR TITLE
Improve duplicate connect

### DIFF
--- a/.changeset/serious-timers-add.md
+++ b/.changeset/serious-timers-add.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Improved duplicate connect handling

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -114,3 +114,18 @@ export function getEmptyAudioStreamTrack() {
   }
   return emptyAudioStreamTrack;
 }
+
+export class Future<T> {
+  promise: Promise<T>;
+
+  resolve!: (arg: T) => void;
+
+  reject!: (e: any) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}


### PR DESCRIPTION
When a user calls connect multiple times, the behavior is now consistent
where it returns a promise so caller wait to see if connection is
successful or otherwise.