### PR TITLE
option to enable/disable adaptiveStream for an element

### DIFF
--- a/.changeset/silent-zoos-run.md
+++ b/.changeset/silent-zoos-run.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+option to enable/disable adaptiveStream for an element

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -195,7 +195,25 @@ export default class RemoteVideoTrack extends RemoteTrack {
     return receiverStats;
   }
 
-  private stopObservingElement(element: HTMLMediaElement) {
+  /**
+   * Start observing an Element for changes.
+   * @param element
+   */
+  public startObservingElement(element: HTMLMediaElement) {
+    if (
+      this.adaptiveStreamSettings &&
+      this.elementInfos.find((info) => info.element === element) === undefined
+    ) {
+      const elementInfo = new HTMLElementInfo(element);
+      this.observeElementInfo(elementInfo);
+    }
+  }
+
+  /**
+   * Stop observing an Element for changes.
+   * @param element
+   */
+  public stopObservingElement(element: HTMLMediaElement) {
     const stopElementInfos = this.elementInfos.filter((info) => info.element === element);
     for (const info of stopElementInfos) {
       info.stopObserving();


### PR DESCRIPTION
By default adaptiveStream can be enable/disable using global variable. In certain case may need to disable/enable adaptive steam for single tracks. For example one video element need to put in PiP but because of adaptiveStream if user move to another tab or window then the stream will be pause. To prevent this I had made `stopObservingElement` public & another new function `startObservingElement` for triggering the element manually. 