### PR TITLE
Add getDisplayMedia support check

### DIFF
--- a/.changeset/friendly-trainers-yawn.md
+++ b/.changeset/friendly-trainers-yawn.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Emit DeviceUnsupportedError when getDisplayMedia is not supported on a device

--- a/src/room/errors.ts
+++ b/src/room/errors.ts
@@ -25,6 +25,12 @@ export class ConnectionError extends LivekitError {
   }
 }
 
+export class DeviceUnsupportedError extends LivekitError {
+  constructor(message?: string) {
+    super(21, message ?? 'device is unsupported');
+  }
+}
+
 export class TrackInvalidError extends LivekitError {
   constructor(message?: string) {
     super(20, message ?? 'track is invalid');

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -15,7 +15,7 @@ import {
   TrackPublishedResponse,
   TrackUnpublishedResponse,
 } from '../../proto/livekit_rtc';
-import { TrackInvalidError, UnexpectedConnectionState } from '../errors';
+import { DeviceUnsupportedError, TrackInvalidError, UnexpectedConnectionState } from '../errors';
 import { EngineEvent, ParticipantEvent, TrackEvent } from '../events';
 import type RTCEngine from '../RTCEngine';
 import LocalAudioTrack from '../track/LocalAudioTrack';
@@ -389,6 +389,11 @@ export default class LocalParticipant extends Participant {
         };
       }
     }
+
+    if (navigator.mediaDevices.getDisplayMedia === undefined) {
+      throw new DeviceUnsupportedError('getDisplayMedia not supported');
+    }
+
     const stream: MediaStream = await navigator.mediaDevices.getDisplayMedia({
       audio: options.audio ?? false,
       video: videoConstraints,

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -1,5 +1,5 @@
 import DeviceManager from '../DeviceManager';
-import { TrackInvalidError } from '../errors';
+import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
 import { mediaTrackToLocalTrack } from '../participant/publishUtils';
 import { audioDefaults, videoDefaults } from '../defaults';
 import LocalAudioTrack from './LocalAudioTrack';
@@ -114,6 +114,11 @@ export async function createLocalScreenTracks(
       height: options.resolution.height,
     };
   }
+
+  if (navigator.mediaDevices.getDisplayMedia === undefined) {
+    throw new DeviceUnsupportedError('getDisplayMedia not supported');
+  }
+
   // typescript definition is missing getDisplayMedia: https://github.com/microsoft/TypeScript/issues/33232
   // @ts-ignore
   const stream: MediaStream = await navigator.mediaDevices.getDisplayMedia({


### PR DESCRIPTION
I noticed that on Android, the `getDisplayMedia` function is undefined. Therefore I added a more verbose error message.