### PR TITLE
Provide more context to ConnectionError when connecting to a room

### DIFF
--- a/.changeset/mighty-boats-wonder.md
+++ b/.changeset/mighty-boats-wonder.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Provide more context to ConnectionError when connecting to a room

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -355,12 +355,16 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       } catch (err) {
         this.recreateEngine();
         this.handleDisconnect(this.options.stopLocalTrackOnUnpublish);
-        let errorMessage = '';
+        const resultingError = new ConnectionError(`could not establish signal connection`)
         if (err instanceof Error) {
-          errorMessage = err.message;
-          log.debug(`error trying to establish signal connection`, { error: err });
+          resultingError.message = `${resultingError.message}: ${err.message}`;
         }
-        reject(new ConnectionError(`could not establish signal connection: ${errorMessage}`));
+        if (err instanceof ConnectionError) {
+          resultingError.reason = err.reason;
+          resultingError.status = err.status;
+        }
+        log.debug(`error trying to establish signal connection`, { error: err });
+        reject(resultingError);
         return;
       }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -355,7 +355,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       } catch (err) {
         this.recreateEngine();
         this.handleDisconnect(this.options.stopLocalTrackOnUnpublish);
-        const resultingError = new ConnectionError(`could not establish signal connection`)
+        const resultingError = new ConnectionError(`could not establish signal connection`);
         if (err instanceof Error) {
           resultingError.message = `${resultingError.message}: ${err.message}`;
         }


### PR DESCRIPTION
When connection to the server fails (e.g. when token is invalid), the only option to recognise the problem is through parsing of `ConnectionError.message`. This pr aims to provide more context to `ConnectionError` by passing the context of original error.