### PR TITLE
Fix rollup dev setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "David Zhao <david@davidzhao.com>",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "rollup --config && yarn downlevel-dts",
+    "build": "rollup --config --bundleConfigAsCjs && yarn downlevel-dts",
     "build:watch": "rollup --watch --config rollup.config.js",
     "build-docs": "typedoc",
     "proto": "protoc --plugin=node_modules/ts-proto/protoc-gen-ts_proto --ts_proto_opt=esModuleInterop=true --ts_proto_out=./src/proto --ts_proto_opt=outputClientImpl=false,useOptionals=messages,oneof=unions -I./protocol ./protocol/livekit_rtc.proto ./protocol/livekit_models.proto",
@@ -85,9 +85,6 @@
     "typedoc-plugin-no-inherit": "1.4.0",
     "typescript": "4.9.4",
     "vite": "3.2.5"
-  },
-  "engines": {
-    "node": ">=16.14.0"
   },
   "browserslist": [
     "safari >= 11",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
     "typescript": "4.9.4",
     "vite": "3.2.5"
   },
+  "engines": {
+    "node": ">=16.14.0"
+  },
   "browserslist": [
     "safari >= 11",
     "ios_saf >= 11",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import replace from 'rollup-plugin-re';
 import filesize from 'rollup-plugin-filesize';
 import del from 'rollup-plugin-delete';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json';
 
 function kebabCaseToPascalCase(string = '') {
   return string.replace(/(^\w|-\w)/g, (replaceString) =>


### PR DESCRIPTION
renovate made us upgrade to rollup v3. This in turn led to rollup complaining about the rollup config file being in the wrong format. 
First attempt was to switch to `.mjs` extension, which solved the issue, but led to older nodejs versions (< 16.14.0) not being supported anymore (related to type assertions when importing json files).
This change now passes a command line flag to rollup telling it to bundle the config as cjs instead.
