### PR TITLE
Populate metadata when creating participant

### DIFF
--- a/.changeset/cool-wolves-shop.md
+++ b/.changeset/cool-wolves-shop.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Set metadata when creating participant

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -69,11 +69,12 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   private _connectionQuality: ConnectionQuality = ConnectionQuality.Unknown;
 
   /** @internal */
-  constructor(sid: string, identity: string, name?: string) {
+  constructor(sid: string, identity: string, name?: string, metadata?: string) {
     super();
     this.sid = sid;
     this.identity = identity;
     this.name = name;
+    this.metadata = metadata;
     this.audioTracks = new Map();
     this.videoTracks = new Map();
     this.tracks = new Map();

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -24,12 +24,18 @@ export default class RemoteParticipant extends Participant {
 
   /** @internal */
   static fromParticipantInfo(signalClient: SignalClient, pi: ParticipantInfo): RemoteParticipant {
-    return new RemoteParticipant(signalClient, pi.sid, pi.identity, pi.name);
+    return new RemoteParticipant(signalClient, pi.sid, pi.identity, pi.name, pi.metadata);
   }
 
   /** @internal */
-  constructor(signalClient: SignalClient, sid: string, identity?: string, name?: string) {
-    super(sid, identity || '', name);
+  constructor(
+    signalClient: SignalClient,
+    sid: string,
+    identity?: string,
+    name?: string,
+    metadata?: string,
+  ) {
+    super(sid, identity || '', name, metadata);
     this.signalClient = signalClient;
     this.tracks = new Map();
     this.audioTracks = new Map();


### PR DESCRIPTION
Fixes a bug that got introduced by #365 where the `ParticipantConnected` event could have been missing the `participantMetadata`. 
