### PR TITLE
Fix `LocalTrack.restart` mute handling

### DIFF
--- a/.changeset/sour-falcons-shop.md
+++ b/.changeset/sour-falcons-shop.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Sync muted state with `MediaStreamTrack.enabled` when calling `LocalTrack.restart`

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -193,6 +193,9 @@ export default abstract class LocalTrack extends Track {
 
     this._mediaStreamTrack = newTrack;
 
+    // sync muted state with the enabled state of the newly created stream
+    this._mediaStreamTrack.enabled = !this.isMuted;
+
     await this.resumeUpstream();
 
     this.attachedElements.forEach((el) => {


### PR DESCRIPTION
This PR is quite similar to #487, which originally was intended to fix the issue current PR is addressing: having `LocalTrack.isMuted` set to `true`, while having `MediaTrack.enabled` set to `true` as well.