### PR TITLE
Add fallback for `addTrack` if `addTransceiver` is not supported by a device

### DIFF
--- a/.changeset/wicked-toys-reflect.md
+++ b/.changeset/wicked-toys-reflect.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add fallback for addTrack if addTransceiver is not supported

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,13 @@ import RemoteTrack from './room/track/RemoteTrack';
 import RemoteTrackPublication from './room/track/RemoteTrackPublication';
 import RemoteVideoTrack, { ElementInfo } from './room/track/RemoteVideoTrack';
 import { TrackPublication } from './room/track/TrackPublication';
-import { getEmptyAudioStreamTrack, getEmptyVideoStreamTrack } from './room/utils';
+import {
+  getEmptyAudioStreamTrack,
+  getEmptyVideoStreamTrack,
+  isDeviceSupported,
+  supportsAdaptiveStream,
+  supportsDynacast,
+} from './room/utils';
 
 export * from './options';
 export * from './room/errors';
@@ -30,6 +36,9 @@ export {
   setLogExtension,
   getEmptyAudioStreamTrack,
   getEmptyVideoStreamTrack,
+  isDeviceSupported,
+  supportsAdaptiveStream,
+  supportsDynacast,
   LogLevel,
   Room,
   ConnectionState,

--- a/src/proto/google/protobuf/timestamp.ts
+++ b/src/proto/google/protobuf/timestamp.ts
@@ -199,7 +199,7 @@ export type DeepPartial<T> = T extends Builtin
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {

--- a/src/proto/livekit_models.ts
+++ b/src/proto/livekit_models.ts
@@ -2921,25 +2921,29 @@ var globalThis: any = (() => {
   throw 'Unable to locate global object';
 })();
 
-const atob: (b64: string) => string =
-  globalThis.atob || ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
 function bytesFromBase64(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const arr = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; ++i) {
-    arr[i] = bin.charCodeAt(i);
+  if (globalThis.Buffer) {
+    return Uint8Array.from(globalThis.Buffer.from(b64, 'base64'));
+  } else {
+    const bin = globalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
   }
-  return arr;
 }
 
-const btoa: (bin: string) => string =
-  globalThis.btoa || ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
 function base64FromBytes(arr: Uint8Array): string {
-  const bin: string[] = [];
-  arr.forEach((byte) => {
-    bin.push(String.fromCharCode(byte));
-  });
-  return btoa(bin.join(''));
+  if (globalThis.Buffer) {
+    return globalThis.Buffer.from(arr).toString('base64');
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(String.fromCharCode(byte));
+    });
+    return globalThis.btoa(bin.join(''));
+  }
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
@@ -2959,7 +2963,7 @@ export type DeepPartial<T> = T extends Builtin
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function toTimestamp(date: Date): Timestamp {
   const seconds = date.getTime() / 1_000;

--- a/src/proto/livekit_rtc.ts
+++ b/src/proto/livekit_rtc.ts
@@ -3480,7 +3480,7 @@ export type DeepPartial<T> = T extends Builtin
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<Exclude<keyof I, KeysOfUnion<P>>, never>;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -538,7 +538,26 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     throw new UnexpectedConnectionState('Required webRTC APIs not supported on this device');
   }
 
-  async createTransceiverRTCRtpSender(
+  async createSimulcastSender(
+    track: LocalVideoTrack,
+    simulcastTrack: SimulcastTrackInfo,
+    opts: TrackPublishOptions,
+    encodings?: RTCRtpEncodingParameters[],
+  ) {
+    // store RTCRtpSender
+    // @ts-ignore
+    if (supportsTransceiver()) {
+      return this.createSimulcastTransceiverSender(track, simulcastTrack, opts, encodings);
+    }
+    if (supportsAddTrack()) {
+      console.log('using add-track');
+      return this.createRTCRtpSender(track.mediaStreamTrack);
+    }
+
+    throw new UnexpectedConnectionState('Cannot stream on this device');
+  }
+
+  private async createTransceiverRTCRtpSender(
     track: LocalTrack,
     opts: TrackPublishOptions,
     encodings?: RTCRtpEncodingParameters[],
@@ -563,7 +582,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     return transceiver.sender;
   }
 
-  async createSimulcastTransceiverSender(
+  private async createSimulcastTransceiverSender(
     track: LocalVideoTrack,
     simulcastTrack: SimulcastTrackInfo,
     opts: TrackPublishOptions,
@@ -589,30 +608,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     return transceiver.sender;
   }
 
-  async createRTCRtpSender(track: MediaStreamTrack) {
+  private async createRTCRtpSender(track: MediaStreamTrack) {
     if (!this.publisher) {
       throw new UnexpectedConnectionState('publisher is closed');
     }
     return this.publisher.pc.addTrack(track);
-  }
-
-  async setupSimulcastSender(
-    track: LocalVideoTrack,
-    simulcastTrack: SimulcastTrackInfo,
-    opts: TrackPublishOptions,
-    encodings?: RTCRtpEncodingParameters[],
-  ) {
-    // store RTCRtpSender
-    // @ts-ignore
-    if (supportsTransceiver()) {
-      return this.createSimulcastTransceiverSender(track, simulcastTrack, opts, encodings);
-    }
-    if (supportsAddTrack()) {
-      console.log('using add-track');
-      return this.createRTCRtpSender(track.mediaStreamTrack);
-    }
-
-    throw new UnexpectedConnectionState('Cannot stream on this device');
   }
 
   // websocket reconnect behavior. if websocket is interrupted, and the PeerConnection

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -25,7 +25,11 @@ import { ConnectionError, TrackInvalidError, UnexpectedConnectionState } from '.
 import { EngineEvent } from './events';
 import PCTransport from './PCTransport';
 import { ReconnectContext, ReconnectPolicy } from './ReconnectPolicy';
-import { isWeb, sleep } from './utils';
+import LocalTrack from './track/LocalTrack';
+import LocalVideoTrack, { SimulcastTrackInfo } from './track/LocalVideoTrack';
+import { TrackPublishOptions, VideoCodec } from './track/options';
+import { Track } from './track/Track';
+import { isWeb, sleep, supportsAddTrack, supportsTransceiver } from './utils';
 
 const lossyDataChannel = '_lossy';
 const reliableDataChannel = '_reliable';
@@ -474,6 +478,142 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       log.error(`Unknown DataChannel Error on ${channelKind}`, event);
     }
   };
+
+  private setPreferredCodec(
+    transceiver: RTCRtpTransceiver,
+    kind: Track.Kind,
+    videoCodec: VideoCodec,
+  ) {
+    if (!('getCapabilities' in RTCRtpSender)) {
+      return;
+    }
+    const cap = RTCRtpSender.getCapabilities(kind);
+    if (!cap) return;
+    log.debug('get capabilities', cap);
+    const matched: RTCRtpCodecCapability[] = [];
+    const partialMatched: RTCRtpCodecCapability[] = [];
+    const unmatched: RTCRtpCodecCapability[] = [];
+    cap.codecs.forEach((c) => {
+      const codec = c.mimeType.toLowerCase();
+      if (codec === 'audio/opus') {
+        matched.push(c);
+        return;
+      }
+      const matchesVideoCodec = codec === `video/${videoCodec}`;
+      if (!matchesVideoCodec) {
+        unmatched.push(c);
+        return;
+      }
+      // for h264 codecs that have sdpFmtpLine available, use only if the
+      // profile-level-id is 42e01f for cross-browser compatibility
+      if (videoCodec === 'h264') {
+        if (c.sdpFmtpLine && c.sdpFmtpLine.includes('profile-level-id=42e01f')) {
+          matched.push(c);
+        } else {
+          partialMatched.push(c);
+        }
+        return;
+      }
+
+      matched.push(c);
+    });
+
+    if ('setCodecPreferences' in transceiver) {
+      transceiver.setCodecPreferences(matched.concat(partialMatched, unmatched));
+    }
+  }
+
+  async createSender(
+    track: LocalTrack,
+    opts: TrackPublishOptions,
+    encodings?: RTCRtpEncodingParameters[],
+  ) {
+    if (supportsTransceiver()) {
+      return this.createTransceiverRTCRtpSender(track, opts, encodings);
+    }
+    if (supportsAddTrack()) {
+      console.log('using add-track fallback');
+      return this.createRTCRtpSender(track.mediaStreamTrack);
+    }
+    throw new UnexpectedConnectionState('Required webRTC APIs not supported on this device');
+  }
+
+  async createTransceiverRTCRtpSender(
+    track: LocalTrack,
+    opts: TrackPublishOptions,
+    encodings?: RTCRtpEncodingParameters[],
+  ) {
+    if (!this.publisher) {
+      throw new UnexpectedConnectionState('publisher is closed');
+    }
+
+    const transceiverInit: RTCRtpTransceiverInit = { direction: 'sendonly' };
+    if (encodings) {
+      transceiverInit.sendEncodings = encodings;
+    }
+    // addTransceiver for react-native is async. web is synchronous, but await won't effect it.
+    const transceiver = await this.publisher.pc.addTransceiver(
+      track.mediaStreamTrack,
+      transceiverInit,
+    );
+    if (track.kind === Track.Kind.Video && opts.videoCodec) {
+      this.setPreferredCodec(transceiver, track.kind, opts.videoCodec);
+      track.codec = opts.videoCodec;
+    }
+    return transceiver.sender;
+  }
+
+  async createSimulcastTransceiverSender(
+    track: LocalVideoTrack,
+    simulcastTrack: SimulcastTrackInfo,
+    opts: TrackPublishOptions,
+    encodings?: RTCRtpEncodingParameters[],
+  ) {
+    if (!this.publisher) {
+      throw new UnexpectedConnectionState('publisher is closed');
+    }
+    const transceiverInit: RTCRtpTransceiverInit = { direction: 'sendonly' };
+    if (encodings) {
+      transceiverInit.sendEncodings = encodings;
+    }
+    // addTransceiver for react-native is async. web is synchronous, but await won't effect it.
+    const transceiver = await this.publisher.pc.addTransceiver(
+      simulcastTrack.mediaStreamTrack,
+      transceiverInit,
+    );
+    if (!opts.videoCodec) {
+      return;
+    }
+    this.setPreferredCodec(transceiver, track.kind, opts.videoCodec);
+    track.setSimulcastTrackSender(opts.videoCodec, transceiver.sender);
+    return transceiver.sender;
+  }
+
+  async createRTCRtpSender(track: MediaStreamTrack) {
+    if (!this.publisher) {
+      throw new UnexpectedConnectionState('publisher is closed');
+    }
+    return this.publisher.pc.addTrack(track);
+  }
+
+  async setupSimulcastSender(
+    track: LocalVideoTrack,
+    simulcastTrack: SimulcastTrackInfo,
+    opts: TrackPublishOptions,
+    encodings?: RTCRtpEncodingParameters[],
+  ) {
+    // store RTCRtpSender
+    // @ts-ignore
+    if (supportsTransceiver()) {
+      return this.createSimulcastTransceiverSender(track, simulcastTrack, opts, encodings);
+    }
+    if (supportsAddTrack()) {
+      console.log('using add-track');
+      return this.createRTCRtpSender(track.mediaStreamTrack);
+    }
+
+    throw new UnexpectedConnectionState('Cannot stream on this device');
+  }
 
   // websocket reconnect behavior. if websocket is interrupted, and the PeerConnection
   // continues to work, we can reconnect to websocket to continue the session

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -532,7 +532,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       return this.createTransceiverRTCRtpSender(track, opts, encodings);
     }
     if (supportsAddTrack()) {
-      console.log('using add-track fallback');
+      log.debug('using add-track fallback');
       return this.createRTCRtpSender(track.mediaStreamTrack);
     }
     throw new UnexpectedConnectionState('Required webRTC APIs not supported on this device');
@@ -550,7 +550,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       return this.createSimulcastTransceiverSender(track, simulcastTrack, opts, encodings);
     }
     if (supportsAddTrack()) {
-      console.log('using add-track');
+      log.debug('using add-track fallback');
       return this.createRTCRtpSender(track.mediaStreamTrack);
     }
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -647,7 +647,7 @@ export default class LocalParticipant extends Participant {
     if (encodings) {
       transceiverInit.sendEncodings = encodings;
     }
-    await this.engine.setupSimulcastSender(track, simulcastTrack, opts, encodings);
+    await this.engine.createSimulcastSender(track, simulcastTrack, opts, encodings);
 
     this.engine.negotiate();
     log.debug(`published ${videoCodec} for track ${track.sid}`, { encodings, trackInfo: ti });

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -564,10 +564,11 @@ export default class LocalParticipant extends Participant {
       );
     }
 
