### PR TITLE
Restore previous behaviour for when to trigger track permission updates

### DIFF
--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -59,7 +59,7 @@ export default class RemoteTrackPublication extends TrackPublication {
   }
 
   get subscriptionStatus(): TrackPublication.SubscriptionStatus {
-    if (!this.allowed) {
+    if (!this.allowed && this.subscribed === true) {
       return TrackPublication.SubscriptionStatus.NotAllowed;
     }
     if (this.subscribed === false) {

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -33,10 +33,13 @@ export default class RemoteTrackPublication extends TrackPublication {
    */
   setSubscribed(subscribed: boolean) {
     const prevStatus = this.subscriptionStatus;
+    const prevPermission = this.permissionStatus;
     this.subscribed = subscribed;
     // reset allowed status when desired subscription state changes
     // server will notify client via signal message if it's not allowed
-    this.allowed = true;
+    if (subscribed) {
+      this.allowed = true;
+    }
 
     const sub: UpdateSubscription = {
       trackSids: [this.trackSid],
@@ -52,6 +55,7 @@ export default class RemoteTrackPublication extends TrackPublication {
     };
     this.emit(TrackEvent.UpdateSubscription, sub);
     this.emitSubscriptionUpdateIfChanged(prevStatus);
+    this.emitPermissionUpdateIfChanged(prevStatus, prevPermission);
   }
 
   get subscriptionStatus(): TrackPublication.SubscriptionStatus {
@@ -204,7 +208,11 @@ export default class RemoteTrackPublication extends TrackPublication {
     previousPermissionStatus: TrackPublication.PermissionStatus,
   ) {
     const currentPermissionStatus = this.permissionStatus;
-    if (previousPermissionStatus === currentPermissionStatus) {
+    if (
+      (previousPermissionStatus === currentPermissionStatus ||
+        this.subscriptionStatus === TrackPublication.SubscriptionStatus.Desired) &&
+      previousSubscriptionStatus !== TrackPublication.SubscriptionStatus.Desired
+    ) {
       return;
     }
     // emitting subscription status instead of permission status to not break 1.0 API


### PR DESCRIPTION
The code path for the permission updates is getting a bit hard to reason about. 
The reason why it's currently necessary is that a new `SubscriptionStatus: Desired` has been introduced and the tricky part is to not break the previous assumptions around `TrackSubscriptionPermissionUpdate`s along with it, because that event emits `SubscriptionStatus` (which has an additional state now). 
This change seems to do the trick right now, but it feels like a clear separation between what a `SubscriptionStatus` and a `PermissionStatus` is, would be a good call generally. Not sure if we'd want to do that already though, because it would change the return type of the `TrackSubscriptionPermissionUpdate` event. 
