### PR TITLE
Wait for dimensions to become available prior to publishing

### DIFF
--- a/.changeset/beige-houses-work.md
+++ b/.changeset/beige-houses-work.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Wait for dimensions to become available prior to publishing


### PR DESCRIPTION
Video dimensions are required for simulcast publishing to take place. When certain transformations are applied to the MediaStreamTrack, it could take a bit of time for getSettings() to return the correct dimensions.

Currently this will fallback to the old behavior. In future versions, we could make dimensions a requirement.