### PR TITLE
Return publication of Track.Source.Unknown in getTrack

### DIFF
--- a/.changeset/soft-bikes-lick.md
+++ b/.changeset/soft-bikes-lick.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Return publication of Track.Source.Unknown in getTrack

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -92,9 +92,6 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
    * @returns
    */
   getTrack(source: Track.Source): TrackPublication | undefined {
-    if (source === Track.Source.Unknown) {
-      return;
-    }
     for (const [, pub] of this.tracks) {
       if (pub.source === source) {
         return pub;


### PR DESCRIPTION
the JSdocs of `getTrack` state that it

> Finds the first track that matches the source filter

this PR fixes the behaviour for `Track.Source.Unknown`