### PR TITLE
Use different monthly format for renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "schedule": "every 4th tuesday",
+  "schedule": "before 6am on the first day of the month",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
the other PR didn't fix the issue, this schedule is now adapted directly from the renovate examples, so it should work... 