### PR TITLE
Track.streamState defaults to active

### DIFF
--- a/.changeset/shaggy-olives-move.md
+++ b/.changeset/shaggy-olives-move.md
@@ -2,4 +2,4 @@
 'livekit-client': patch
 ---
 
-Track.streamState defaults will default to active
+Track.streamState defaults to active

--- a/.changeset/shaggy-olives-move.md
+++ b/.changeset/shaggy-olives-move.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Track.streamState defaults will default to active

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -31,9 +31,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
   ) {
     super(mediaTrack, sid, Track.Kind.Video, receiver);
     this.adaptiveStreamSettings = adaptiveStreamSettings;
-    if (this.isAdaptiveStream) {
-      this.streamState = Track.StreamState.Paused;
-    }
   }
 
   get isAdaptiveStream(): boolean {

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -32,7 +32,8 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
   mediaStream?: MediaStream;
 
   /**
-   * indicates current state of stream
+   * indicates current state of stream, it'll indicate `paused` if the track
+   * has been paused by congestion controller
    */
   streamState: Track.StreamState = Track.StreamState.Active;
 


### PR DESCRIPTION
StreamState is used to communicate when congestion controller pauses.
It does not make sense to initialize this value to paused since in most
cases, congestion controller has not paused the track and we'd want it to
avoid flickering.