### PR TITLE
add getActiveAudioOutputDevice to room API

### DIFF
--- a/.changeset/rotten-pumpkins-share.md
+++ b/.changeset/rotten-pumpkins-share.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+add getActiveAudioOutputDevice method to Room

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -557,7 +557,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    * @return the previously successfully set audio output device ID or `undefined` in any other case.
    */
   getActiveAudioOutputDevice(): string | undefined {
-      return this.options.audioOutput?.deviceId;
+    return this.options.audioOutput?.deviceId;
   }
 
   /**
@@ -604,7 +604,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       const prevDeviceId = this.options.audioOutput.deviceId;
       this.options.audioOutput.deviceId = deviceId;
       try {
-        await Promise.all(Array.from(this.participants.values()).map(p => p.setAudioOutput({deviceId})));
+        await Promise.all(
+          Array.from(this.participants.values()).map((p) => p.setAudioOutput({ deviceId })),
+        );
       } catch (e) {
         this.options.audioOutput.deviceId = prevDeviceId;
         throw e;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -554,10 +554,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    *
    * Note: to get the active `audioinput` or `videoinput` use [[LocalTrack.getDeviceId()]]
    *
-   * @return the previously successfully set audio output device ID or `undefined` in any other case.
+   * @return the previously successfully set audio output device ID or an empty string if the default device is used.
    */
-  getActiveAudioOutputDevice(): string | undefined {
-    return this.options.audioOutput?.deviceId;
+  getActiveAudioOutputDevice(): string {
+    return this.options.audioOutput?.deviceId ?? '';
   }
 
   /**


### PR DESCRIPTION
fixes https://github.com/livekit/client-sdk-js/issues/497 

This is a very trivial implementation. I was working on some more advanced version trying to figure out the default device if no `deviceId` is currently set however I'm not sure this really adds any value.
Then again, as far as I can see the `options` are public so one wouldn't really need this method.

If we decide to remove the method I'd change this PR to document the ways to access the current devices on the `switchActiveDevice` method so people find this faster.