### PR TITLE
fix video attach to incorrect element when transceiver reuse

### DIFF
--- a/.changeset/thirty-eagles-wait.md
+++ b/.changeset/thirty-eagles-wait.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+fix video attach to incorrect element when tranceiver reuse

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -188,8 +188,8 @@ export default class RemoteTrackPublication extends TrackPublication {
   }
 
   protected handleEnded = (track: RemoteTrack) => {
-    this.emit(TrackEvent.Ended, track);
     this.setTrack(undefined);
+    this.emit(TrackEvent.Ended, track);
   };
 
   protected get isAdaptiveStream(): boolean {


### PR DESCRIPTION
When MediaStreamTrack been removed  from  MediaStream ,we emit event before setTrack, cause ui received `unsubscribed` event to render the participant. But the RemoteTrack holds a stale `MediaStreamTrack`, when transceiver reuse involved, the `MediaStreamTrack` might be added to other participant's `MediaStream`, that cause video track has been attached to incorrect element. If this participant don't have any subsequent track events fired, then ui don't have chance to render the correct track. This cause the video chaos issue on my local cluster kill node test