### PR TITLE
Specify more explicit browser targets

### DIFF
--- a/.changeset/yellow-experts-joke.md
+++ b/.changeset/yellow-experts-joke.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Update browserslist

--- a/README.md
+++ b/README.md
@@ -279,7 +279,9 @@ setLogExtension((level: LogLevel, msg: string, context: object) => {
 | Edge (Chromium) | Windows, macOS        |           |
 
 We aim to support a broad range of browser versions by transpiling the library code with babel.
-Note that some features like adaptiveStream and dynacast rely on specific browser APIs to be present.
-You can check compatibility with the helper functions `supportsAdaptiveStream()` and `supportsDynacast()`
+
+> Note that the library requires some specific browser APIs to be present present.
+> You can check general compatibility with the helper function `isBrowserSupported()`.
+> Support for more modern features like adaptiveStream and dynacast can be checked for with `supportsAdaptiveStream()` and `supportsDynacast()`.
 
 If you are targeting legacy browsers, but still want adaptiveStream functionality you'll likely need to use polyfills for [ResizeObserver](https://www.npmjs.com/package/resize-observer-polyfill) and [IntersectionObserver](https://www.npmjs.com/package/intersection-observer).

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ setLogExtension((level: LogLevel, msg: string, context: object) => {
 | Edge (Chromium) | Windows, macOS        |           |
 
 We aim to support a broad range of browser versions by transpiling the library code with babel.
+You can have a look at the `"browerslist"` section of `package.json` for more details.
 
 > Note that the library requires some specific browser APIs to be present.
 > You can check general compatibility with the helper function `isBrowserSupported()`.

--- a/README.md
+++ b/README.md
@@ -277,3 +277,9 @@ setLogExtension((level: LogLevel, msg: string, context: object) => {
 | Firefox         | Windows, macOS, Linux | Android   |
 | Safari          | macOS                 | iOS       |
 | Edge (Chromium) | Windows, macOS        |           |
+
+We aim to support a broad range of browser versions by transpiling the library code with babel.
+Note that some features like adaptiveStream and dynacast rely on specific browser APIs to be present.
+You can check compatibility with the helper functions `supportsAdaptiveStream()` and `supportsDynacast()`
+
+If you are targeting legacy browsers, but still want adaptiveStream functionality you'll likely need to use polyfills for [ResizeObserver](https://www.npmjs.com/package/resize-observer-polyfill) and [IntersectionObserver](https://www.npmjs.com/package/intersection-observer).

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ setLogExtension((level: LogLevel, msg: string, context: object) => {
 
 We aim to support a broad range of browser versions by transpiling the library code with babel.
 
-> Note that the library requires some specific browser APIs to be present present.
+> Note that the library requires some specific browser APIs to be present.
 > You can check general compatibility with the helper function `isBrowserSupported()`.
 > Support for more modern features like adaptiveStream and dynacast can be checked for with `supportsAdaptiveStream()` and `supportsDynacast()`.
 

--- a/package.json
+++ b/package.json
@@ -78,8 +78,15 @@
     "typescript": "4.7.4"
   },
   "browserslist": [
-    "defaults",
     "safari >= 11",
-    "not IE 11"
+    "ios_saf >= 11",
+    "chrome >= 56",
+    "and_chr >= 56",
+    "android >= 56",
+    "firefox >= 53",
+    "edge >= 50",
+    "Samsung >= 6.0",
+    "not IE 11",
+    "not dead"
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { TrackPublication } from './room/track/TrackPublication';
 import {
   getEmptyAudioStreamTrack,
   getEmptyVideoStreamTrack,
-  isDeviceSupported,
+  isBrowserSupported,
   supportsAdaptiveStream,
   supportsDynacast,
 } from './room/utils';
@@ -36,7 +36,7 @@ export {
   setLogExtension,
   getEmptyAudioStreamTrack,
   getEmptyVideoStreamTrack,
-  isDeviceSupported,
+  isBrowserSupported,
   supportsAdaptiveStream,
   supportsDynacast,
   LogLevel,

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -33,7 +33,7 @@ export function supportsDynacast() {
   return supportsTransceiver();
 }
 
-export function isDeviceSupported() {
+export function isBrowserSupported() {
   return supportsTransceiver() || supportsAddTrack();
 }
 


### PR DESCRIPTION
...as part of the efforts to increase compatibility. 
Firefox version above 53 because below that it adds ~10kb on the gzipped bundle size. 
FF v53 was released in 2017, so I think this is an ok trade off. 

This PR is also removing the `defaults` setting of browserslist, which means some browsers like opera, baidu, kaios aren't considered at all anymore for transpilation. The reasoning behind this is, that they do not support the necessary webRTC APIs anyways to use the library. 