### PR TITLE
Handle unknown signal messages from the server

### DIFF
--- a/.changeset/honest-bikes-know.md
+++ b/.changeset/honest-bikes-know.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fixed handling of unknown signal messages

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -495,9 +495,7 @@ export class SignalClient {
   private handleSignalResponse(res: SignalResponse) {
     const msg = res.message;
     if (msg == undefined) {
-      log.error('received unexpected message', {
-        message: msg,
-      });
+      log.debug('received unsupported message');
       return;
     }
     if (msg.$case === 'answer') {

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -493,7 +493,13 @@ export class SignalClient {
   }
 
   private handleSignalResponse(res: SignalResponse) {
-    const msg = res.message!;
+    const msg = res.message;
+    if (msg == undefined) {
+      log.error('received unexpected message', {
+        message: msg,
+      });
+      return;
+    }
     if (msg.$case === 'answer') {
       const sd = fromProtoSessionDescription(msg.answer);
       if (this.onAnswer) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -681,14 +681,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       return;
     }
 
-    log.debug(`${connection} disconnected`);
+    log.warn(`${connection} disconnected`);
     if (this.reconnectAttempts === 0) {
       // only reset start time on the first try
       this.reconnectStart = Date.now();
     }
 
     const disconnect = (duration: number) => {
-      log.info(
+      log.warn(
         `could not recover connection after ${this.reconnectAttempts} attempts, ${duration}ms. giving up`,
       );
       this.emit(EngineEvent.Disconnected);


### PR DESCRIPTION
When we switched to [using oneof](https://github.com/livekit/client-sdk-js/pull/379) in generated protobufs, it broke the ability to handle unknown signal messages from the server. This is due to the protobuf parser returning `undefined` for `message` field, versus a new value for `$case`.
