### PR TITLE
Specify tsconfig rootDir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "rootDir": "./",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
From [the docs](https://www.typescriptlang.org/tsconfig#rootDir):
> Default: The longest common path of all non-declaration input files. If [composite](https://www.typescriptlang.org/tsconfig#composite) is set, the default is instead the directory containing the tsconfig.json file.

In this repo's case, the "the longest common path of all non-declaration input files" happens to be `./` so the correct behavior is occuring. However, when attempting to build this in alternative ways (we're linking it into a `node_modules` folder so that we can do local development), that changes and the build is no longer predictable.

This change just makes explicit what the expected/desired behavior is.