### PR TITLE
keep mediastream id for migration

### DIFF
--- a/.changeset/gorgeous-dogs-confess.md
+++ b/.changeset/gorgeous-dogs-confess.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+keep mediastream id unchange for migration

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -20,8 +20,8 @@ import {
   VideoCaptureOptions,
   VideoCodec,
   VideoPresets,
-  VideoQuality
-} from '../src/index'
+  VideoQuality,
+} from '../src/index';
 
 const $ = (id: string) => document.getElementById(id);
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -975,7 +975,7 @@ export default class LocalParticipant extends Participant {
     this.tracks.forEach((track: LocalTrackPublication) => {
       if (track.track !== undefined) {
         infos.push({
-          cid: track.track.mediaStreamTrack.id,
+          cid: track.track.mediaStreamID,
           track: track.trackInfo,
         });
       }

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -37,6 +37,8 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
   protected _mediaStreamTrack: MediaStreamTrack;
 
+  protected _mediaStreamID: string;
+
   protected isInBackground: boolean;
 
   private backgroundTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -47,6 +49,7 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
     super();
     this.kind = kind;
     this._mediaStreamTrack = mediaTrack;
+    this._mediaStreamID = mediaTrack.id;
     this.source = Track.Source.Unknown;
     if (isWeb()) {
       this.isInBackground = document.visibilityState === 'hidden';
@@ -63,6 +66,15 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
   get mediaStreamTrack() {
     return this._mediaStreamTrack;
+  }
+
+  /**
+   * @internal
+   * used for keep mediaStream's first id, since it's id might change
+   * if we disable/enable a track
+   */
+  get mediaStreamID(): string {
+    return this._mediaStreamID;
   }
 
   /**


### PR DESCRIPTION
mediastream.id might change during unmute/mute, when migration involved, the changed stream id might cause server side can't find the destination track or find a incorrect one, so keep it when Track construct and used in SyncState for migration