### PR TITLE
Use exact source matching for `getTrack`

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -107,8 +107,8 @@ export default class LocalParticipant extends Participant {
     return this.microphoneError;
   }
 
-  getTrack(source: Track.Source): LocalTrackPublication | undefined {
-    const track = super.getTrack(source, true);
+  getTrack(source: Track.Source, exact?: boolean): LocalTrackPublication | undefined {
+    const track = super.getTrack(source, exact);
     if (track) {
       return track as LocalTrackPublication;
     }
@@ -201,7 +201,7 @@ export default class LocalParticipant extends Participant {
     publishOptions?: TrackPublishOptions,
   ) {
     log.debug('setTrackEnabled', { source, enabled });
-    let track = this.getTrack(source);
+    let track = this.getTrack(source, true);
     if (enabled) {
       if (track) {
         await track.unmute();

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -108,7 +108,7 @@ export default class LocalParticipant extends Participant {
   }
 
   getTrack(source: Track.Source): LocalTrackPublication | undefined {
-    const track = super.getTrack(source);
+    const track = super.getTrack(source, true);
     if (track) {
       return track as LocalTrackPublication;
     }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -107,8 +107,8 @@ export default class LocalParticipant extends Participant {
     return this.microphoneError;
   }
 
-  getTrack(source: Track.Source, exact?: boolean): LocalTrackPublication | undefined {
-    const track = super.getTrack(source, exact);
+  getTrack(source: Track.Source): LocalTrackPublication | undefined {
+    const track = super.getTrack(source, true);
     if (track) {
       return track as LocalTrackPublication;
     }
@@ -201,7 +201,7 @@ export default class LocalParticipant extends Participant {
     publishOptions?: TrackPublishOptions,
   ) {
     log.debug('setTrackEnabled', { source, enabled });
-    let track = this.getTrack(source, true);
+    let track = this.getTrack(source);
     if (enabled) {
       if (track) {
         await track.unmute();

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -108,7 +108,7 @@ export default class LocalParticipant extends Participant {
   }
 
   getTrack(source: Track.Source): LocalTrackPublication | undefined {
-    const track = super.getTrack(source, true);
+    const track = super.getTrack(source);
     if (track) {
       return track as LocalTrackPublication;
     }

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -88,10 +88,11 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   /**
    * Finds the first track that matches the source filter, for example, getting
    * the user's camera track with getTrackBySource(Track.Source.Camera).
-   * @param source
-   * @returns
+   * @param {Track.Source} source
+   * @param {boolean | undefined} exact - Specifies whether only exact source matches should be returned or if a best guess is acceptable
+   * @returns {TrackPublication | undefined }
    */
-  getTrack(source: Track.Source): TrackPublication | undefined {
+  getTrack(source: Track.Source, exact?: boolean): TrackPublication | undefined {
     if (source === Track.Source.Unknown) {
       return;
     }
@@ -99,34 +100,38 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
       if (pub.source === source) {
         return pub;
       }
-      if (pub.source === Track.Source.Unknown) {
-        if (
-          source === Track.Source.Microphone &&
-          pub.kind === Track.Kind.Audio &&
-          pub.trackName !== 'screen'
-        ) {
-          return pub;
-        }
-        if (
-          source === Track.Source.Camera &&
-          pub.kind === Track.Kind.Video &&
-          pub.trackName !== 'screen'
-        ) {
-          return pub;
-        }
-        if (
-          source === Track.Source.ScreenShare &&
-          pub.kind === Track.Kind.Video &&
-          pub.trackName === 'screen'
-        ) {
-          return pub;
-        }
-        if (
-          source === Track.Source.ScreenShareAudio &&
-          pub.kind === Track.Kind.Audio &&
-          pub.trackName === 'screen'
-        ) {
-          return pub;
+    }
+    if (!exact) {
+      for (const [, pub] of this.tracks) {
+        if (pub.source === Track.Source.Unknown) {
+          if (
+            source === Track.Source.Microphone &&
+            pub.kind === Track.Kind.Audio &&
+            pub.trackName !== 'screen'
+          ) {
+            return pub;
+          }
+          if (
+            source === Track.Source.Camera &&
+            pub.kind === Track.Kind.Video &&
+            pub.trackName !== 'screen'
+          ) {
+            return pub;
+          }
+          if (
+            source === Track.Source.ScreenShare &&
+            pub.kind === Track.Kind.Video &&
+            pub.trackName === 'screen'
+          ) {
+            return pub;
+          }
+          if (
+            source === Track.Source.ScreenShareAudio &&
+            pub.kind === Track.Kind.Audio &&
+            pub.trackName === 'screen'
+          ) {
+            return pub;
+          }
         }
       }
     }

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -88,11 +88,10 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   /**
    * Finds the first track that matches the source filter, for example, getting
    * the user's camera track with getTrackBySource(Track.Source.Camera).
-   * @param {Track.Source} source
-   * @param {boolean | undefined} exact - Specifies whether only exact source matches should be returned or if a best guess is acceptable
-   * @returns {TrackPublication | undefined }
+   * @param source
+   * @returns
    */
-  getTrack(source: Track.Source, exact?: boolean): TrackPublication | undefined {
+  getTrack(source: Track.Source): TrackPublication | undefined {
     if (source === Track.Source.Unknown) {
       return;
     }
@@ -100,38 +99,34 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
       if (pub.source === source) {
         return pub;
       }
-    }
-    if (!exact) {
-      for (const [, pub] of this.tracks) {
-        if (pub.source === Track.Source.Unknown) {
-          if (
-            source === Track.Source.Microphone &&
-            pub.kind === Track.Kind.Audio &&
-            pub.trackName !== 'screen'
-          ) {
-            return pub;
-          }
-          if (
-            source === Track.Source.Camera &&
-            pub.kind === Track.Kind.Video &&
-            pub.trackName !== 'screen'
-          ) {
-            return pub;
-          }
-          if (
-            source === Track.Source.ScreenShare &&
-            pub.kind === Track.Kind.Video &&
-            pub.trackName === 'screen'
-          ) {
-            return pub;
-          }
-          if (
-            source === Track.Source.ScreenShareAudio &&
-            pub.kind === Track.Kind.Audio &&
-            pub.trackName === 'screen'
-          ) {
-            return pub;
-          }
+      if (pub.source === Track.Source.Unknown) {
+        if (
+          source === Track.Source.Microphone &&
+          pub.kind === Track.Kind.Audio &&
+          pub.trackName !== 'screen'
+        ) {
+          return pub;
+        }
+        if (
+          source === Track.Source.Camera &&
+          pub.kind === Track.Kind.Video &&
+          pub.trackName !== 'screen'
+        ) {
+          return pub;
+        }
+        if (
+          source === Track.Source.ScreenShare &&
+          pub.kind === Track.Kind.Video &&
+          pub.trackName === 'screen'
+        ) {
+          return pub;
+        }
+        if (
+          source === Track.Source.ScreenShareAudio &&
+          pub.kind === Track.Kind.Audio &&
+          pub.trackName === 'screen'
+        ) {
+          return pub;
         }
       }
     }

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -99,36 +99,6 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
       if (pub.source === source) {
         return pub;
       }
-      if (pub.source === Track.Source.Unknown) {
-        if (
-          source === Track.Source.Microphone &&
-          pub.kind === Track.Kind.Audio &&
-          pub.trackName !== 'screen'
-        ) {
-          return pub;
-        }
-        if (
-          source === Track.Source.Camera &&
-          pub.kind === Track.Kind.Video &&
-          pub.trackName !== 'screen'
-        ) {
-          return pub;
-        }
-        if (
-          source === Track.Source.ScreenShare &&
-          pub.kind === Track.Kind.Video &&
-          pub.trackName === 'screen'
-        ) {
-          return pub;
-        }
-        if (
-          source === Track.Source.ScreenShareAudio &&
-          pub.kind === Track.Kind.Audio &&
-          pub.trackName === 'screen'
-        ) {
-          return pub;
-        }
-      }
     }
   }
 


### PR DESCRIPTION
A user reported a problem when using multiple audio tracks alongside the `setMicrophoneEnabled` method. 
What happened was that `getTrack`, which is used within `setTrackEnabled`, would return a "best guess" track based on the assumption that every audio track that's not named `screen` could potentially be a microphone track. 

This PR introduces an optional `exact` parameter for the `getTrack` function to force the function to only return exact source matches. 
The only place where this is being actively used is `setTrackEnabled`, where we can assume control over the local tracks and thus can be sure that an adequate source has been set.

thanks @mmckegg for the report!