### PR TITLE
enable simulcast codecs for firefox

### DIFF
--- a/.changeset/weak-parents-shout.md
+++ b/.changeset/weak-parents-shout.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+enable simucalst codecs for firefox

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -509,7 +509,7 @@ export default class LocalParticipant extends Participant {
         }
 
         // set vp8 codec as backup for any other codecs
-        if (opts.videoCodec && opts.videoCodec !== 'vp8' && !isFireFox()) {
+        if (opts.videoCodec && opts.videoCodec !== 'vp8') {
           req.simulcastCodecs = [
             {
               codec: opts.videoCodec,


### PR DESCRIPTION
server side will prefer codec for client if AddTrackRequest has desired codec now, so remove the simulcast codec limit for firefox