### PR TITLE
Fixes calling start() on a remote track multiple times

### DIFF
--- a/.changeset/nine-crabs-vanish.md
+++ b/.changeset/nine-crabs-vanish.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Prevent multiple redundant monitors from being started if start is called multiple times on a RemoteTrack

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -1,4 +1,4 @@
-import { AudioReceiverStats, computeBitrate, monitorFrequency } from '../stats';
+import { AudioReceiverStats, computeBitrate } from '../stats';
 import RemoteTrack from './RemoteTrack';
 import { Track } from './Track';
 
@@ -63,9 +63,6 @@ export default class RemoteAudioTrack extends RemoteTrack {
     }
 
     this.prevStats = stats;
-    setTimeout(() => {
-      this.monitorReceiver();
-    }, monitorFrequency);
   };
 
   protected async getReceiverStats(): Promise<AudioReceiverStats | undefined> {

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -48,6 +48,7 @@ export default abstract class RemoteTrack extends Track {
   }
 
   stop() {
+    this.stopMonitor();
     // use `enabled` of track to enable re-use of transceiver
     super.disable();
   }
@@ -56,6 +57,13 @@ export default abstract class RemoteTrack extends Track {
   startMonitor() {
     if (!this.monitorInterval) {
       this.monitorInterval = setInterval(() => this.monitorReceiver(), monitorFrequency);
+    }
+  }
+
+  /* @internal */
+  stopMonitor() {
+    if (this.monitorInterval) {
+      clearInterval(this.monitorInterval);
     }
   }
 

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -5,6 +5,7 @@ import { Track } from './Track';
 export default abstract class RemoteTrack extends Track {
   /** @internal */
   receiver?: RTCRtpReceiver;
+  monitorStarted = false;
 
   constructor(
     mediaTrack: MediaStreamTrack,
@@ -52,9 +53,12 @@ export default abstract class RemoteTrack extends Track {
 
   /* @internal */
   startMonitor() {
-    setTimeout(() => {
-      this.monitorReceiver();
-    }, monitorFrequency);
+    if (!this.monitorStarted) {
+      setTimeout(() => {
+        this.monitorReceiver();
+      }, monitorFrequency);
+      this.monitorStarted = true;
+    }
   }
 
   protected abstract monitorReceiver(): void;

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -6,7 +6,7 @@ export default abstract class RemoteTrack extends Track {
   /** @internal */
   receiver?: RTCRtpReceiver;
 
-  monitorStarted = false;
+  monitorInterval?: ReturnType<typeof setInterval>;
 
   constructor(
     mediaTrack: MediaStreamTrack,
@@ -54,11 +54,8 @@ export default abstract class RemoteTrack extends Track {
 
   /* @internal */
   startMonitor() {
-    if (!this.monitorStarted) {
-      setTimeout(() => {
-        this.monitorReceiver();
-      }, monitorFrequency);
-      this.monitorStarted = true;
+    if (!this.monitorInterval) {
+      this.monitorInterval = setInterval(() => this.monitorReceiver(), monitorFrequency)
     }
   }
 

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -5,6 +5,7 @@ import { Track } from './Track';
 export default abstract class RemoteTrack extends Track {
   /** @internal */
   receiver?: RTCRtpReceiver;
+
   monitorStarted = false;
 
   constructor(

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -55,7 +55,7 @@ export default abstract class RemoteTrack extends Track {
   /* @internal */
   startMonitor() {
     if (!this.monitorInterval) {
-      this.monitorInterval = setInterval(() => this.monitorReceiver(), monitorFrequency)
+      this.monitorInterval = setInterval(() => this.monitorReceiver(), monitorFrequency);
     }
   }
 

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,7 +1,7 @@
 import { debounce } from 'ts-debounce';
 import log from '../../logger';
 import { TrackEvent } from '../events';
-import { computeBitrate, monitorFrequency, VideoReceiverStats } from '../stats';
+import { computeBitrate, VideoReceiverStats } from '../stats';
 import { getIntersectionObserver, getResizeObserver, ObservableMediaElement } from '../utils';
 import RemoteTrack from './RemoteTrack';
 import { attachToElement, detachTrack, Track } from './Track';
@@ -160,9 +160,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
     }
 
     this.prevStats = stats;
-    setTimeout(() => {
-      this.monitorReceiver();
-    }, monitorFrequency);
   };
 
   private async getReceiverStats(): Promise<VideoReceiverStats | undefined> {


### PR DESCRIPTION
Prevent multiple redundant monitors from being started if start is called multiple times on a RemoteTrack 

Fixes issue: https://github.com/livekit/client-sdk-js/issues/392