### PR TITLE
Add isLocal getter to participant class

### DIFF
--- a/.changeset/cool-ligers-impress.md
+++ b/.changeset/cool-ligers-impress.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add isLocal getter to participant class

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -579,6 +579,10 @@ export default class LocalParticipant extends Participant {
     return publication;
   }
 
+  override get isLocal(): boolean {
+    return true;
+  }
+
   /** @internal
    * publish additional codec to existing track
    */

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -164,6 +164,10 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     return !!track;
   }
 
+  get isLocal(): boolean {
+    return false;
+  }
+
   /** when participant joined the room */
   get joinedAt(): Date | undefined {
     if (this.participantInfo) {


### PR DESCRIPTION
convenience property to avoid checks like `participant.identity === room.localParticipant.identity`