### PR TITLE
don't declare simulcastCodecs for firefox

### DIFF
--- a/.changeset/bright-waves-jump.md
+++ b/.changeset/bright-waves-jump.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+don't declare simulcast codecs for firefox

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -509,7 +509,7 @@ export default class LocalParticipant extends Participant {
         }
 
         // set vp8 codec as backup for any other codecs
-        if (opts.videoCodec && opts.videoCodec !== 'vp8') {
+        if (opts.videoCodec && opts.videoCodec !== 'vp8' && !isFireFox()) {
           req.simulcastCodecs = [
             {
               codec: opts.videoCodec,


### PR DESCRIPTION
fix issue that subscriber can't receive video stream when publisher prefer h264 codec in firefox.
we declare `h264`, `vp8` simulcast codecs when prefer h264 in sample app with **Firefox** (always use vp8 as backup codec), and subscriber match h264 first, while firefox can’t use `setCodecPreferences` (it not support that api)  to send a h264 stream. fixed by disable simulcast codecs feature for firefox.