### PR TITLE
Make local track publication timeout

### DIFF
--- a/.changeset/clever-candles-shake.md
+++ b/.changeset/clever-candles-shake.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Make local track publication timeout instead of waiting indefinitely for server response

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -164,8 +164,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (this.pendingTrackResolvers[req.cid]) {
       throw new TrackInvalidError('a track with the same ID has already been published');
     }
-    return new Promise<TrackInfo>((resolve) => {
-      this.pendingTrackResolvers[req.cid] = resolve;
+    return new Promise<TrackInfo>((resolve, reject) => {
+      const publicationTimeout = setTimeout(() => {
+        reject('Publication of local track timed out');
+      }, 15_000);
+      this.pendingTrackResolvers[req.cid] = (info: TrackInfo) => {
+        clearTimeout(publicationTimeout);
+        resolve(info);
+      };
       this.client.sendAddTrack(req);
     });
   }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -166,7 +166,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
     return new Promise<TrackInfo>((resolve, reject) => {
       const publicationTimeout = setTimeout(() => {
-        reject('Publication of local track timed out');
+        reject(
+          new ConnectionError('publication of local track timed out, no response from server'),
+        );
       }, 15_000);
       this.pendingTrackResolvers[req.cid] = (info: TrackInfo) => {
         clearTimeout(publicationTimeout);


### PR DESCRIPTION
instead of waiting indefinitely for server response.

The timeout is currently at 15s, which is the same duration as the ICE reconnect timeout, but it feels a bit long.