### PR TITLE
fix safari data channel migration failed

### DIFF
--- a/.changeset/good-feet-notice.md
+++ b/.changeset/good-feet-notice.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+fix safari data channel migration failed

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -582,7 +582,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     await this.waitForPCConnected();
     this.client.setReconnected();
 
-    // recreate publish datachannel if it's id is null 
+    // recreate publish datachannel if it's id is null
     // (for safari https://bugs.webkit.org/show_bug.cgi?id=184688)
     if (this.reliableDC?.readyState === 'open' && this.reliableDC.id === null) {
       this.createDataChannels();


### PR DESCRIPTION
As safari don't have datachannel id set if the datachannel is created by browser (https://bugs.webkit.org/show_bug.cgi?id=184688), it will cause datachannel break after migration, so we recreate it in this case. Since safari can't get remote candidate's address, we can't distinguish normal reconnect or migrate, so recreate after connection resume every time.