### PR TITLE
Fix `localTrack.replaceTrack` mute handling

### DIFF
--- a/.changeset/lemon-ears-care.md
+++ b/.changeset/lemon-ears-care.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+Sync muted state with track.enabled when calling replaceTrack"

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -173,7 +173,7 @@ export default abstract class LocalTrack extends Track {
     this._mediaStreamTrack = newTrack;
 
     // sync muted state with the enabled state of the newly provided track
-    this.setTrackMuted(!this._mediaStreamTrack.enabled);
+    this._mediaStreamTrack.enabled = this.isMuted;
 
     await this.resumeUpstream();
 

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -122,7 +122,7 @@ export default abstract class LocalTrack extends Track {
     this._mediaStreamTrack = track;
 
     // sync muted state with the enabled state of the newly provided track
-    this._mediaStreamTrack.enabled = this.isMuted;
+    this._mediaStreamTrack.enabled = !this.isMuted;
 
     await this.resumeUpstream();
 

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -172,6 +172,9 @@ export default abstract class LocalTrack extends Track {
 
     this._mediaStreamTrack = newTrack;
 
+    // sync muted state with the enabled state of the newly provided track
+    this.setTrackMuted(!this._mediaStreamTrack.enabled);
+
     await this.resumeUpstream();
 
     this.attachedElements.forEach((el) => {

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -121,6 +121,9 @@ export default abstract class LocalTrack extends Track {
     }
     this._mediaStreamTrack = track;
 
+    // sync muted state with the enabled state of the newly provided track
+    this._mediaStreamTrack.enabled = this.isMuted;
+
     await this.resumeUpstream();
 
     this.attachedElements.forEach((el) => {
@@ -171,9 +174,6 @@ export default abstract class LocalTrack extends Track {
     }
 
     this._mediaStreamTrack = newTrack;
-
-    // sync muted state with the enabled state of the newly provided track
-    this._mediaStreamTrack.enabled = this.isMuted;
 
     await this.resumeUpstream();
 


### PR DESCRIPTION
syncs muted state with the enabled state of the newly provided track when calling `replaceTrack`

fixes #486