### PR TITLE
Use mutex for disconnect calls

### DIFF
--- a/.changeset/gentle-lizards-smile.md
+++ b/.changeset/gentle-lizards-smile.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+use mutex to prevent simultaneous calls to disconnect

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -317,13 +317,14 @@ export class SignalClient {
         this.ws.onmessage = null;
         this.ws.onopen = null;
 
-        let closeResolver: (args: any) => void;
-        const closePromise = new Promise((resolve) => {
-          closeResolver = resolve;
-        });
-
         // calling `ws.close()` only starts the closing handshake (CLOSING state), prefer to wait until state is actually CLOSED
-        this.ws.onclose = () => closeResolver(true);
+        const closePromise = new Promise((resolve) => {
+          if (this.ws) {
+            this.ws.onclose = resolve;
+          } else {
+            resolve(true);
+          }
+        });
 
         this.ws.close();
         // 250ms grace period for ws to close gracefully

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -317,15 +317,6 @@ export class SignalClient {
         this.ws.onmessage = null;
         this.ws.onopen = null;
 
-        const emptyBufferPromise = new Promise(async (resolve) => {
-          while (this.ws && this.ws.bufferedAmount > 0) {
-            await sleep(50);
-          }
-          resolve(true);
-        });
-        // 250ms grace period for buffer to be cleared
-        await Promise.race([emptyBufferPromise, sleep(250)]);
-
         let closeResolver: (args: any) => void;
         const closePromise = new Promise((resolve) => {
           closeResolver = resolve;

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -320,3 +320,38 @@ export function createAudioAnalyser(
 
   return { calculateVolume, analyser, cleanup };
 }
+
+export class Mutex {
+  private _locking: Promise<void>;
+
+  private _locks: number;
+
+  constructor() {
+    this._locking = Promise.resolve();
+    this._locks = 0;
+  }
+
+  isLocked() {
+    return this._locks > 0;
+  }
+
+  lock() {
+    this._locks += 1;
+
+    let unlockNext: () => void;
+
+    const willLock = new Promise<void>(
+      (resolve) =>
+        (unlockNext = () => {
+          this._locks -= 1;
+          resolve();
+        }),
+    );
+
+    const willUnlock = this._locking.then(() => unlockNext);
+
+    this._locking = this._locking.then(() => willLock);
+
+    return willUnlock;
+  }
+}


### PR DESCRIPTION
with recent changes to wait for proper closing of the websocket within the `SignalClient` we now have to make sure that simultaneous calls to disconnect don't create unexpected state. 
Added locks for `Room.disconnect`, `Engine.close`, and `SignalClient.close`.