### PR TITLE
Try to re-aquire mediastreamtrack when device has been disconnected, …

### DIFF
--- a/.changeset/sharp-pandas-explode.md
+++ b/.changeset/sharp-pandas-explode.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+Try to re-aquire mediastreamtrack when device has been disconnected, pause upstream if no device could be acquired

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -99,7 +99,6 @@ const appActions = {
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {
     const room = new Room(roomOptions);
-    console.log('permissions', { permissions: navigator?.permissions });
 
     room
       .on(RoomEvent.ParticipantConnected, participantConnected)

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -21,8 +21,8 @@ import {
   VideoCaptureOptions,
   VideoCodec,
   VideoPresets,
-  VideoQuality
-} from '../src/index'
+  VideoQuality,
+} from '../src/index';
 
 const $ = (id: string) => document.getElementById(id);
 
@@ -99,6 +99,8 @@ const appActions = {
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {
     const room = new Room(roomOptions);
+    console.log('permissions', { permissions: navigator?.permissions });
+
     room
       .on(RoomEvent.ParticipantConnected, participantConnected)
       .on(RoomEvent.ParticipantDisconnected, participantDisconnected)
@@ -370,7 +372,7 @@ function participantDisconnected(participant: RemoteParticipant) {
 
 function handleRoomDisconnect(reason?: DisconnectReason) {
   if (!currentRoom) return;
-  appendLog('disconnected from room', {reason});
+  appendLog('disconnected from room', { reason });
   setButtonsForState(false);
   renderParticipant(currentRoom.localParticipant, true);
   currentRoom.participants.forEach((p) => {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -32,7 +32,7 @@ import {
 } from '../track/options';
 import { Track } from '../track/Track';
 import { constraintsForOptions, mergeDefaultOptions } from '../track/utils';
-import { isFireFox } from '../utils';
+import { isFireFox, isWeb } from '../utils';
 import Participant from './Participant';
 import { ParticipantTrackPermission, trackPermissionToProto } from './ParticipantTrackPermission';
 import { computeVideoEncodings, mediaTrackToLocalTrack } from './publishUtils';
@@ -894,11 +894,47 @@ export default class LocalParticipant extends Participant {
     this.unpublishTrack(track.track!);
   };
 
-  private handleTrackEnded = (track: LocalTrack) => {
-    log.debug('unpublishing local track due to TrackEnded', {
-      track: track.sid,
-    });
-    this.unpublishTrack(track);
+  private handleTrackEnded = async (track: LocalTrack) => {
+    if (
+      track.source === Track.Source.ScreenShare ||
+      track.source === Track.Source.ScreenShareAudio
+    ) {
+      log.debug('unpublishing local track due to TrackEnded', {
+        track: track.sid,
+      });
+      this.unpublishTrack(track);
+    } else if (track.isUserProvided) {
+      // do nothing for user managed tracks
+    } else if (track instanceof LocalAudioTrack || track instanceof LocalVideoTrack) {
+      try {
+        if (isWeb()) {
+          const currentPermissions = await navigator?.permissions.query({
+            // @ts-ignore
+            name: track.source === Track.Source.Camera ? 'camera' : 'microphone',
+          });
+          // the permission query for camera and microphone currently not supported in Safari and Firefox
+          if (currentPermissions && currentPermissions.state === 'denied') {
+            log.warn(`user has revoked access to ${track.source}`);
+
+            // detect granted change after permissions were denied to try and resume then
+            currentPermissions.onchange = (ev) => {
+              // @ts-ignore
+              if (ev?.target?.state !== 'denied') {
+                track.restartTrack();
+                // @ts-ignore
+                ev.target.onchange = undefined;
+              }
+            };
+            throw new Error('GetUserMedia Permission denied');
+          }
+        }
+        log.debug('track ended, attempting to use a different device');
+        await track.restartTrack();
+      } catch (e) {
+        log.warn(`could not restart track, pausing upstream instead`);
+        await track.pauseUpstream();
+      }
+    }
   };
 
   private getPublicationForTrack(

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -909,20 +909,18 @@ export default class LocalParticipant extends Participant {
       try {
         if (isWeb()) {
           const currentPermissions = await navigator?.permissions.query({
+            // the permission query for camera and microphone currently not supported in Safari and Firefox
             // @ts-ignore
             name: track.source === Track.Source.Camera ? 'camera' : 'microphone',
           });
-          // the permission query for camera and microphone currently not supported in Safari and Firefox
           if (currentPermissions && currentPermissions.state === 'denied') {
             log.warn(`user has revoked access to ${track.source}`);
 
             // detect granted change after permissions were denied to try and resume then
-            currentPermissions.onchange = (ev) => {
-              // @ts-ignore
-              if (ev?.target?.state !== 'denied') {
+            currentPermissions.onchange = () => {
+              if (currentPermissions.state !== 'denied') {
                 track.restartTrack();
-                // @ts-ignore
-                ev.target.onchange = undefined;
+                currentPermissions.onchange = null;
               }
             };
             throw new Error('GetUserMedia Permission denied');

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -927,7 +927,7 @@ export default class LocalParticipant extends Participant {
               throw new Error('GetUserMedia Permission denied');
             }
           } catch (e: any) {
-            // permissions query fails for firefox, but we continue and try to restart the track
+            // permissions query fails for firefox, we continue and try to restart the track
           }
         }
         log.debug('track ended, attempting to use a different device');

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -117,6 +117,8 @@ export default class LocalTrack extends Track {
     }
     this._mediaStreamTrack = track;
 
+    await this.resumeUpstream();
+
     this.attachedElements.forEach((el) => {
       attachToElement(track, el);
     });
@@ -165,6 +167,8 @@ export default class LocalTrack extends Track {
     }
 
     this._mediaStreamTrack = newTrack;
+
+    await this.resumeUpstream();
 
     this.attachedElements.forEach((el) => {
       attachToElement(newTrack, el);


### PR DESCRIPTION
…pause upstream if no device could be acquired

The function is currently deeply nested. We can figure out the best course of action first and then I'll clean it up.

The basic idea to react to the 'ended' event is:
- Unpublish if it's a screen track (-> stop initiated by stopping via browser UI)
- Don't do anything if the camera/microphone track is user provided
- Try to restart the track if it has ended (-> will effectively re-acquire with the given constraints and might switch to a different device)
- If reacquiring fails, replace the current mediastreamtrack with an empty one and set it to muted on the server side (-> calling `pauseUpstream`)
- If the track ended because media permissions were revoked, attach an eventlistener to try to restart the track once permissions have been granted again (currently not supported in firefox and safari)