### PR TITLE
Renovate fixes

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -2,6 +2,10 @@
   "compilerOptions": {
     "target": "ESNext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "outDir": "build",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
     "strict": true /* Enable all strict type-checking options. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "skipLibCheck": true /* Skip type checking of declaration files. */,

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -26,7 +26,6 @@ export default {
       format: 'esm',
       strict: true,
       sourcemap: true,
-      inlineDynamicImports: true,
     },
   ],
   plugins: [

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -8,8 +8,6 @@ import { Track } from './Track';
 import { constraintsForOptions, detectSilence } from './utils';
 
 export default class LocalAudioTrack extends LocalTrack {
-  sender?: RTCRtpSender;
-
   /** @internal */
   stopOnMute: boolean = false;
 

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -8,7 +8,7 @@ import { TrackPublication } from './TrackPublication';
 import { RemoteTrack } from './types';
 
 export default class RemoteTrackPublication extends TrackPublication {
-  track?: RemoteTrack;
+  track?: RemoteTrack = undefined;
 
   /** @internal */
   protected allowed = true;

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -10,9 +10,6 @@ import { AdaptiveStreamSettings } from './types';
 const REACTION_DELAY = 100;
 
 export default class RemoteVideoTrack extends RemoteTrack {
-  /** @internal */
-  receiver?: RTCRtpReceiver;
-
   private prevStats?: VideoReceiverStats;
 
   private elementInfos: ElementInfo[] = [];


### PR DESCRIPTION
Some things that came up when upgrading dev dependencies. 

Also makes sourcemaps work again for `yarn sample` which was unrelated to the dependency upgrades.