### PR TITLE
Check for duplicate source publications before adding them to tracks

### DIFF
--- a/.changeset/long-pugs-wave.md
+++ b/.changeset/long-pugs-wave.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Check for duplicate source publications before adding them to tracks

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -210,6 +210,20 @@ export default class RemoteParticipant extends Participant {
         publication = new RemoteTrackPublication(kind, ti.sid, ti.name);
         publication.updateInfo(ti);
         newTracks.set(ti.sid, publication);
+        const existingTrackOfSource = Array.from(this.tracks.values()).find(
+          (publishedTrack) => publishedTrack.source === publication?.source,
+        );
+        if (existingTrackOfSource) {
+          log.warn(
+            `received a second track publication for ${this.identity} with the same source: ${publication.source}`,
+            {
+              oldTrack: existingTrackOfSource,
+              newTrack: publication,
+              participant: this,
+              participantInfo: info,
+            },
+          );
+        }
         this.addTrackPublication(publication);
       } else {
         publication.updateInfo(ti);
@@ -220,19 +234,6 @@ export default class RemoteParticipant extends Participant {
     // always emit events for new publications, Room will not forward them unless it's ready
     newTracks.forEach((publication) => {
       this.emit(ParticipantEvent.TrackPublished, publication);
-      const existingTrackOfSource = Array.from(this.tracks.values()).find(
-        (publishedTrack) => publishedTrack.source === publication.source,
-      );
-      if (existingTrackOfSource) {
-        log.warn(
-          `received a second track publication for ${this.identity} with the same source: ${publication.source}`,
-          {
-            oldTrack: existingTrackOfSource,
-            newTrack: publication,
-            participant: this,
-          },
-        );
-      }
     });
 
     // detect removed tracks


### PR DESCRIPTION
Prior the check ran only after `addTrackPublication` which gave false positives for new tracks that have just been added.