### PR TITLE
fix video track lost for migration on safari

### DIFF
--- a/.changeset/six-insects-enjoy.md
+++ b/.changeset/six-insects-enjoy.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+fix video track lost for safari migration

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -129,6 +129,9 @@ export default class RemoteTrackPublication extends TrackPublication {
   setTrack(track?: RemoteTrack) {
     const prevStatus = this.subscriptionStatus;
     const prevTrack = this.track;
+    if (!!prevTrack === !!track) {
+      return;
+    }
     if (prevTrack) {
       // unregister listener
       prevTrack.off(TrackEvent.VideoDimensionsChanged, this.handleVideoDimensionsChange);

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -129,7 +129,7 @@ export default class RemoteTrackPublication extends TrackPublication {
   setTrack(track?: RemoteTrack) {
     const prevStatus = this.subscriptionStatus;
     const prevTrack = this.track;
-    if (!!prevTrack === !!track) {
+    if (prevTrack === track) {
       return;
     }
     if (prevTrack) {
@@ -138,6 +138,7 @@ export default class RemoteTrackPublication extends TrackPublication {
       prevTrack.off(TrackEvent.VisibilityChanged, this.handleVisibilityChange);
       prevTrack.off(TrackEvent.Ended, this.handleEnded);
       prevTrack.detach();
+      this.emit(TrackEvent.Unsubscribed, prevTrack);
     }
     super.setTrack(track);
     if (track) {
@@ -145,16 +146,9 @@ export default class RemoteTrackPublication extends TrackPublication {
       track.on(TrackEvent.VideoDimensionsChanged, this.handleVideoDimensionsChange);
       track.on(TrackEvent.VisibilityChanged, this.handleVisibilityChange);
       track.on(TrackEvent.Ended, this.handleEnded);
+      this.emit(TrackEvent.Subscribed, track);
     }
     this.emitSubscriptionUpdateIfChanged(prevStatus);
-    if (!!track !== !!prevTrack) {
-      // when undefined status changes, there's a subscription changed event
-      if (track) {
-        this.emit(TrackEvent.Subscribed, track);
-      } else if (prevTrack) {
-        this.emit(TrackEvent.Unsubscribed, prevTrack);
-      }
-    }
   }
 
   /** @internal */


### PR DESCRIPTION
 In case of session migration, safari have chance not fire the `stream.onremovetrack` event, so the RemoteTrack are not cleared, will be set again by the same remote track then cause the track detach and not attached, then some video tracks are disappeared in ui