### PR TITLE
Make sure reconnect future is set to undefined when rejected

### DIFF
--- a/.changeset/lemon-planets-sing.md
+++ b/.changeset/lemon-planets-sing.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix: reset connect future to undefined when promise is rejected

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -176,7 +176,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       .on(EngineEvent.Resuming, () => {
         if (!this.reconnectFuture) {
           this.reconnectFuture = new Future(undefined, () => {
-            this.reconnectFuture = undefined;
+            this.clearConnectionFutures();
           });
         }
         if (this.setAndEmitConnectionState(ConnectionState.Reconnecting)) {
@@ -361,7 +361,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       });
     };
     this.connectFuture = new Future(connectFn, () => {
-      this.connectFuture = undefined;
+      this.clearConnectionFutures();
       this.emit(RoomEvent.Connected);
     });
 
@@ -407,6 +407,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (sid) {
       return this.participants.get(sid);
     }
+  }
+
+  private clearConnectionFutures() {
+    this.connectFuture = undefined;
+    this.reconnectFuture = undefined;
   }
 
   /**
@@ -630,7 +635,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   private handleRestarting = () => {
     if (!this.reconnectFuture) {
       this.reconnectFuture = new Future(undefined, () => {
-        this.reconnectFuture = undefined;
+        this.clearConnectionFutures();
       });
     }
     // also unwind existing participants & existing subscriptions

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -175,7 +175,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       .on(EngineEvent.DataPacketReceived, this.handleDataPacket)
       .on(EngineEvent.Resuming, () => {
         if (!this.reconnectFuture) {
-          this.reconnectFuture = new Future();
+          this.reconnectFuture = new Future(undefined, () => {
+            this.reconnectFuture = undefined;
+          });
         }
         if (this.setAndEmitConnectionState(ConnectionState.Reconnecting)) {
           this.emit(RoomEvent.Reconnecting);
@@ -627,7 +629,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   private handleRestarting = () => {
     if (!this.reconnectFuture) {
-      this.reconnectFuture = new Future();
+      this.reconnectFuture = new Future(undefined, () => {
+        this.reconnectFuture = undefined;
+      });
     }
     // also unwind existing participants & existing subscriptions
     for (const p of this.participants.values()) {


### PR DESCRIPTION
In case the `reconnectFuture` was rejected it did not get reset to `undefined` as this only happened in `EngineEvent.Resumed`. 

This could potentially lead to an infinite loop in `onTrackAdded` as it was recursively invoking itself if `reconnectFuture !== undefined`.

Fix by providing `onFinally` callback to the Future constructor to reset the future to `undefined` in any case. 