### PR TITLE
Prewarm an audio element pool when connecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "async-await-queue": "^1.2.1",
+    "create-silent-audio": "^0.1.2",
     "events": "^3.3.0",
     "loglevel": "^1.8.0",
     "protobufjs": "^7.0.0",

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -17,12 +17,7 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
    * and blocks autoplay when the tab is in the background. maximize chances
    * by initializing some directly when the SDK initializes
    */
-  static audioElementPool: Array<HTMLAudioElement> = new Array<HTMLAudioElement>(8)
-    .fill(new Audio(), 0, 8)
-    .map((el) => {
-      el.autoplay = true;
-      return el;
-    });
+  static audioElementPool: Array<HTMLAudioElement> = [];
 
   kind: Track.Kind;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3416,6 +3416,11 @@ core-js-compat@^3.25.1:
   dependencies:
     browserslist "^4.21.4"
 
+create-silent-audio@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/create-silent-audio/-/create-silent-audio-0.1.2.tgz#c8632eb881fde1124e21a1e4d5cc560ed956292c"
+  integrity sha512-4DQm+AAc65KGaZGJDNeCBO2dCT/dHYwbUoNnBp4+N2O5JnyvIofIUrRZ8FjLEkTR+Sr8BeCYRnjOjGnszx2Zyw==
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"


### PR DESCRIPTION
This PR
- creates an audio element pool
- tries to play silent audio when connecting and triggers `audioPlaybackFailed` if that doesn't work
- adds playback of silent pool audio nodes to `startAudio`

potentially fixes https://github.com/livekit/client-sdk-js/issues/589, but there are some caveats: 
- user still needs to click `startAudio` when first connecting (also this will fire a lot more now)
- only works if users do not supply their own HTML element to the `attach` function, because we can only use prewarmed elements if we can choose which element it can be

