### PR TITLE
Update ice server from join response

### DIFF
--- a/.changeset/khaki-turkeys-work.md
+++ b/.changeset/khaki-turkeys-work.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Update ice servers from join response

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -241,7 +241,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.participantSid = joinResponse.participant?.sid;
 
     // update ICE servers before creating PeerConnection
-    if (joinResponse.iceServers && !this.rtcConfig.iceServers) {
+    if (joinResponse.iceServers)  {
       const rtcIceServers: RTCIceServer[] = [];
       joinResponse.iceServers.forEach((iceServer) => {
         const rtcIceServer: RTCIceServer = {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -241,7 +241,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.participantSid = joinResponse.participant?.sid;
 
     // update ICE servers before creating PeerConnection
-    if (joinResponse.iceServers)  {
+    if (joinResponse.iceServers) {
       const rtcIceServers: RTCIceServer[] = [];
       joinResponse.iceServers.forEach((iceServer) => {
         const rtcIceServer: RTCIceServer = {


### PR DESCRIPTION
When ice servers from join response changed while reconnected (fallback to tls relay), should use new ice servers to create peerconnection