### PR TITLE
Disable red encoding by default for stereo track

### DIFF
--- a/.changeset/four-snails-rescue.md
+++ b/.changeset/four-snails-rescue.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Disable red by default for stereo track

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -439,7 +439,13 @@ export default class LocalParticipant extends Participant {
           `Opus DTX will be disabled for stereo tracks by default. Enable them explicitly to make it work.`,
         );
       }
+      if (options.red === undefined) {
+        log.info(
+          `Opus RED will be disabled for stereo tracks by default. Enable them explicitly to make it work.`,
+        );
+      }
       options.dtx ??= false;
+      options.red ??= false;
     }
     const opts: TrackPublishOptions = {
       ...this.roomOptions.publishDefaults,

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -28,8 +28,7 @@ export interface TrackPublishDefaults {
   audioBitrate?: number;
 
   /**
-   * dtx (Discontinuous Transmission of audio), defaults to true.
-   * If the audio track is stereo, need enable it explicitly.
+   * dtx (Discontinuous Transmission of audio), enabled by default for mono tracks.
    */
   dtx?: boolean;
 

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -33,8 +33,7 @@ export interface TrackPublishDefaults {
   dtx?: boolean;
 
   /**
-   * red (Redundant Audio Data), defaults to true
-   * If the audio track is stereo, need enable it explicitly.
+   * red (Redundant Audio Data), enabled by default for mono tracks.
    */
   red?: boolean;
 

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -28,12 +28,14 @@ export interface TrackPublishDefaults {
   audioBitrate?: number;
 
   /**
-   * dtx (Discontinuous Transmission of audio), defaults to true
+   * dtx (Discontinuous Transmission of audio), defaults to true.
+   * If the audio track is stereo, need enable it explicitly.
    */
   dtx?: boolean;
 
   /**
    * red (Redundant Audio Data), defaults to true
+   * If the audio track is stereo, need enable it explicitly.
    */
   red?: boolean;
 

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -234,9 +234,9 @@ export interface AudioPreset {
 const codecs = ['vp8', 'h264', 'av1'] as const;
 const backupCodecs = ['vp8', 'h264'] as const;
 
-export type VideoCodec = (typeof codecs)[number];
+export type VideoCodec = typeof codecs[number];
 
-export type BackupVideoCodec = (typeof backupCodecs)[number];
+export type BackupVideoCodec = typeof backupCodecs[number];
 
 export function isBackupCodec(codec: string): codec is BackupVideoCodec {
   return !!backupCodecs.find((backup) => backup === codec);

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -234,9 +234,9 @@ export interface AudioPreset {
 const codecs = ['vp8', 'h264', 'av1'] as const;
 const backupCodecs = ['vp8', 'h264'] as const;
 
-export type VideoCodec = typeof codecs[number];
+export type VideoCodec = (typeof codecs)[number];
 
-export type BackupVideoCodec = typeof backupCodecs[number];
+export type BackupVideoCodec = (typeof backupCodecs)[number];
 
 export function isBackupCodec(codec: string): codec is BackupVideoCodec {
   return !!backupCodecs.find((backup) => backup === codec);


### PR DESCRIPTION
As the stereo audio track has high bitrates(128kbps or more), we don't want to consume 3x bitrates for it by enabling red encoding by default because that would cause higher packet loss if the network is poor, so disable it. The user can enable it explicitly if required.