### PR TITLE
Prevent concurrent setParameter call to avoid exception

### DIFF
--- a/.changeset/sour-clocks-juggle.md
+++ b/.changeset/sour-clocks-juggle.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Prevent concurrent RTCRtpSender.setParameter call to avoid exception

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -957,7 +957,7 @@ export default class LocalParticipant extends Participant {
         }
       }
     } else if (update.subscribedQualities.length > 0) {
-      pub.videoTrack?.setPublishingLayers(update.subscribedQualities);
+      await pub.videoTrack?.setPublishingLayers(update.subscribedQualities);
     }
   };
 


### PR DESCRIPTION
if multiple get/setParameter are called concurrently, certain timing of events could lead to the browser throwing an exception in `setParameter`, due to a missing `getParameter` call.