### PR TITLE
Defer publishing of tracks during reconnection

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Slack Community Chat
-    url: https://join.slack.com/t/livekit-users/shared_invite/zt-19nswkhip-4Y56hpIHM94EyWUpRH1GGQ
+    url: https://join.slack.com/t/livekit-users/shared_invite/zt-rrdy5abr-5pZ1wW8pXEkiQxBzFiXPUg
     about: Ask questions and discuss with other LiveKit users in real time.

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -758,8 +758,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     log.debug(`reconnected to server`, {
       region: joinResponse.serverRegion,
     });
-    this.setAndEmitConnectionState(ConnectionState.Connected);
-    this.emit(RoomEvent.Reconnected);
 
     // rehydrate participants
     if (joinResponse.participant) {
@@ -800,6 +798,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         }
       }),
     );
+    this.setAndEmitConnectionState(ConnectionState.Connected);
+    this.emit(RoomEvent.Reconnected);
   };
 
   private handleDisconnect(shouldStopTracks = true, reason?: DisconnectReason) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -131,7 +131,9 @@ export default class LocalParticipant extends Participant {
   }
 
   private handleReconnecting = () => {
-    this.reconnectFuture = new Future<void>();
+    if (!this.reconnectFuture) {
+      this.reconnectFuture = new Future<void>();
+    }
   };
 
   private handleReconnected = () => {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -498,9 +498,14 @@ export default class LocalParticipant extends Participant {
     }
     const publishPromise = this.publish(track, opts, options, isStereo);
     this.pendingPublishPromises.set(track, publishPromise);
-    const publication = await publishPromise;
-    this.pendingPublishPromises.delete(track);
-    return publication;
+    try {
+      const publication = await publishPromise;
+      return publication;
+    } catch (e) {
+      throw e;
+    } finally {
+      this.pendingPublishPromises.delete(track);
+    }
   }
 
   private async publish(


### PR DESCRIPTION
fixes #507

- defers publishing until engine has reconnected
- emits `Reconnected` event only once tracks have been republished
- keeps track of pending publications and prevents publishing the same `LocalTrack` twice

caveats: 
currently this only works when passing a `LocalTrack` instance and not when trying to publish a `MediastreamTrack` directly.