### PR TITLE
Queue and await parallel calls to mute/unmute for local tracks

### DIFF
--- a/.changeset/thick-ways-turn.md
+++ b/.changeset/thick-ways-turn.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Queue and await parallel calls to mute/unmute for a track

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "release": "yarn build && changeset publish"
   },
   "dependencies": {
+    "async-await-queue": "^1.2.1",
     "events": "^3.3.0",
     "loglevel": "^1.8.0",
     "protobufjs": "^6.11.2",

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -35,22 +35,26 @@ export default class LocalAudioTrack extends LocalTrack {
   }
 
   async mute(): Promise<LocalAudioTrack> {
-    // disabled special handling as it will cause BT headsets to switch communication modes
-    if (this.source === Track.Source.Microphone && this.stopOnMute) {
-      log.debug('stopping mic track');
-      // also stop the track, so that microphone indicator is turned off
-      this._mediaStreamTrack.stop();
-    }
-    await super.mute();
+    await this.muteQueue.run(async () => {
+      // disabled special handling as it will cause BT headsets to switch communication modes
+      if (this.source === Track.Source.Microphone && this.stopOnMute) {
+        log.debug('stopping mic track');
+        // also stop the track, so that microphone indicator is turned off
+        this._mediaStreamTrack.stop();
+      }
+      await super.mute();
+    });
     return this;
   }
 
   async unmute(): Promise<LocalAudioTrack> {
-    if (this.source === Track.Source.Microphone && this.stopOnMute && !this.isUserProvided) {
-      log.debug('reacquiring mic track');
-      await this.restartTrack();
-    }
-    await super.unmute();
+    await this.muteQueue.run(async () => {
+      if (this.source === Track.Source.Microphone && this.stopOnMute && !this.isUserProvided) {
+        log.debug('reacquiring mic track');
+        await this.restartTrack();
+      }
+      await super.unmute();
+    });
     return this;
   }
 

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -1,3 +1,4 @@
+import Queue from 'async-await-queue';
 import log from '../../logger';
 import DeviceManager from '../DeviceManager';
 import { TrackInvalidError } from '../errors';
@@ -21,6 +22,8 @@ export default class LocalTrack extends Track {
 
   protected providedByUser: boolean;
 
+  protected muteQueue: Queue;
+
   protected constructor(
     mediaTrack: MediaStreamTrack,
     kind: Track.Kind,
@@ -33,6 +36,7 @@ export default class LocalTrack extends Track {
     this.reacquireTrack = false;
     this.wasMuted = false;
     this.providedByUser = userProvidedTrack;
+    this.muteQueue = new Queue();
   }
 
   get id(): string {
@@ -170,6 +174,7 @@ export default class LocalTrack extends Track {
   }
 
   protected setTrackMuted(muted: boolean) {
+    log.debug(`setting ${this.kind} track ${muted ? 'muted' : 'unmuted'}`);
     if (this.isMuted === muted) {
       return;
     }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -220,31 +220,36 @@ export default class LocalTrack extends Track {
   };
 
   async pauseUpstream() {
-    if (this._isUpstreamPaused === true) {
-      return;
-    }
-    if (!this.sender) {
-      log.warn('unable to pause upstream for an unpublished track');
-      return;
-    }
-    this._isUpstreamPaused = true;
-    this.emit(TrackEvent.UpstreamPaused, this);
-    const emptyTrack =
-      this.kind === Track.Kind.Audio ? getEmptyAudioStreamTrack() : getEmptyVideoStreamTrack();
-    await this.sender.replaceTrack(emptyTrack);
+    this.muteQueue.run(async () => {
+      if (this._isUpstreamPaused === true) {
+        return;
+      }
+      if (!this.sender) {
+        log.warn('unable to pause upstream for an unpublished track');
+        return;
+      }
+
+      this._isUpstreamPaused = true;
+      this.emit(TrackEvent.UpstreamPaused, this);
+      const emptyTrack =
+        this.kind === Track.Kind.Audio ? getEmptyAudioStreamTrack() : getEmptyVideoStreamTrack();
+      await this.sender.replaceTrack(emptyTrack);
+    });
   }
 
   async resumeUpstream() {
-    if (this._isUpstreamPaused === false) {
-      return;
-    }
-    if (!this.sender) {
-      log.warn('unable to resume upstream for an unpublished track');
-      return;
-    }
-    this._isUpstreamPaused = false;
-    this.emit(TrackEvent.UpstreamResumed, this);
+    this.muteQueue.run(async () => {
+      if (this._isUpstreamPaused === false) {
+        return;
+      }
+      if (!this.sender) {
+        log.warn('unable to resume upstream for an unpublished track');
+        return;
+      }
+      this._isUpstreamPaused = false;
+      this.emit(TrackEvent.UpstreamResumed, this);
 
-    await this.sender.replaceTrack(this._mediaStreamTrack);
+      await this.sender.replaceTrack(this._mediaStreamTrack);
+    });
   }
 }

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -86,21 +86,25 @@ export default class LocalVideoTrack extends LocalTrack {
   }
 
   async mute(): Promise<LocalVideoTrack> {
-    if (this.source === Track.Source.Camera) {
-      log.debug('stopping camera track');
-      // also stop the track, so that camera indicator is turned off
-      this._mediaStreamTrack.stop();
-    }
-    await super.mute();
+    await this.muteQueue.run(async () => {
+      if (this.source === Track.Source.Camera) {
+        log.debug('stopping camera track');
+        // also stop the track, so that camera indicator is turned off
+        this._mediaStreamTrack.stop();
+      }
+      await super.mute();
+    });
     return this;
   }
 
   async unmute(): Promise<LocalVideoTrack> {
-    if (this.source === Track.Source.Camera && !this.isUserProvided) {
-      log.debug('reacquiring camera track');
-      await this.restartTrack();
-    }
-    await super.unmute();
+    await this.muteQueue.run(async () => {
+      if (this.source === Track.Source.Camera && !this.isUserProvided) {
+        log.debug('reacquiring camera track');
+        await this.restartTrack();
+      }
+      await super.unmute();
+    });
     return this;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2171,6 +2171,11 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async-await-queue@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/async-await-queue/-/async-await-queue-1.2.1.tgz#baf459f5fbac902b060a88fee4da853fd86f2128"
+  integrity sha512-v2j+/EMzAnuJZ8I4570KJMFhi6G9g3WZyFh6cPnmQSJh3nLao77XpRt01kyFegQazPSKvue1yaIYDp/NfV/b0g==
+
 async@^2.6.1:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"


### PR DESCRIPTION
Introduces an additional dependency on 'async-await-queue'. 
Keeping this PR clean, but we might be able to reuse the same lib for the signal request queue in order to keep the overall bundle size down as much as possible.