### PR TITLE
add participant id when resuming

### DIFF
--- a/.changeset/slow-chefs-yawn.md
+++ b/.changeset/slow-chefs-yawn.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+add participant id when reconnecting

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -38,6 +38,9 @@ interface ConnectOpts {
   /** internal */
   reconnect?: boolean;
 
+  /** internal */
+  sid?: string;
+
   /** @deprecated */
   publishOnly?: string;
 
@@ -161,12 +164,13 @@ export class SignalClient {
     return res as JoinResponse;
   }
 
-  async reconnect(url: string, token: string): Promise<void> {
+  async reconnect(url: string, token: string, sid?: string): Promise<void> {
     this.isReconnecting = true;
     // clear ping interval and restart it once reconnected
     this.clearPingInterval();
     await this.connect(url, token, {
       reconnect: true,
+      sid,
     });
   }
 
@@ -607,6 +611,9 @@ function createConnectionParams(token: string, info: ClientInfo, opts?: ConnectO
   // opts
   if (opts?.reconnect) {
     params.set('reconnect', '1');
+    if(opts?.sid) {
+      params.set('sid', opts.sid);
+    }
   }
   if (opts?.autoSubscribe !== undefined) {
     params.set('auto_subscribe', opts.autoSubscribe ? '1' : '0');

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -611,7 +611,7 @@ function createConnectionParams(token: string, info: ClientInfo, opts?: ConnectO
   // opts
   if (opts?.reconnect) {
     params.set('reconnect', '1');
-    if(opts?.sid) {
+    if (opts?.sid) {
       params.set('sid', opts.sid);
     }
   }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -120,6 +120,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
   private reconnectTimeout?: ReturnType<typeof setTimeout>;
 
+  private participantSid?: string;
+
   constructor(private options: RoomOptions) {
     super();
     this.client = new SignalClient();
@@ -236,6 +238,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (this.publisher || this.subscriber) {
       return;
     }
+
+    this.participantSid = joinResponse.participant?.sid;
 
     // update ICE servers before creating PeerConnection
     if (joinResponse.iceServers && !this.rtcConfig.iceServers) {
@@ -798,7 +802,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
 
     try {
-      await this.client.reconnect(this.url, this.token);
+      await this.client.reconnect(this.url, this.token, this.participantSid);
     } catch (e) {
       let message = '';
       if (e instanceof Error) {


### PR DESCRIPTION
add participant id to parameter when resuming, server will refuse the resuming request when id mismatch and require a full reconnect