### PR TITLE
Fix edgecase race condition between subsequent disconnect and connect calls

### DIFF
--- a/.changeset/weak-kings-move.md
+++ b/.changeset/weak-kings-move.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix race edgecase between subsequent disconnect and connect calls


### PR DESCRIPTION
Calling `disconnect` without awaiting and `connect` in quick succession could potentially lead to the disconnect call being signalled for the newly established connection in ultra-low latency environments. 
Fixed by making sure that potential ongoing disconnect attempts are resolved before trying to connect again.