### PR TITLE
Register engine events on localParticipant when updated

### DIFF
--- a/.changeset/few-dolls-reflect.md
+++ b/.changeset/few-dolls-reflect.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Register engine events on localParticipant when updated

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -594,8 +594,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   }
 
   private recreateEngine() {
-    console.log('recreating engine', this.participants, this.engine);
-
     this.engine?.close();
     /* @ts-ignore */
     this.engine = undefined;
@@ -604,7 +602,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // the old engine
     this.participants.clear();
     this.createEngine();
-    this.localParticipant.engine = this.engine;
   }
 
   private onTrackAdded(

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -140,12 +140,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       ...options?.publishDefaults,
     };
 
-    this.createEngine();
+    this.maybeCreateEngine();
 
     this.localParticipant = new LocalParticipant('', '', this.engine, this.options);
   }
 
-  private createEngine() {
+  private maybeCreateEngine() {
     if (this.engine) {
       return;
     }
@@ -231,19 +231,21 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.connectFuture) {
       return this.connectFuture.promise;
     }
-    if (this.state === ConnectionState.Reconnecting) {
-      log.info('Reconnection attempt replaced by new connection attempt');
-      // make sure we close and recreate the existing engine in order to get rid of any potentially ongoing reconnection attempts
-      this.recreateEngine();
-    }
+
     const connectFn = async (resolve: () => void, reject: (reason: any) => void) => {
       this.setAndEmitConnectionState(ConnectionState.Connecting);
       if (!this.abortController || this.abortController.signal.aborted) {
         this.abortController = new AbortController();
       }
 
-      // create engine if previously disconnected
-      this.createEngine();
+      if (this.state === ConnectionState.Reconnecting) {
+        log.info('Reconnection attempt replaced by new connection attempt');
+        // make sure we close and recreate the existing engine in order to get rid of any potentially ongoing reconnection attempts
+        this.recreateEngine();
+      } else {
+        // create engine if previously disconnected
+        this.maybeCreateEngine();
+      }
 
       this.acquireAudioContext();
 
@@ -601,7 +603,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // clear out existing remote participants, since they may have attached
     // the old engine
     this.participants.clear();
-    this.createEngine();
+    this.maybeCreateEngine();
   }
 
   private onTrackAdded(

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -615,7 +615,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // technically subscribed.
     // We'll defer these events until when the room is connected or eventually disconnected.
     if (this.state === ConnectionState.Connecting || this.state == ConnectionState.Reconnecting) {
-      log.info('defering on track added');
       const reconnectedHandler = () => {
         this.onTrackAdded(mediaTrack, stream, receiver);
         cleanup();

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -233,6 +233,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
     if (this.state === ConnectionState.Reconnecting) {
       log.info('Reconnection attempt replaced by new connection attempt');
+      // make sure we close and recreate the existing engine in order to get rid of any potentially ongoing reconnection attempts
       this.recreateEngine();
     }
     const connectFn = async (resolve: () => void, reject: (reason: any) => void) => {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -232,8 +232,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return this.connectFuture.promise;
     }
 
+    this.setAndEmitConnectionState(ConnectionState.Connecting);
+
     const connectFn = async (resolve: () => void, reject: (reason: any) => void) => {
-      this.setAndEmitConnectionState(ConnectionState.Connecting);
       if (!this.abortController || this.abortController.signal.aborted) {
         this.abortController = new AbortController();
       }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -908,7 +908,6 @@ export default class LocalParticipant extends Participant {
   };
 
   private handleSubscribedQualityUpdate = async (update: SubscribedQualityUpdate) => {
-    log.info('subscribed quality update', { update, dynacast: this.roomOptions.dynacast });
     if (!this.roomOptions?.dynacast) {
       return;
     }


### PR DESCRIPTION
We didn't register the events after setting `localParticipant.engine` previously. 
Error surfaced when calling `recreateEngine` instead of `createEngine` during connect, where the localparticipant wouldn't notice that the engine had changed.