### PR TITLE
Ignore stopObservingElementInfo calls when not adaptive stream

### DIFF
--- a/.changeset/heavy-geese-buy.md
+++ b/.changeset/heavy-geese-buy.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ignore stopObservingElementInfo calls on RemoteVideoTracks when not adaptive stream

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -118,6 +118,10 @@ export default class RemoteVideoTrack extends RemoteTrack {
    * @internal
    */
   stopObservingElementInfo(elementInfo: ElementInfo) {
+    if(!this.isAdaptiveStream) {
+      log.warn('stopObservingElementInfo ignored');
+      return
+    }
     const stopElementInfos = this.elementInfos.filter((info) => info === elementInfo);
     for (const info of stopElementInfos) {
       info.stopObserving();

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -118,9 +118,9 @@ export default class RemoteVideoTrack extends RemoteTrack {
    * @internal
    */
   stopObservingElementInfo(elementInfo: ElementInfo) {
-    if(!this.isAdaptiveStream) {
+    if (!this.isAdaptiveStream) {
       log.warn('stopObservingElementInfo ignored');
-      return
+      return;
     }
     const stopElementInfos = this.elementInfos.filter((info) => info === elementInfo);
     for (const info of stopElementInfos) {


### PR DESCRIPTION
`stopObservingElementInfo` isn't safe to call when not adaptive streaming; this method calls through to `updateVisibility`, which when not adaptiveStreaming, will always set the visibility to not visible and consequently kick off a stream settings update even though it shouldn't.

This PR fixes that by ignoring calls to `stopObservingElementInfo` when not adaptive streaming.