### PR TITLE
Clear pending track resolver on track unpublish

### DIFF
--- a/.changeset/itchy-beans-tell.md
+++ b/.changeset/itchy-beans-tell.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Decrease publication timeout to 10s and clean local state on failed unpublish attempts

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -722,18 +722,18 @@ export default class LocalParticipant extends Participant {
       track.sender
     ) {
       try {
-        this.engine.publisher.pc.removeTrack(track.sender);
+        this.engine.removeTrack(track.sender);
         if (track instanceof LocalVideoTrack) {
           for (const [, trackInfo] of track.simulcastCodecs) {
             if (trackInfo.sender) {
-              this.engine.publisher.pc.removeTrack(trackInfo.sender);
+              this.engine.removeTrack(trackInfo.sender);
               trackInfo.sender = undefined;
             }
           }
           track.simulcastCodecs.clear();
         }
       } catch (e) {
-        log.warn('failed to remove track', { error: e, method: 'unpublishTrack' });
+        log.warn('failed to unpublish track', { error: e, method: 'unpublishTrack' });
       } finally {
         this.engine.negotiate();
       }


### PR DESCRIPTION
- decreases publication timeout to 10s
- new `engine.removeTrack` method that clears `pendingTrackResolver` track entry (and rejects publication promise if `unpublish` is called while track is not fully published (no response from server)). 