### PR TITLE
Presence of Track subscription to take priority over allowed status.

### DIFF
--- a/.changeset/lucky-icons-punch.md
+++ b/.changeset/lucky-icons-punch.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Determine track allowed status primarily by precense of Track

--- a/.changeset/olive-maps-trade.md
+++ b/.changeset/olive-maps-trade.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Improved Track event handling for permission changed

--- a/.changeset/violet-hats-scream.md
+++ b/.changeset/violet-hats-scream.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Room.disconnect is now an async function

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -1,5 +1,5 @@
-import 'webrtc-adapter';
 import Queue from 'async-await-queue';
+import 'webrtc-adapter';
 import log from '../logger';
 import {
   ClientInfo,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -375,7 +375,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       this.engine.close();
     }
 
-    this.handleDisconnect(stopTracks);
+    this.handleDisconnect(stopTracks, DisconnectReason.CLIENT_INITIATED);
     /* @ts-ignore */
     this.engine = undefined;
   };
@@ -648,6 +648,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private handleDisconnect(shouldStopTracks = true, reason?: DisconnectReason) {
+    if (this.state === ConnectionState.Disconnected) {
+      return;
+    }
     this.participants.forEach((p) => {
       p.tracks.forEach((pub) => {
         p.unpublishTrack(pub.trackSid);
@@ -663,6 +666,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         pub.track?.stop();
       }
     });
+    this.localParticipant.tracks.clear();
+    this.localParticipant.videoTracks.clear();
+    this.localParticipant.audioTracks.clear();
 
     this.participants.clear();
     this.activeSpeakers = [];

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -824,18 +824,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
 
-    pub._allowed = update.allowed;
-    participant.emit(
-      ParticipantEvent.TrackSubscriptionPermissionChanged,
-      pub,
-      pub.subscriptionStatus,
-    );
-    this.emitWhenConnected(
-      RoomEvent.TrackSubscriptionPermissionChanged,
-      pub,
-      pub.subscriptionStatus,
-      participant,
-    );
+    pub.setAllowed(update.allowed);
   };
 
   private handleDataPacket = (userPacket: UserPacket, kind: DataPacket_Kind) => {
@@ -972,7 +961,15 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             participant,
           );
         },
-      );
+      )
+      .on(ParticipantEvent.TrackSubscriptionPermissionChanged, (pub, status) => {
+        this.emitWhenConnected(
+          RoomEvent.TrackSubscriptionPermissionChanged,
+          pub,
+          status,
+          participant,
+        );
+      });
 
     // update info at the end after callbacks have been set up
     if (info) {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -358,7 +358,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   /**
    * disconnects the room, emits [[RoomEvent.Disconnected]]
    */
-  disconnect = (stopTracks = true) => {
+  disconnect = async (stopTracks = true) => {
+    log.info('disconnect from room', { identity: this.localParticipant.identity });
     if (this.state === ConnectionState.Connecting) {
       // try aborting pending connection attempt
       log.warn('abort connection attempt');
@@ -367,7 +368,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
     // send leave
     if (this.engine?.client.isConnected) {
-      this.engine.client.sendLeave();
+      await this.engine.client.sendLeave();
     }
     // close engine (also closes client)
     if (this.engine) {

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -402,6 +402,8 @@ export enum TrackEvent {
   Muted = 'muted',
   Unmuted = 'unmuted',
   Ended = 'ended',
+  Subscribed = 'subscribed',
+  Unsubscribed = 'unsubscribed',
   /** @internal */
   UpdateSettings = 'updateSettings',
   /** @internal */
@@ -433,4 +435,9 @@ export enum TrackEvent {
    * Only fires on LocalTracks
    */
   UpstreamResumed = 'upstreamResumed',
+  /**
+   * @internal
+   * Fires on RemoteTrackPublication
+   */
+  SubscriptionPermissionChanged = 'subscriptionPermissionChanged',
 }

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -153,6 +153,7 @@ export default class RemoteTrackPublication extends TrackPublication {
     }
   }
 
+  /** @internal */
   setAllowed(allowed: boolean) {
     const prevStatus = this.subscriptionStatus;
     this.allowed = allowed;

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -28,6 +28,9 @@ export default class RemoteTrackPublication extends TrackPublication {
    */
   setSubscribed(subscribed: boolean) {
     this.subscribed = subscribed;
+    // reset allowed status when desired subscription state changes
+    // server will notify client via signal message if it's not allowed
+    this._allowed = true;
 
     const sub: UpdateSubscription = {
       trackSids: [this.trackSid],
@@ -46,10 +49,10 @@ export default class RemoteTrackPublication extends TrackPublication {
 
   get subscriptionStatus(): TrackPublication.SubscriptionStatus {
     if (this.subscribed === false || !super.isSubscribed) {
+      if (!this._allowed) {
+        return TrackPublication.SubscriptionStatus.NotAllowed;
+      }
       return TrackPublication.SubscriptionStatus.Unsubscribed;
-    }
-    if (!this._allowed) {
-      return TrackPublication.SubscriptionStatus.NotAllowed;
     }
     return TrackPublication.SubscriptionStatus.Subscribed;
   }
@@ -61,10 +64,11 @@ export default class RemoteTrackPublication extends TrackPublication {
     if (this.subscribed === false) {
       return false;
     }
-    if (!this._allowed) {
-      return false;
-    }
     return super.isSubscribed;
+  }
+
+  get shouldSubscribe(): boolean | undefined {
+    return this.subscribed;
   }
 
   get isEnabled(): boolean {

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -67,10 +67,6 @@ export default class RemoteTrackPublication extends TrackPublication {
     return super.isSubscribed;
   }
 
-  get shouldSubscribe(): boolean | undefined {
-    return this.subscribed;
-  }
-
   get isEnabled(): boolean {
     return !this.disabled;
   }


### PR DESCRIPTION
Client may end up with a copy of incorrect RemoteTrackPublication.allowed
status, if rapid successions of subscribe/unsubscribe/permission updates
occur.