### PR TITLE
Throw error on unexpected connection state before signalling add track

### DIFF
--- a/.changeset/great-jokes-compare.md
+++ b/.changeset/great-jokes-compare.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Throw error on unexpected connection state before signalling add track

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -526,6 +526,9 @@ export default class LocalParticipant extends Participant {
     if (!this.engine || this.engine.isClosed) {
       throw new UnexpectedConnectionState('cannot publish track when not connected');
     }
+    if (!this.engine.publisher) {
+      throw new UnexpectedConnectionState('publisher is closed');
+    }
 
     const ti = await this.engine.addTrack(req);
     const publication = new LocalTrackPublication(track.kind, ti, track);
@@ -533,9 +536,6 @@ export default class LocalParticipant extends Participant {
     publication.options = opts;
     track.sid = ti.sid;
 
-    if (!this.engine.publisher) {
-      throw new UnexpectedConnectionState('publisher is closed');
-    }
     log.debug(`publishing ${track.kind} with encodings`, { encodings, trackInfo: ti });
     const transceiverInit: RTCRtpTransceiverInit = { direction: 'sendonly' };
     if (encodings) {


### PR DESCRIPTION
Prior to this fix it would be possible for the `engine.addTrack` request to be queued even though the publisher isn't defined yet. 