### PR TITLE
Add method to populate an offline room with simulated participants

### DIFF
--- a/.changeset/eight-rice-lick.md
+++ b/.changeset/eight-rice-lick.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add util function to simulate participants within a room

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -57,7 +57,6 @@ import {
   Future,
   getDummyVideoStreamTrack,
   getEmptyAudioStreamTrack,
-  getEmptyVideoStreamTrack,
   isWeb,
   Mutex,
   supportsSetSinkId,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1261,6 +1261,18 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     count: number,
     options: { audio?: boolean; video?: boolean; aspectRatios: Array<number> },
   ) {
+    this.localParticipant
+      .on(ParticipantEvent.ParticipantMetadataChanged, this.onLocalParticipantMetadataChanged)
+      .on(ParticipantEvent.TrackMuted, this.onLocalTrackMuted)
+      .on(ParticipantEvent.TrackUnmuted, this.onLocalTrackUnmuted)
+      .on(ParticipantEvent.LocalTrackPublished, this.onLocalTrackPublished)
+      .on(ParticipantEvent.LocalTrackUnpublished, this.onLocalTrackUnpublished)
+      .on(ParticipantEvent.ConnectionQualityChanged, this.onLocalConnectionQualityChanged)
+      .on(ParticipantEvent.MediaDevicesError, this.onMediaDevicesError)
+      .on(
+        ParticipantEvent.ParticipantPermissionsChanged,
+        this.onLocalParticipantPermissionsChanged,
+      );
     this.emit(RoomEvent.SignalConnected);
     this.emit(RoomEvent.Connected);
     this.setAndEmitConnectionState(ConnectionState.Connected);
@@ -1279,7 +1291,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // @ts-ignore
     this.localParticipant.addTrackPublication(pub);
     this.localParticipant.emit(ParticipantEvent.LocalTrackPublished, pub);
-    this.emit(RoomEvent.LocalTrackPublished, pub, this.localParticipant);
+
     for (let i = 0; i < count - 1; i += 1) {
       let info: ParticipantInfo = ParticipantInfo.fromPartial({
         sid: Math.floor(Math.random() * 10_000).toString(),

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1260,8 +1260,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     count: number,
     options: { audio?: boolean; video?: boolean; aspectRatios: Array<number> },
   ) {
+    this.handleDisconnect();
     this.name = 'sim-room';
     this.localParticipant.identity = 'simulated-local';
+    this.localParticipant.name = 'simulated-local';
     this.localParticipant
       .on(ParticipantEvent.ParticipantMetadataChanged, this.onLocalParticipantMetadataChanged)
       .on(ParticipantEvent.TrackMuted, this.onLocalTrackMuted)

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -56,7 +56,7 @@ import { getNewAudioContext } from './track/utils';
 import type { SimulationOptions } from './types';
 import {
   Future,
-  getDummyVideoStreamTrack,
+  createDummyVideoStreamTrack,
   getEmptyAudioStreamTrack,
   isWeb,
   Mutex,
@@ -1294,7 +1294,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           name: 'video-dummy',
         }),
         new LocalVideoTrack(
-          getDummyVideoStreamTrack(160 * participantOptions.aspectRatios[0] ?? 1, 160, true, true),
+          createDummyVideoStreamTrack(
+            160 * participantOptions.aspectRatios[0] ?? 1,
+            160,
+            true,
+            true,
+          ),
         ),
       );
       // @ts-ignore
@@ -1326,7 +1331,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       });
       const p = this.getOrCreateParticipant(info.identity, info);
       if (participantOptions.video) {
-        const dummyVideo = getDummyVideoStreamTrack(
+        const dummyVideo = createDummyVideoStreamTrack(
           160 * participantOptions.aspectRatios[i % participantOptions.aspectRatios.length] ?? 1,
           160,
           false,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1260,6 +1260,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     count: number,
     options: { audio?: boolean; video?: boolean; aspectRatios: Array<number> },
   ) {
+    this.name = 'sim-room';
+    this.localParticipant.identity = 'simulated-local';
     this.localParticipant
       .on(ParticipantEvent.ParticipantMetadataChanged, this.onLocalParticipantMetadataChanged)
       .on(ParticipantEvent.TrackMuted, this.onLocalTrackMuted)
@@ -1289,7 +1291,19 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     );
     // @ts-ignore
     this.localParticipant.addTrackPublication(pub);
-    this.localParticipant.emit(ParticipantEvent.LocalTrackPublished, pub);
+    const audioPub = new LocalTrackPublication(
+      Track.Kind.Audio,
+      TrackInfo.fromPartial({
+        source: TrackSource.MICROPHONE,
+        sid: Math.floor(Math.random() * 10_000).toString(),
+        type: TrackType.AUDIO,
+        name: 'video-dummy',
+      }),
+      new LocalAudioTrack(getEmptyAudioStreamTrack()),
+    );
+    // @ts-ignore
+    this.localParticipant.addTrackPublication(audioPub);
+    this.localParticipant.emit(ParticipantEvent.LocalTrackPublished, audioPub);
 
     for (let i = 0; i < count - 1; i += 1) {
       let info: ParticipantInfo = ParticipantInfo.fromPartial({

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1260,7 +1260,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   /**
    * Allows to populate a room with simulated participants.
-   * No actual connection to a server will be established, all state is local.
+   * No actual connection to a server will be established, all state is
    * @experimental
    */
   simulateParticipants(options: SimulationOptions) {
@@ -1326,7 +1326,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       });
       const p = this.getOrCreateParticipant(info.identity, info);
       if (participantOptions.video) {
-        console.log('aspect index for ', i, i % participantOptions.aspectRatios.length);
         const dummyVideo = getDummyVideoStreamTrack(
           160 * participantOptions.aspectRatios[i % participantOptions.aspectRatios.length] ?? 1,
           160,

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -1,0 +1,12 @@
+export type SimulationOptions = {
+  publish?: {
+    audio?: boolean;
+    video?: boolean;
+  };
+  participants?: {
+    count?: number;
+    aspectRatios?: Array<number>;
+    audio?: boolean;
+    video?: boolean;
+  };
+};

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -181,20 +181,39 @@ let emptyVideoStreamTrack: MediaStreamTrack | undefined;
 
 export function getEmptyVideoStreamTrack() {
   if (!emptyVideoStreamTrack) {
-    const canvas = document.createElement('canvas');
-    // the canvas size is set to 16, because electron apps seem to fail with smaller values
-    canvas.width = 16;
-    canvas.height = 16;
-    canvas.getContext('2d')?.fillRect(0, 0, canvas.width, canvas.height);
-    // @ts-ignore
-    const emptyStream = canvas.captureStream();
-    [emptyVideoStreamTrack] = emptyStream.getTracks();
-    if (!emptyVideoStreamTrack) {
-      throw Error('Could not get empty media stream video track');
-    }
-    emptyVideoStreamTrack.enabled = false;
+    emptyVideoStreamTrack = getDummyVideoStreamTrack();
   }
   return emptyVideoStreamTrack;
+}
+
+export function getDummyVideoStreamTrack(
+  width: number = 16,
+  height: number = 16,
+  enabled: boolean = false,
+  paintContent: boolean = false,
+) {
+  const canvas = document.createElement('canvas');
+  // the canvas size is set to 16 by default, because electron apps seem to fail with smaller values
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  ctx?.fillRect(0, 0, canvas.width, canvas.height);
+  if (paintContent && ctx) {
+    ctx.beginPath();
+    ctx.arc(width / 2, height / 2, 50, 0, Math.PI * 2, true);
+    ctx.closePath();
+    ctx.fillStyle = 'grey';
+    ctx.fill();
+  }
+  // @ts-ignore
+  const dummyStream = canvas.captureStream();
+  const [dummyTrack] = dummyStream.getTracks();
+  if (!dummyTrack) {
+    throw Error('Could not get empty media stream video track');
+  }
+  dummyTrack.enabled = enabled;
+
+  return dummyTrack;
 }
 
 let emptyAudioStreamTrack: MediaStreamTrack | undefined;

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -181,12 +181,12 @@ let emptyVideoStreamTrack: MediaStreamTrack | undefined;
 
 export function getEmptyVideoStreamTrack() {
   if (!emptyVideoStreamTrack) {
-    emptyVideoStreamTrack = getDummyVideoStreamTrack();
+    emptyVideoStreamTrack = createDummyVideoStreamTrack();
   }
   return emptyVideoStreamTrack;
 }
 
-export function getDummyVideoStreamTrack(
+export function createDummyVideoStreamTrack(
   width: number = 16,
   height: number = 16,
   enabled: boolean = false,


### PR DESCRIPTION
Would be great to add additional features in the future that mimic remote participant behaviour. 
As a first attempt, this keeps remote participants static.