### PR TITLE
Mute track if ended event has been fired

### DIFF
--- a/.changeset/eighty-knives-help.md
+++ b/.changeset/eighty-knives-help.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+mute track if ended event has been fired on underlying mediastreamtrack

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -965,6 +965,7 @@ export default class LocalParticipant extends Participant {
       this.unpublishTrack(track);
     } else if (track.isUserProvided) {
       await track.pauseUpstream();
+      await track.mute();
     } else if (track instanceof LocalAudioTrack || track instanceof LocalVideoTrack) {
       try {
         if (isWeb()) {
@@ -993,8 +994,9 @@ export default class LocalParticipant extends Participant {
         log.debug('track ended, attempting to use a different device');
         await track.restartTrack();
       } catch (e) {
-        log.warn(`could not restart track, pausing upstream instead`);
+        log.warn(`could not restart track, muting instead`);
         await track.pauseUpstream();
+        await track.mute();
       }
     }
   };

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -964,7 +964,6 @@ export default class LocalParticipant extends Participant {
       });
       this.unpublishTrack(track);
     } else if (track.isUserProvided) {
-      await track.pauseUpstream();
       await track.mute();
     } else if (track instanceof LocalAudioTrack || track instanceof LocalVideoTrack) {
       try {
@@ -995,7 +994,6 @@ export default class LocalParticipant extends Participant {
         await track.restartTrack();
       } catch (e) {
         log.warn(`could not restart track, muting instead`);
-        await track.pauseUpstream();
         await track.mute();
       }
     }


### PR DESCRIPTION
fixes https://github.com/livekit/client-sdk-js/issues/496
Considering the fact that after the `ended` event we will not be able to reuse that track again ever, we might as well mute it to surface the fact that the local publication isn't currently active anymore. 
