### PR TITLE
Use RoomEvent for emitting event on the room

### DIFF
--- a/.changeset/nasty-cobras-reflect.md
+++ b/.changeset/nasty-cobras-reflect.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Use RoomEvent for emitting event on the room

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -807,7 +807,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       pub.subscriptionStatus,
     );
     this.emitWhenConnected(
-      ParticipantEvent.TrackSubscriptionPermissionChanged,
+      RoomEvent.TrackSubscriptionPermissionChanged,
       pub,
       pub.subscriptionStatus,
       participant,


### PR DESCRIPTION
Should not have had any effect as the event strings are the same, but seems cleaner this way.