### PR TITLE
Decouple permission and subscription status

### DIFF
--- a/.changeset/late-ladybugs-appear.md
+++ b/.changeset/late-ladybugs-appear.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+**Breaking** Decouple SubscriptionStatus and SubscriptionPermissionStatus

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1225,7 +1225,7 @@ export type RoomEventCallbacks = {
   ) => void;
   trackSubscriptionPermissionChanged: (
     publication: RemoteTrackPublication,
-    status: TrackPublication.SubscriptionStatus,
+    status: TrackPublication.PermissionStatus,
     participant: RemoteParticipant,
   ) => void;
   trackSubscriptionStatusChanged: (

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -279,7 +279,7 @@ export type ParticipantEventCallbacks = {
   ) => void;
   trackSubscriptionPermissionChanged: (
     publication: RemoteTrackPublication,
-    status: TrackPublication.SubscriptionStatus,
+    status: TrackPublication.PermissionStatus,
   ) => void;
   mediaDevicesError: (error: Error) => void;
   participantPermissionsChanged: (prevPermissions: ParticipantPermission) => void;

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -58,7 +58,7 @@ export default class RemoteParticipant extends Participant {
     });
     publication.on(
       TrackEvent.SubscriptionPermissionChanged,
-      (status: TrackPublication.SubscriptionStatus) => {
+      (status: TrackPublication.PermissionStatus) => {
         this.emit(ParticipantEvent.TrackSubscriptionPermissionChanged, publication, status);
       },
     );

--- a/src/room/track/TrackPublication.ts
+++ b/src/room/track/TrackPublication.ts
@@ -118,10 +118,9 @@ export class TrackPublication extends (EventEmitter as new () => TypedEventEmitt
 
 export namespace TrackPublication {
   export enum SubscriptionStatus {
-    Subscribed = 'subscribed',
-    NotAllowed = 'not_allowed',
-    Unsubscribed = 'unsubscribed',
     Desired = 'desired',
+    Subscribed = 'subscribed',
+    Unsubscribed = 'unsubscribed',
   }
 
   export enum PermissionStatus {
@@ -136,8 +135,8 @@ export type PublicationEventCallbacks = {
   ended: (track?: Track) => void;
   updateSettings: (settings: UpdateTrackSettings) => void;
   subscriptionPermissionChanged: (
-    status: TrackPublication.SubscriptionStatus,
-    prevStatus: TrackPublication.SubscriptionStatus,
+    status: TrackPublication.PermissionStatus,
+    prevStatus: TrackPublication.PermissionStatus,
   ) => void;
   updateSubscription: (sub: UpdateSubscription) => void;
   subscribed: (track: RemoteTrack) => void;


### PR DESCRIPTION
includes a breaking API change for `SubscriptionPermissionChanged` events:

`SubscriptionStatus` now only returns `desired | subscribed | unsubscribed`
And the `TrackSubscriptionPermissionChanged` event now returns `PermissionStatus` as `allowed | not_allowed`.