### PR TITLE
Move all logic into `publishTrack` and set explicit defaults

### DIFF
--- a/src/room/defaults.ts
+++ b/src/room/defaults.ts
@@ -12,12 +12,14 @@ import {
 export const publishDefaults: TrackPublishDefaults = {
   audioBitrate: AudioPresets.music.maxBitrate,
   dtx: true,
+  red: true,
+  forceStereo: false,
   simulcast: true,
   screenShareEncoding: ScreenSharePresets.h1080fps15.encoding,
   stopMicTrackOnMute: false,
   videoCodec: 'vp8',
   backupCodec: { codec: 'vp8', encoding: VideoPresets.h540.encoding },
-};
+} as const;
 
 export const audioDefaults: AudioCaptureOptions = {
   autoGainControl: true,

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -423,7 +423,7 @@ export default class LocalParticipant extends Participant {
       ('channelCount' in track.mediaStreamTrack.getSettings() &&
         // @ts-ignore `channelCount` on getSettings() is currently only available for Safari, but is generally the best way to determine a stereo track https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/channelCount
         track.mediaStreamTrack.getSettings().channelCount === 2) ||
-      track.mediaStreamTrack.getConstraints().channelCount == 2;
+      track.mediaStreamTrack.getConstraints().channelCount === 2;
 
     // disable red and dtx for stereo track if not enabled explicitly
     if (isStereo) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -430,11 +430,13 @@ export default class LocalParticipant extends Participant {
       if (!options) {
         options = {};
       }
+      if (options.red === undefined || options.dtx === undefined) {
+        log.warn(
+          `Opus RED and DTX will be disabled for stereo tracks by default. Enable them explicitly to make it work.`,
+        );
+      }
       options.red ??= false;
       options.dtx ??= false;
-      log.warn(
-        `Opus RED and DTX will be disabled for stereo tracks by default. Enable them explicitly to make it work.`,
-      );
     }
     const opts: TrackPublishOptions = {
       ...this.roomOptions.publishDefaults,

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -505,7 +505,7 @@ export default class LocalParticipant extends Participant {
       muted: track.isMuted,
       source: Track.sourceToProto(track.source),
       disableDtx: !(opts.dtx ?? true),
-      stereo: isStereo ?? false,
+      stereo: isStereo,
       disableRed: !(opts.red ?? true),
     });
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1,6 +1,6 @@
 import 'webrtc-adapter';
 import log from '../../logger';
-import type { RoomOptions } from '../../options';
+import type { InternalRoomOptions } from '../../options';
 import {
   DataPacket,
   DataPacket_Kind,
@@ -66,10 +66,10 @@ export default class LocalParticipant extends Participant {
   private allParticipantsAllowedToSubscribe: boolean = true;
 
   // keep a pointer to room options
-  private roomOptions?: RoomOptions;
+  private roomOptions: InternalRoomOptions;
 
   /** @internal */
-  constructor(sid: string, identity: string, engine: RTCEngine, options: RoomOptions) {
+  constructor(sid: string, identity: string, engine: RTCEngine, options: InternalRoomOptions) {
     super(sid, identity);
     this.audioTracks = new Map();
     this.videoTracks = new Map();
@@ -214,26 +214,6 @@ export default class LocalParticipant extends Participant {
         }
         this.pendingPublishing.add(source);
         try {
-          // determine stereo option by channel count if not set.
-          if (!publishOptions || publishOptions.stereo === undefined) {
-            let channelCount: ConstrainULong | undefined;
-            if (options) {
-              if ('channelCount' in options) {
-                channelCount = options.channelCount;
-              } else if (
-                'audio' in options &&
-                options.audio &&
-                typeof options.audio !== 'boolean'
-              ) {
-                channelCount = options.audio.channelCount;
-              }
-            }
-            if (channelCount && channelCount > 1) {
-              publishOptions ??= {};
-              publishOptions.stereo = true;
-            }
-          }
-
           switch (source) {
             case Track.Source.Camera:
               localTracks = await this.createTracks({
@@ -424,16 +404,6 @@ export default class LocalParticipant extends Participant {
     track: LocalTrack | MediaStreamTrack,
     options?: TrackPublishOptions,
   ): Promise<LocalTrackPublication> {
-    // disable red and dtx for stereo track if not enabled explicitly
-    if (options?.stereo) {
-      options.red ??= false;
-      options.dtx ??= false;
-    }
-    const opts: TrackPublishOptions = {
-      ...this.roomOptions?.publishDefaults,
-      ...options,
-    };
-
     // convert raw media track into audio or video track
     if (track instanceof MediaStreamTrack) {
       switch (track.kind) {
@@ -447,6 +417,29 @@ export default class LocalParticipant extends Participant {
           throw new TrackInvalidError(`unsupported MediaStreamTrack kind ${track.kind}`);
       }
     }
+
+    const isStereo =
+      options?.forceStereo ||
+      ('channelCount' in track.mediaStreamTrack.getSettings() &&
+        // @ts-ignore `channelCount` on getSettings() is currently only available for Safari, but is generally the best way to determine a stereo track https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/channelCount
+        track.mediaStreamTrack.getSettings().channelCount === 2) ||
+      track.mediaStreamTrack.getConstraints().channelCount == 2;
+
+    // disable red and dtx for stereo track if not enabled explicitly
+    if (isStereo) {
+      if (!options) {
+        options = {};
+      }
+      options.red ??= false;
+      options.dtx ??= false;
+      log.warn(
+        `Opus RED and DTX will be disabled for stereo tracks by default. Enable them explicitly to make it work.`,
+      );
+    }
+    const opts: TrackPublishOptions = {
+      ...this.roomOptions.publishDefaults,
+      ...options,
+    };
 
     // is it already published? if so skip
     let existingPublication: LocalTrackPublication | undefined;
@@ -512,7 +505,7 @@ export default class LocalParticipant extends Participant {
       muted: track.isMuted,
       source: Track.sourceToProto(track.source),
       disableDtx: !(opts.dtx ?? true),
-      stereo: opts.stereo ?? false,
+      stereo: isStereo ?? false,
       disableRed: !(opts.red ?? true),
     });
 

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -40,7 +40,7 @@ export interface TrackPublishDefaults {
   /**
    * stereo audio track. defaults determined by capture channel count.
    */
-  stereo?: boolean;
+  forceStereo?: boolean;
 
   /**
    * use simulcast, defaults to true.


### PR DESCRIPTION
Tried to move even more of the logic into `publishTrack` as the way we would determine a stereo track was relying on the `channelCount` constraint anyways. 
By inspecting the `channelCount` both via `getSettings()` and `getConstraints()` we can be pretty confident to capture most cases, and then there's `forceStereo` for the one's where we don't. 
Renamed `stereo` to `forceStereo` to make it clear that you don't _have_ to use that flag, but it's sufficient that you pass in `channelCount: 2` generally via capture constraints.
based against @cnderrauber's stereo branch. 