### PR TITLE
fix: emit mute status event for unsubscribed user

### DIFF
--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -208,7 +208,11 @@ export default class RemoteTrackPublication extends TrackPublication {
   updateInfo(info: TrackInfo) {
     super.updateInfo(info);
     this.metadataMuted = info.muted;
-    this.track?.setMuted(info.muted);
+    if (this.track) {
+      this.track.setMuted(info.muted);
+    } else {
+      this.emit(info.muted ? TrackEvent.Muted : TrackEvent.Unmuted);
+    }
   }
 
   private emitSubscriptionUpdateIfChanged(previousStatus: TrackPublication.SubscriptionStatus) {


### PR DESCRIPTION
Hi!

This PR changes some behavior about muted status event.

Before this change, event about muted status was not emitted if the track publication is not subscribed, despite of its internal muted status is changed.

I don't know if it is livekit's intended behavior. But in my use case I want to know the change of muted status even when user didn't subscribed the track.

This change will affect these events:

- `ParticipantEvent.Muted`
- `ParticipantEvent.Muted`
- `TrackEvent.Muted`
- `TrackEvent.Muted`
