### PR TITLE
Only trigger AudioPlaybackFailed when it's `NotAllowed`

### DIFF
--- a/.changeset/ten-timers-exercise.md
+++ b/.changeset/ten-timers-exercise.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Only trigger AudioPlaybackFailed when error is NotAllowed

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
 import type { SignalClient } from '../../api/SignalClient';
+import log from '../../logger';
 import { TrackSource, TrackType } from '../../proto/livekit_models';
 import { StreamState as ProtoStreamState } from '../../proto/livekit_rtc';
 import { TrackEvent } from '../events';
@@ -132,7 +133,11 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
           this.emit(TrackEvent.AudioPlaybackStarted);
         })
         .catch((e) => {
-          this.emit(TrackEvent.AudioPlaybackFailed, e);
+          if (e.name === 'NotAllowedError') {
+            this.emit(TrackEvent.AudioPlaybackFailed, e);
+          } else {
+            log.warn('could not playback audio', e);
+          }
           // If audio playback isn't allowed make sure we still play back the video
           if (
             element &&


### PR DESCRIPTION
Other errors could be raised when playing back an audio track. For example: a user could attach to another track, aborting the current attempt.

In those cases, we do not want to fire AudioPlaybackFailed incorrectly.