### PR TITLE
Revert "unlock before returning (#526)"

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -402,7 +402,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     try {
       if (this.state === ConnectionState.Disconnected) {
         log.debug('already disconnected');
-        unlock();
         return;
       }
       log.info('disconnect from room', { identity: this.localParticipant.identity });


### PR DESCRIPTION
The finally clause will be executed also for the early return. 
Unlocking twice doesn't cause any problems, but feels cleaner to just do it once. 
