### PR TITLE
Grace period for websocket to close gracefully

### DIFF
--- a/.changeset/mean-flies-happen.md
+++ b/.changeset/mean-flies-happen.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+grace period for WS to close gracefully

--- a/src/connectionHelper/checks/turn.ts
+++ b/src/connectionHelper/checks/turn.ts
@@ -37,7 +37,7 @@ export class TURNCheck extends Checker {
     } else if (hasTURN && !hasTLS) {
       this.appendWarning('TURN is configured server side, but TURN/TLS is unavailable.');
     }
-    signalClient.close();
+    await signalClient.close();
     if (this.connectOptions?.rtcConfig?.iceServers || hasTURN) {
       await this.room!.connect(this.url, this.token, {
         rtcConfig: {

--- a/src/connectionHelper/checks/websocket.ts
+++ b/src/connectionHelper/checks/websocket.ts
@@ -17,6 +17,6 @@ export class WebSocketCheck extends Checker {
       maxRetries: 0,
     });
     this.appendMessage(`Connected to server, version ${joinRes.serverVersion}.`);
-    signalClient.close();
+    await signalClient.close();
   }
 }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -179,7 +179,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
   }
 
-  close() {
+  async close() {
     this._isClosed = true;
     this.removeAllListeners();
     this.deregisterOnLineListener();
@@ -202,7 +202,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.subscriber.close();
       this.subscriber = undefined;
     }
-    this.client.close();
+    await this.client.close();
   }
 
   addTrack(req: AddTrackRequest): Promise<TrackInfo> {
@@ -784,9 +784,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
 
     if (this.client.isConnected) {
-      this.client.sendLeave();
+      await this.client.sendLeave();
     }
-    this.client.close();
+    await this.client.close();
     this.primaryPC = undefined;
     this.publisher?.close();
     this.publisher = undefined;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -404,7 +404,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
     // close engine (also closes client)
     if (this.engine) {
-      this.engine.close();
+      await this.engine.close();
     }
     this.handleDisconnect(stopTracks, DisconnectReason.CLIENT_INITIATED);
     /* @ts-ignore */
@@ -440,12 +440,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   /**
    * @internal for testing
    */
-  simulateScenario(scenario: string) {
+  async simulateScenario(scenario: string) {
     let postAction = () => {};
     let req: SimulateScenario | undefined;
     switch (scenario) {
       case 'signal-reconnect':
-        this.engine.client.close();
+        await this.engine.client.close();
         if (this.engine.client.onClose) {
           this.engine.client.onClose('simulate disconnect');
         }
@@ -508,8 +508,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
   }
 
-  private onBeforeUnload = () => {
-    this.disconnect();
+  private onBeforeUnload = async () => {
+    await this.disconnect();
   };
 
   /**


### PR DESCRIPTION
and await `signalClient.leave()`
 