### PR TITLE
Fix handling of permissions after resubscribe

### DIFF
--- a/.changeset/metal-gorillas-decide.md
+++ b/.changeset/metal-gorillas-decide.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix handling of permissions after resubscribe

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -1,3 +1,4 @@
+import 'webrtc-adapter';
 import log from '../logger';
 import {
   ClientInfo,
@@ -29,7 +30,6 @@ import {
 import { ConnectionError } from '../room/errors';
 import { getClientInfo, sleep } from '../room/utils';
 import Queue from './RequestQueue';
-import 'webrtc-adapter';
 
 // internal options
 interface ConnectOpts {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -782,7 +782,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       pub.track.streamState = Track.streamStateFromProto(streamState.state);
       participant.emit(ParticipantEvent.TrackStreamStateChanged, pub, pub.track.streamState);
       this.emitWhenConnected(
-        ParticipantEvent.TrackStreamStateChanged,
+        RoomEvent.TrackStreamStateChanged,
         pub,
         pub.track.streamState,
         participant,
@@ -807,7 +807,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       pub.subscriptionStatus,
     );
     this.emitWhenConnected(
-      ParticipantEvent.TrackSubscriptionPermissionChanged,
+      RoomEvent.TrackSubscriptionPermissionChanged,
       pub,
       pub.subscriptionStatus,
       participant,

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -156,6 +156,8 @@ export default class RemoteParticipant extends Participant {
     track.start();
 
     publication.setTrack(track);
+    // subscription means participant has permissions to subscribe
+    publication._allowed = true;
     // set participant volume on new microphone tracks
     if (
       this.volume !== undefined &&

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -1,11 +1,11 @@
-import log from '../../logger'
-import { TrackInfo, VideoQuality } from '../../proto/livekit_models'
-import { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc'
-import { TrackEvent } from '../events'
-import RemoteVideoTrack from './RemoteVideoTrack'
-import { Track } from './Track'
-import { TrackPublication } from './TrackPublication'
-import { RemoteTrack } from './types'
+import log from '../../logger';
+import { TrackInfo, VideoQuality } from '../../proto/livekit_models';
+import { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc';
+import { TrackEvent } from '../events';
+import RemoteVideoTrack from './RemoteVideoTrack';
+import { Track } from './Track';
+import { TrackPublication } from './TrackPublication';
+import { RemoteTrack } from './types';
 
 export default class RemoteTrackPublication extends TrackPublication {
   track?: RemoteTrack;

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -1,11 +1,11 @@
-import log from '../../logger';
-import { TrackInfo, VideoQuality } from '../../proto/livekit_models';
-import { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc';
-import { TrackEvent } from '../events';
-import RemoteVideoTrack from './RemoteVideoTrack';
-import { Track } from './Track';
-import { TrackPublication } from './TrackPublication';
-import { RemoteTrack } from './types';
+import log from '../../logger'
+import { TrackInfo, VideoQuality } from '../../proto/livekit_models'
+import { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc'
+import { TrackEvent } from '../events'
+import RemoteVideoTrack from './RemoteVideoTrack'
+import { Track } from './Track'
+import { TrackPublication } from './TrackPublication'
+import { RemoteTrack } from './types'
 
 export default class RemoteTrackPublication extends TrackPublication {
   track?: RemoteTrack;
@@ -125,6 +125,7 @@ export default class RemoteTrackPublication extends TrackPublication {
     return this.currentVideoQuality;
   }
 
+  /** @internal */
   setTrack(track?: Track) {
     if (this.track) {
       // unregister listener
@@ -164,6 +165,7 @@ export default class RemoteTrackPublication extends TrackPublication {
 
   protected handleEnded = (track: RemoteTrack) => {
     this.emit(TrackEvent.Ended, track);
+    this.setTrack(undefined);
   };
 
   protected get isAdaptiveStream(): boolean {


### PR DESCRIPTION
When a user subscribes a track, but then have permission revoked. The
revoked state may be cached even when permissions are granted afterwards.
Since subscription is an indicator that a user is allowed to subscribe
to a track. We'll flip _allowed to true on subscribe.