### PR TITLE
Respect stopLocalTrackOnUnpublish in event of engine disconnect

### DIFF
--- a/.changeset/cuddly-llamas-marry.md
+++ b/.changeset/cuddly-llamas-marry.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Respect stopLocalTrackOnUnpublish in event of engine disconnect

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -151,7 +151,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         },
       )
       .on(EngineEvent.Disconnected, () => {
-        this.handleDisconnect();
+        this.handleDisconnect(this.options.stopLocalTrackOnUnpublish);
       })
       .on(EngineEvent.ActiveSpeakersUpdate, this.handleActiveSpeakersUpdate)
       .on(EngineEvent.DataPacketReceived, this.handleDataPacket)


### PR DESCRIPTION
The option name does not exactly say it would do the same for disconnect events.
Any suggestion on handling it differently? Maybe a separate option for `stopLocalTrackOnDisconnect`? 