### PR TITLE
add forceStereoAudioSupport option to Room constructor

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -44,6 +44,12 @@ export interface InternalRoomOptions {
   publishDefaults?: TrackPublishDefaults;
 
   /**
+   * whether to force inclusion of stereo=1 in opus audio codec sdp, defaults to false
+   * see https://github.com/w3c/webrtc-extensions/issues/63
+   */
+  forceStereoAudioSupport: boolean;
+
+  /**
    * should local tracks be stopped when they are unpublished. defaults to true
    * set this to false if you would prefer to clean up unpublished local tracks manually.
    */

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -268,8 +268,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     // @ts-ignore
     this.rtcConfig.continualGatheringPolicy = 'gather_continually';
 
-    this.publisher = new PCTransport(this.rtcConfig);
-    this.subscriber = new PCTransport(this.rtcConfig);
+    this.publisher = new PCTransport(this.rtcConfig, this.options.forceStereoAudioSupport);
+    this.subscriber = new PCTransport(this.rtcConfig, this.options.forceStereoAudioSupport);
 
     this.emit(EngineEvent.TransportsCreated, this.publisher, this.subscriber);
 

--- a/src/room/defaults.ts
+++ b/src/room/defaults.ts
@@ -33,6 +33,7 @@ export const roomOptionDefaults: InternalRoomOptions = {
   adaptiveStream: false,
   dynacast: false,
   stopLocalTrackOnUnpublish: true,
+  forceStereoAudioSupport: false,
   reconnectPolicy: new DefaultReconnectPolicy(),
 } as const;
 


### PR DESCRIPTION
As far as I could tell, there is currently no way in the livekit client to stream stereo audio. Even when constraints are specified as `channels: 2`, the stream will always end up mono on the other end.

According to https://github.com/w3c/webrtc-extensions/issues/63, munging the sdp and adding `stereo=1` is the only way to make this happen. There is discussion to make this the default, but currently this is not the case.

From my limited research, it seems that adding this option has no affect on mono streams, it just allows stereo streams over the transport.

**This PR adds an additonal option `forceStereoAudioSupport` to the `Room` constructor which when enabled adds the sdp munging for stereo support if not already in the sdp**

The change as above solves my immediate use case problem, so I'll be using this fork until a solution lands in the main project. I'm not sure if this is the right solution for the main project, maybe it would be better to just always add the `stereo=1` option. I'll leave this up to the maintainers to decide! Hopefully this PR provides a good starting point.

