### PR TITLE
Only set maxFramerate on encoding if defined

### DIFF
--- a/.changeset/shy-feet-happen.md
+++ b/.changeset/shy-feet-happen.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Only set maxFramerate on encoding if defined

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -309,13 +309,15 @@ function encodingsFromPresets(
     }
     const size = Math.min(width, height);
     const rid = videoRids[idx];
-    encodings.push({
+    const encoding: RTCRtpEncodingParameters = {
       rid,
       scaleResolutionDownBy: Math.max(1, size / Math.min(preset.width, preset.height)),
       maxBitrate: preset.encoding.maxBitrate,
-      /* @ts-ignore */
-      maxFramerate: preset.encoding.maxFramerate,
-    });
+    };
+    if (preset.encoding.maxFramerate) {
+      encoding.maxFramerate = preset.encoding.maxFramerate;
+    }
+    encodings.push(encoding);
   });
   return encodings;
 }


### PR DESCRIPTION
fixes firefox complaining about `max_framerate needs to be >= 0.0`. 
FF throws an error if `maxFramerate = undefined`. 