-    this.engine.negotiate();
-
     // store RTPSender
     track.sender = await this.engine.createSender(track, opts, encodings);
+
+    this.engine.negotiate();
+
     if (track instanceof LocalVideoTrack) {
       track.startMonitor(this.engine.client);
     } else if (track instanceof LocalAudioTrack) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -42,7 +42,6 @@ import {
   mediaTrackToLocalTrack,
 } from './publishUtils';
 import RemoteParticipant from './RemoteParticipant';
-import 'webrtc-adapter';
 
 export default class LocalParticipant extends Participant {
   audioTracks: Map<string, LocalTrackPublication>;

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -551,10 +551,9 @@ export default class LocalParticipant extends Participant {
       throw new UnexpectedConnectionState('publisher is closed');
     }
     log.debug(`publishing ${track.kind} with encodings`, { encodings, trackInfo: ti });
-    const transceiverInit: RTCRtpTransceiverInit = { direction: 'sendonly' };
-    if (encodings) {
-      transceiverInit.sendEncodings = encodings;
-    }
+
+    // store RTPSender
+    track.sender = await this.engine.createSender(track, opts, encodings);
 
     if (track.codec === 'av1' && encodings && encodings[0]?.maxBitrate) {
       this.engine.publisher.setTrackCodecBitrate(
@@ -563,9 +562,6 @@ export default class LocalParticipant extends Participant {
         encodings[0].maxBitrate / 1000,
       );
     }
-
-    // store RTPSender
-    track.sender = await this.engine.createSender(track, opts, encodings);
 
     this.engine.negotiate();
 

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -29,6 +29,10 @@ export function supportsAdaptiveStream() {
   return typeof ResizeObserver !== undefined && typeof IntersectionObserver !== undefined;
 }
 
+export function supportsDynacast() {
+  return supportsTransceiver();
+}
+
 export function isDeviceSupported() {
   return supportsTransceiver() || supportsAddTrack();
 }

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -17,12 +17,12 @@ export async function sleep(duration: number): Promise<void> {
 
 /** @internal */
 export function supportsTransceiver() {
-  return false; // TODO 'addTransceiver' in RTCPeerConnection.prototype && 'addTransceiver' in RTCPeerConnection
+  return 'addTransceiver' in RTCPeerConnection;
 }
 
 /** @internal */
 export function supportsAddTrack() {
-  return 'addTrack' in RTCPeerConnection.prototype;
+  return 'addTrack' in RTCPeerConnection;
 }
 
 export function supportsAdaptiveStream() {

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -15,6 +15,24 @@ export async function sleep(duration: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, duration));
 }
 
+/** @internal */
+export function supportsTransceiver() {
+  return false; // TODO 'addTransceiver' in RTCPeerConnection.prototype && 'addTransceiver' in RTCPeerConnection
+}
+
+/** @internal */
+export function supportsAddTrack() {
+  return 'addTrack' in RTCPeerConnection.prototype;
+}
+
+export function supportsAdaptiveStream() {
+  return typeof ResizeObserver !== undefined && typeof IntersectionObserver !== undefined;
+}
+
+export function isDeviceSupported() {
+  return supportsTransceiver() || supportsAddTrack();
+}
+
 export function isFireFox(): boolean {
   if (!isWeb()) return false;
   return navigator.userAgent.indexOf('Firefox') !== -1;


### PR DESCRIPTION
the work in this PR is largely based upon the work in #373 (thank you @cscherban !)
main difference implementation wise is that there's no support for `addStream`. 
apart from that it's mostly refactoring.

To increase compatibility further, we will have to add some more specific browser targets to the babel transpilation (will open a separate PR for that).

note: using `addTrack` currently breaks dynacast as this check is failing https://github.com/livekit/client-sdk-js/blob/main/src/room/track/LocalVideoTrack.ts#L322
