### PR TITLE
Improve autoplay when multiple streams are attached to the same media element

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1045,6 +1045,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.options.expWebAudioMix) {
       this.participants.forEach((participant) => participant.setAudioContext(this.audioContext));
     }
+
+    const newContextIsRunning = this.audioContext?.state === 'running';
+    if (newContextIsRunning !== this.canPlaybackAudio) {
+      this.audioEnabled = newContextIsRunning;
+      this.emit(RoomEvent.AudioPlaybackStatusChanged, newContextIsRunning);
+    }
   }
 
   private createParticipant(id: string, info?: ParticipantInfo): RemoteParticipant {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -556,7 +556,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     });
 
     try {
-      await Promise.all(elements.map((e) => e.play()));
+      await Promise.all(
+        elements.map((e) => {
+          e.muted = false;
+          return e.play();
+        }),
+      );
       this.handleAudioPlaybackStarted();
     } catch (err) {
       this.handleAudioPlaybackFailed(err);

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -121,7 +121,7 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
     // we'll want to re-attach it in that case
     attachToElement(this._mediaStreamTrack, element);
 
-    if (element instanceof HTMLAudioElement) {
+    if ((element.srcObject as MediaStream).getAudioTracks().length > 0) {
       // manually play audio to detect audio playback status
       element
         .play()
@@ -260,7 +260,7 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
   }
 
   element.autoplay = true;
-  // In case there are no audio tracks present on the mediastream, we set the element as muted to ensure autoplay
+  // In case there are no audio tracks present on the mediastream, we set the element as muted to ensure autoplay works
   element.muted = mediaStream.getAudioTracks().length === 0;
   if (element instanceof HTMLVideoElement) {
     element.playsInline = true;

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -259,6 +259,13 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
     mediaStream.addTrack(track);
   }
 
+  element.autoplay = true;
+  // In case there are no audio tracks present on the mediastream, we set the element as muted to ensure autoplay
+  element.muted = mediaStream.getAudioTracks().length === 0;
+  if (element instanceof HTMLVideoElement) {
+    element.playsInline = true;
+  }
+
   // avoid flicker
   if (element.srcObject !== mediaStream) {
     element.srcObject = mediaStream;
@@ -279,10 +286,6 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
         });
       }, 0);
     }
-  }
-  element.autoplay = true;
-  if (element instanceof HTMLVideoElement) {
-    element.playsInline = true;
   }
 }
 


### PR DESCRIPTION
A couple of improvements for auto playback. 
Thanks @davideberlein for the suggestions!

1. Emits `RoomEvent.AudioPlaybackStatusChanged` not only when tracks emit it, but also if `acquireAudioContext` fails 
2. Sets video elements to `muted` if there's no audio stream attached to it to make sure autoplay is working
3. in case there is an audio stream present, it will try to start playing. if it fails it sets the element to muted and thus makes sure that at least the video is playing.