### PR TITLE
fix setting audioBitrate on unknown track sources

### DIFF
--- a/.changeset/fresh-pens-enjoy.md
+++ b/.changeset/fresh-pens-enjoy.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+fix setting audioBitrate on unknown track sources

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -530,7 +530,7 @@ export default class LocalParticipant extends Participant {
         opts,
       );
       req.layers = videoLayersFromEncodings(req.width, req.height, simEncodings ?? encodings);
-    } else if (track.kind === Track.Kind.Audio && opts.audioBitrate) {
+    } else if (track instanceof LocalAudioTrack && opts.audioBitrate) {
       encodings = [
         {
           maxBitrate: opts.audioBitrate,


### PR DESCRIPTION
If a track is created using `localPartipant.publishTrack` without a source specified (or source: unknown), then the `audioBitrate` option would be ignored. This was due to the code using track source instead of track type for the check.

However, if an app needs to have multiple audio tracks (which mine does), then `source: unknown` is required to prevent automatic unwanted de-duplication when also using microphone api.

**This PR changes the check for adding audioBitrate to use track type instead of source, and now the audioBitrate option is added for all audio tracks**