### PR TITLE
Switch disconnect to the unload event instead of beforeunload

### DIFF
--- a/.changeset/spotty-horses-shave.md
+++ b/.changeset/spotty-horses-shave.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Switch disconnect to the unload event instead of beforeunload

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -392,7 +392,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         this.abortController?.signal.removeEventListener('abort', abortHandler);
         // also hook unload event
         if (isWeb()) {
-          window.addEventListener('beforeunload', this.onBeforeUnload);
+          window.addEventListener('unload', this.onUnload);
           navigator.mediaDevices?.addEventListener('devicechange', this.handleDeviceChange);
         }
         this.setAndEmitConnectionState(ConnectionState.Connected);
@@ -542,7 +542,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
   }
 
-  private onBeforeUnload = async () => {
+  private onUnload = async () => {
     await this.disconnect();
   };
 
@@ -837,7 +837,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       this.audioContext = undefined;
     }
     if (isWeb()) {
-      window.removeEventListener('beforeunload', this.onBeforeUnload);
+      window.removeEventListener('unload', this.onUnload);
       navigator.mediaDevices?.removeEventListener('devicechange', this.handleDeviceChange);
     }
     this.setAndEmitConnectionState(ConnectionState.Disconnected);


### PR DESCRIPTION
Because the room disconnect is called on the beforeunload event users aren't able to add their own beforeunload confirmation warning. This is because the user will be disconnected from the room even if they decide to stay on the page.

For example, when a recording is in progress in our application we want to warn a user before they leave to remind them to stop the recording.

This switches the room disconnect to the unload event so in our client code we are able to add the confirm navigation warning.

As far as I know there shouldn't be an issue with the disconnect happening on unload instead of beforeunload, but let me know.