### PR TITLE
Allowing subscription settings to update before fully subscribed

### DIFF
--- a/.changeset/ten-moons-smile.md
+++ b/.changeset/ten-moons-smile.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Allow subscription settings before fully subscribed

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -298,9 +298,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
     this.primaryPC = primaryPC;
     primaryPC.onconnectionstatechange = async () => {
-      log.debug('primary PC state changed', {
-        state: primaryPC.connectionState,
-      });
+      log.debug(`primary PC state changed ${primaryPC.connectionState}`);
       if (primaryPC.connectionState === 'connected') {
         try {
           this.connectedServerAddr = await getConnectedAddress(primaryPC);
@@ -322,9 +320,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
     };
     secondaryPC.onconnectionstatechange = async () => {
-      log.debug('secondary PC state changed', {
-        state: secondaryPC.connectionState,
-      });
+      log.debug(`secondary PC state changed ${secondaryPC.connectionState}`);
       // also reconnect if secondary peerconnection fails
       if (secondaryPC.connectionState === 'failed') {
         this.handleDisconnect('secondary peerconnection');

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1191,7 +1191,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     event: E,
     ...args: Parameters<RoomEventCallbacks[E]>
   ): boolean {
-    log.debug('room event', { event, args });
+    // active speaker updates are too spammy
+    if (event !== RoomEvent.ActiveSpeakersChanged) {
+      log.debug(`room event ${event}`, { event, args });
+    }
     return super.emit(event, ...args);
   }
 }

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -219,7 +219,7 @@ export default class RemoteTrackPublication extends TrackPublication {
       });
       return false;
     }
-    if (!this.isSubscribed) {
+    if (!this.isDesired) {
       log.warn('cannot update track settings when not subscribed', { trackSid: this.trackSid });
       return false;
     }


### PR DESCRIPTION
also made logs easier to parse. browsers sometimes log contextual objects as [object Object]