### PR TITLE
Give up on reconnections if token is invalid

### DIFF
--- a/.changeset/plenty-cherries-invite.md
+++ b/.changeset/plenty-cherries-invite.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Give up on reconnections if token is invalid

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -234,7 +234,7 @@ export class SignalClient {
         if (!this.isConnected) {
           try {
             const resp = await fetch(`http${url.substring(2)}/validate${params}`);
-            if (!resp.ok) {
+            if (resp.status === 401) {
               const msg = await resp.text();
               reject(new ConnectionError(msg, ConnectionErrorReason.NotAllowed, resp.status));
             } else {

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -234,7 +234,7 @@ export class SignalClient {
         if (!this.isConnected) {
           try {
             const resp = await fetch(`http${url.substring(2)}/validate${params}`);
-            if (resp.status === 401) {
+            if (resp.status.toFixed(0).startsWith('4')) {
               const msg = await resp.text();
               reject(new ConnectionError(msg, ConnectionErrorReason.NotAllowed, resp.status));
             } else {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -837,6 +837,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
       joinResponse = await this.join(this.url, this.token, this.signalOpts);
     } catch (e) {
+      if (e instanceof ConnectionError && e.reason === ConnectionErrorReason.NotAllowed) {
+        throw new UnexpectedConnectionState('could not reconnect, token might have expired');
+      }
       throw new SignalReconnectError();
     }
 
@@ -876,6 +879,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       let message = '';
       if (e instanceof Error) {
         message = e.message;
+      }
+      if (e instanceof ConnectionError && e.reason === ConnectionErrorReason.NotAllowed) {
+        throw new UnexpectedConnectionState('could not reconnect, token might be expired');
       }
       throw new SignalReconnectError(message);
     }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -838,7 +838,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       joinResponse = await this.join(this.url, this.token, this.signalOpts);
     } catch (e) {
       if (e instanceof ConnectionError && e.reason === ConnectionErrorReason.NotAllowed) {
-        throw new UnexpectedConnectionState('could not reconnect, token might have expired');
+        throw new UnexpectedConnectionState('could not reconnect, token might be expired');
       }
       throw new SignalReconnectError();
     }


### PR DESCRIPTION
Reconnect attempts will now fail immediately in case the reason for reconnection failing was the user being unauthorized to join