### PR TITLE
Reconcile local mute status after resuming connection

### DIFF
--- a/.changeset/lovely-laws-collect.md
+++ b/.changeset/lovely-laws-collect.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Reconcile local mute status after resuming connection

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -390,6 +390,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     let postAction = () => {};
     let req: SimulateScenario | undefined;
     switch (scenario) {
+      case 'signal-reconnect':
+        this.engine.client.close();
+        if (this.engine.client.onClose) {
+          this.engine.client.onClose('simulate disconnect');
+        }
+        break;
       case 'speaker':
         req = SimulateScenario.fromPartial({
           speakerUpdate: 3,


### PR DESCRIPTION
During any period of disconnection, changes to local mute status may not have been delivered to the server. We'll handle it by monitoring differences in state and ensuring server state matches client expectation.