### PR TITLE
Move monitor APIs into parent classes

### DIFF
--- a/.changeset/mean-impalas-sell.md
+++ b/.changeset/mean-impalas-sell.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Move monitor APIs in parent classes

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -78,12 +78,15 @@ export default class LocalAudioTrack extends LocalTrack {
     if (!isWeb()) {
       return;
     }
-    setTimeout(() => {
+    if (this.monitorInterval) {
+      return;
+    }
+    this.monitorInterval = setInterval(() => {
       this.monitorSender();
     }, monitorFrequency);
   }
 
-  private monitorSender = async () => {
+  protected monitorSender = async () => {
     if (!this.sender) {
       this._currentBitrate = 0;
       return;
@@ -102,9 +105,6 @@ export default class LocalAudioTrack extends LocalTrack {
     }
 
     this.prevStats = stats;
-    setTimeout(() => {
-      this.monitorSender();
-    }, monitorFrequency);
   };
 
   async getSenderStats(): Promise<AudioSenderStats | undefined> {

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -7,7 +7,7 @@ import { getEmptyAudioStreamTrack, getEmptyVideoStreamTrack, isMobile } from '..
 import type { VideoCodec } from './options';
 import { attachToElement, detachTrack, Track } from './Track';
 
-export default class LocalTrack extends Track {
+export default abstract class LocalTrack extends Track {
   /** @internal */
   sender?: RTCRtpSender;
 
@@ -249,4 +249,6 @@ export default class LocalTrack extends Track {
       await this.sender.replaceTrack(this._mediaStreamTrack);
     });
   }
+
+  protected abstract monitorSender(): void;
 }

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -67,7 +67,10 @@ export default class LocalVideoTrack extends LocalTrack {
       this.encodings = params.encodings;
     }
 
-    setTimeout(() => {
+    if (this.monitorInterval) {
+      return;
+    }
+    this.monitorInterval = setInterval(() => {
       this.monitorSender();
     }, monitorFrequency);
   }
@@ -268,7 +271,7 @@ export default class LocalVideoTrack extends LocalTrack {
     await setPublishingLayersForSender(this.sender, this.encodings, qualities);
   }
 
-  private monitorSender = async () => {
+  protected monitorSender = async () => {
     if (!this.sender) {
       this._currentBitrate = 0;
       return;
@@ -293,9 +296,6 @@ export default class LocalVideoTrack extends LocalTrack {
     }
 
     this.prevStats = statsMap;
-    setTimeout(() => {
-      this.monitorSender();
-    }, monitorFrequency);
   };
 
   protected async handleAppVisibilityChanged() {

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -6,8 +6,6 @@ export default abstract class RemoteTrack extends Track {
   /** @internal */
   receiver?: RTCRtpReceiver;
 
-  monitorInterval?: ReturnType<typeof setInterval>;
-
   constructor(
     mediaTrack: MediaStreamTrack,
     sid: string,
@@ -57,13 +55,6 @@ export default abstract class RemoteTrack extends Track {
   startMonitor() {
     if (!this.monitorInterval) {
       this.monitorInterval = setInterval(() => this.monitorReceiver(), monitorFrequency);
-    }
-  }
-
-  /* @internal */
-  stopMonitor() {
-    if (this.monitorInterval) {
-      clearInterval(this.monitorInterval);
     }
   }
 

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
+import type { SignalClient } from '../../api/SignalClient';
 import { TrackSource, TrackType } from '../../proto/livekit_models';
 import { StreamState as ProtoStreamState } from '../../proto/livekit_rtc';
 import { TrackEvent } from '../events';
@@ -11,7 +12,7 @@ const BACKGROUND_REACTION_DELAY = 5000;
 // Safari tracks which audio elements have been "blessed" by the user.
 const recycledElements: Array<HTMLAudioElement> = [];
 
-export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEventCallbacks>) {
+export abstract class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEventCallbacks>) {
   kind: Track.Kind;
 
   attachedElements: HTMLMediaElement[] = [];
@@ -44,6 +45,8 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
   private backgroundTimeout: ReturnType<typeof setTimeout> | undefined;
 
   protected _currentBitrate: number = 0;
+
+  protected monitorInterval?: ReturnType<typeof setInterval>;
 
   protected constructor(mediaTrack: MediaStreamTrack, kind: Track.Kind) {
     super();
@@ -170,6 +173,7 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
   }
 
   stop() {
+    this.stopMonitor();
     this._mediaStreamTrack.stop();
     if (isWeb()) {
       document.removeEventListener('visibilitychange', this.appVisibilityChangedListener);
@@ -182,6 +186,16 @@ export class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEve
 
   protected disable() {
     this._mediaStreamTrack.enabled = false;
+  }
+
+  /* @internal */
+  abstract startMonitor(signalClient?: SignalClient): void;
+
+  /* @internal */
+  protected stopMonitor() {
+    if (this.monitorInterval) {
+      clearInterval(this.monitorInterval);
+    }
   }
 
   private recycleElement(element: HTMLMediaElement) {


### PR DESCRIPTION
follow up on https://github.com/livekit/client-sdk-js/pull/393 and unifies the approach to use an interval instead of setTimeout also for local tracks, making sure that the aren't multiple parallel monitoring loops running. 