### PR TITLE
Fix race condition with full reconnect sequence during server restart

### DIFF
--- a/.changeset/sixty-penguins-film.md
+++ b/.changeset/sixty-penguins-film.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+Fix race condition with full reconnect sequence during server restart

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -29,6 +29,9 @@ import {
   StreamStateUpdate,
   SubscriptionPermissionUpdate,
 } from '../proto/livekit_rtc';
+import DeviceManager from './DeviceManager';
+import RTCEngine from './RTCEngine';
+import { RegionUrlProvider } from './RegionUrlProvider';
 import {
   audioDefaults,
   publishDefaults,
@@ -36,14 +39,12 @@ import {
   roomOptionDefaults,
   videoDefaults,
 } from './defaults';
-import DeviceManager from './DeviceManager';
 import { ConnectionError, ConnectionErrorReason, UnsupportedServer } from './errors';
 import { EngineEvent, ParticipantEvent, RoomEvent, TrackEvent } from './events';
 import LocalParticipant from './participant/LocalParticipant';
 import type Participant from './participant/Participant';
 import type { ConnectionQuality } from './participant/Participant';
 import RemoteParticipant from './participant/RemoteParticipant';
-import RTCEngine from './RTCEngine';
 import LocalAudioTrack from './track/LocalAudioTrack';
 import LocalTrackPublication from './track/LocalTrackPublication';
 import LocalVideoTrack from './track/LocalVideoTrack';
@@ -55,16 +56,15 @@ import type { AdaptiveStreamSettings } from './track/types';
 import { getNewAudioContext } from './track/utils';
 import type { SimulationOptions } from './types';
 import {
-  createDummyVideoStreamTrack,
   Future,
+  Mutex,
+  createDummyVideoStreamTrack,
   getEmptyAudioStreamTrack,
   isCloud,
   isWeb,
-  Mutex,
   supportsSetSinkId,
   unpackStreamId,
 } from './utils';
-import { RegionUrlProvider } from './RegionUrlProvider';
 
 export enum ConnectionState {
   Disconnected = 'disconnected',

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -10,35 +10,35 @@ import {
   TrackPublishedResponse,
   TrackUnpublishedResponse,
 } from '../../proto/livekit_rtc';
+import type RTCEngine from '../RTCEngine';
 import { DeviceUnsupportedError, TrackInvalidError, UnexpectedConnectionState } from '../errors';
 import { EngineEvent, ParticipantEvent, TrackEvent } from '../events';
-import type RTCEngine from '../RTCEngine';
 import LocalAudioTrack from '../track/LocalAudioTrack';
 import LocalTrack from '../track/LocalTrack';
 import LocalTrackPublication from '../track/LocalTrackPublication';
 import LocalVideoTrack, { videoLayersFromEncodings } from '../track/LocalVideoTrack';
+import { Track } from '../track/Track';
 import {
   AudioCaptureOptions,
   BackupVideoCodec,
   CreateLocalTracksOptions,
-  isBackupCodec,
   ScreenShareCaptureOptions,
   ScreenSharePresets,
   TrackPublishOptions,
   VideoCaptureOptions,
+  isBackupCodec,
 } from '../track/options';
-import { Track } from '../track/Track';
 import { constraintsForOptions, mergeDefaultOptions } from '../track/utils';
 import type { DataPublishOptions } from '../types';
 import { Future, isFireFox, isSafari, isWeb, supportsAV1 } from '../utils';
 import Participant from './Participant';
 import { ParticipantTrackPermission, trackPermissionToProto } from './ParticipantTrackPermission';
+import RemoteParticipant from './RemoteParticipant';
 import {
   computeTrackBackupEncodings,
   computeVideoEncodings,
   mediaTrackToLocalTrack,
 } from './publishUtils';
-import RemoteParticipant from './RemoteParticipant';
 
 export default class LocalParticipant extends Participant {
   audioTracks: Map<string, LocalTrackPublication>;
@@ -961,13 +961,15 @@ export default class LocalParticipant extends Participant {
   }
 
   /** @internal */
-  updateInfo(info: ParticipantInfo) {
+  updateInfo(info: ParticipantInfo): boolean {
     if (info.sid !== this.sid) {
       // drop updates that specify a wrong sid.
       // the sid for local participant is only explicitly set on join and full reconnect
-      return;
+      return false;
     }
-    super.updateInfo(info);
+    if (!super.updateInfo(info)) {
+      return false;
+    }
 
     // reconcile track mute status.
     // if server's track mute status doesn't match actual, we'll have to update
@@ -986,6 +988,7 @@ export default class LocalParticipant extends Participant {
         }
       }
     });
+    return true;
   }
 
   private updateTrackSubscriptionPermissions = () => {

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -215,8 +215,10 @@ export default class RemoteParticipant extends Participant {
   }
 
   /** @internal */
-  updateInfo(info: ParticipantInfo) {
-    super.updateInfo(info);
+  updateInfo(info: ParticipantInfo): boolean {
+    if (!super.updateInfo(info)) {
+      return false;
+    }
 
     // we are getting a list of all available tracks, reconcile in here
     // and send out events for changes
@@ -277,6 +279,7 @@ export default class RemoteParticipant extends Participant {
     newTracks.forEach((publication) => {
       this.emit(ParticipantEvent.TrackPublished, publication);
     });
+    return true;
   }
 
   /** @internal */


### PR DESCRIPTION
When all participants are reconnecting at the same time, it creates an opportunity for participant updates included in JoinResponse to be applied after ParticipantUpdate events. This is due to await returning control to us when we are performing `await RTCEngine.join`

Checking ParticipantInfo version prior to updating would guarantee we do not wipe out any existing tracks that were received