### PR TITLE
Always fire EngineEvent.Resuming

### DIFF
--- a/.changeset/large-readers-talk.md
+++ b/.changeset/large-readers-talk.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+internal getter connectedServerAddress is has been changed to an async function getConnectedServerAddress

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -112,8 +112,11 @@ const appActions = {
       .on(RoomEvent.DataReceived, handleData)
       .on(RoomEvent.Disconnected, handleRoomDisconnect)
       .on(RoomEvent.Reconnecting, () => appendLog('Reconnecting to room'))
-      .on(RoomEvent.Reconnected, () => {
-        appendLog('Successfully reconnected. server', room.engine.connectedServerAddress);
+      .on(RoomEvent.Reconnected, async () => {
+        appendLog(
+          'Successfully reconnected. server',
+          await room.engine.getConnectedServerAddress(),
+        );
       })
       .on(RoomEvent.LocalTrackPublished, (pub) => {
         const track = pub.track as LocalAudioTrack;
@@ -182,7 +185,7 @@ const appActions = {
       const elapsed = Date.now() - startTime;
       appendLog(
         `successfully connected to ${room.name} in ${Math.round(elapsed)}ms`,
-        room.engine.connectedServerAddress,
+        await room.engine.getConnectedServerAddress(),
       );
     } catch (error: any) {
       let message: any = error;

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -189,6 +189,8 @@ export default class PCTransport extends EventEmitter {
   }
 
   close() {
+    this.pc.onconnectionstatechange = null;
+    this.pc.oniceconnectionstatechange = null;
     this.pc.close();
   }
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -858,10 +858,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
 
     log.info(`resuming signal connection, attempt ${this.reconnectAttempts}`);
-    // do not emit for the first attempt, since ICE restart could happen frequently
-    if (this.reconnectAttempts !== 0) {
-      this.emit(EngineEvent.Resuming);
-    }
+    this.emit(EngineEvent.Resuming);
 
     try {
       const res = await this.client.reconnect(this.url, this.token, this.participantSid, reason);

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -896,7 +896,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     participant.tracks.forEach((publication) => {
       participant.unpublishTrack(publication.trackSid, true);
     });
-    this.emitWhenConnected(RoomEvent.ParticipantDisconnected, participant);
+    this.emit(RoomEvent.ParticipantDisconnected, participant);
   }
 
   // updates are sent only when there's a change to speaker ordering
@@ -1124,7 +1124,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         },
       )
       .on(ParticipantEvent.TrackUnpublished, (publication: RemoteTrackPublication) => {
-        this.emitWhenConnected(RoomEvent.TrackUnpublished, publication, participant);
+        this.emit(RoomEvent.TrackUnpublished, publication, participant);
       })
       .on(
         ParticipantEvent.TrackUnsubscribed,


### PR DESCRIPTION
Revert previous change in behavior (and premature optimization) of skipping resuming event. Doing so breaks migration