### PR TITLE
Handle connection state mismatch with periodic reconciliation

### DIFF
--- a/.changeset/gorgeous-lamps-smash.md
+++ b/.changeset/gorgeous-lamps-smash.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Handle connection state mismatch with periodic reconciliation

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1120,6 +1120,39 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     await this.ensureDataTransportConnected(kind, false);
   }
 
+  /* @internal */
+  verifyTransport(): boolean {
+    // primary connection
+    if (!this.primaryPC) {
+      return false;
+    }
+    if (
+      this.primaryPC.connectionState === 'closed' ||
+      this.primaryPC.connectionState === 'failed'
+    ) {
+      return false;
+    }
+
+    // also verify publisher connection if it's needed or different
+    if (this.hasPublished && this.subscriberPrimary) {
+      if (!this.publisher) {
+        return false;
+      }
+      if (
+        this.publisher.pc.connectionState === 'closed' ||
+        this.publisher.pc.connectionState === 'failed'
+      ) {
+        return false;
+      }
+    }
+
+    // ensure signal is connected
+    if (!this.client.ws || this.client.ws.readyState === WebSocket.CLOSED) {
+      return false;
+    }
+    return true;
+  }
+
   /** @internal */
   negotiate(): Promise<void> {
     // observe signal state

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -45,6 +45,7 @@ import LocalParticipant from './participant/LocalParticipant';
 import type Participant from './participant/Participant';
 import type { ConnectionQuality } from './participant/Participant';
 import RemoteParticipant from './participant/RemoteParticipant';
+import CriticalTimers from './timers';
 import LocalAudioTrack from './track/LocalAudioTrack';
 import LocalTrackPublication from './track/LocalTrackPublication';
 import LocalVideoTrack from './track/LocalVideoTrack';
@@ -72,6 +73,8 @@ export enum ConnectionState {
   Connected = 'connected',
   Reconnecting = 'reconnecting',
 }
+
+const connectionReconcileFrequency = 2 * 1000;
 
 /** @deprecated RoomState has been renamed to [[ConnectionState]] */
 export const RoomState = ConnectionState;
@@ -125,6 +128,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   private disconnectLock: Mutex;
 
   private cachedParticipantSids: Array<string>;
+
+  private connectionReconcileInterval?: ReturnType<typeof setInterval>;
 
   /**
    * Creates a new Room, the primary construct for a LiveKit session.
@@ -215,6 +220,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       .on(EngineEvent.ActiveSpeakersUpdate, this.handleActiveSpeakersUpdate)
       .on(EngineEvent.DataPacketReceived, this.handleDataPacket)
       .on(EngineEvent.Resuming, () => {
+        this.clearConnectionReconcile();
         if (this.setAndEmitConnectionState(ConnectionState.Reconnecting)) {
           this.emit(RoomEvent.Reconnecting);
         }
@@ -223,6 +229,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       .on(EngineEvent.Resumed, () => {
         this.setAndEmitConnectionState(ConnectionState.Connected);
         this.emit(RoomEvent.Reconnected);
+        this.registerConnectionReconcile();
         this.updateSubscriptions();
 
         // once reconnected, figure out if any participants connected during reconnect and emit events for it
@@ -488,6 +495,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
     this.setAndEmitConnectionState(ConnectionState.Connected);
     this.emit(RoomEvent.Connected);
+    this.registerConnectionReconcile();
   };
 
   /**
@@ -829,6 +837,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   }
 
   private handleRestarting = () => {
+    this.clearConnectionReconcile();
     // also unwind existing participants & existing subscriptions
     for (const p of this.participants.values()) {
       this.handleParticipantDisconnected(p.sid, p);
@@ -894,6 +903,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
     this.setAndEmitConnectionState(ConnectionState.Connected);
     this.emit(RoomEvent.Reconnected);
+    this.registerConnectionReconcile();
 
     // emit participant connected events after connection has been re-established
     this.participants.forEach((participant) => {
@@ -902,57 +912,61 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private handleDisconnect(shouldStopTracks = true, reason?: DisconnectReason) {
+    this.clearConnectionReconcile();
     if (this.state === ConnectionState.Disconnected) {
       return;
     }
 
-    this.participants.forEach((p) => {
-      p.tracks.forEach((pub) => {
-        p.unpublishTrack(pub.trackSid);
+    try {
+      this.participants.forEach((p) => {
+        p.tracks.forEach((pub) => {
+          p.unpublishTrack(pub.trackSid);
+        });
       });
-    });
 
-    this.localParticipant.tracks.forEach((pub) => {
-      if (pub.track) {
-        this.localParticipant.unpublishTrack(pub.track, shouldStopTracks);
+      this.localParticipant.tracks.forEach((pub) => {
+        if (pub.track) {
+          this.localParticipant.unpublishTrack(pub.track, shouldStopTracks);
+        }
+        if (shouldStopTracks) {
+          pub.track?.detach();
+          pub.track?.stop();
+        }
+      });
+
+      this.localParticipant
+        .off(ParticipantEvent.ParticipantMetadataChanged, this.onLocalParticipantMetadataChanged)
+        .off(ParticipantEvent.ParticipantNameChanged, this.onLocalParticipantNameChanged)
+        .off(ParticipantEvent.TrackMuted, this.onLocalTrackMuted)
+        .off(ParticipantEvent.TrackUnmuted, this.onLocalTrackUnmuted)
+        .off(ParticipantEvent.LocalTrackPublished, this.onLocalTrackPublished)
+        .off(ParticipantEvent.LocalTrackUnpublished, this.onLocalTrackUnpublished)
+        .off(ParticipantEvent.ConnectionQualityChanged, this.onLocalConnectionQualityChanged)
+        .off(ParticipantEvent.MediaDevicesError, this.onMediaDevicesError)
+        .off(
+          ParticipantEvent.ParticipantPermissionsChanged,
+          this.onLocalParticipantPermissionsChanged,
+        );
+
+      this.localParticipant.tracks.clear();
+      this.localParticipant.videoTracks.clear();
+      this.localParticipant.audioTracks.clear();
+
+      this.participants.clear();
+      this.activeSpeakers = [];
+      if (this.audioContext && typeof this.options.expWebAudioMix === 'boolean') {
+        this.audioContext.close();
+        this.audioContext = undefined;
       }
-      if (shouldStopTracks) {
-        pub.track?.detach();
-        pub.track?.stop();
+      if (isWeb()) {
+        window.removeEventListener('beforeunload', this.onPageLeave);
+        window.removeEventListener('pagehide', this.onPageLeave);
+        navigator.mediaDevices?.removeEventListener('devicechange', this.handleDeviceChange);
       }
-    });
-
-    this.localParticipant
-      .off(ParticipantEvent.ParticipantMetadataChanged, this.onLocalParticipantMetadataChanged)
-      .off(ParticipantEvent.ParticipantNameChanged, this.onLocalParticipantNameChanged)
-      .off(ParticipantEvent.TrackMuted, this.onLocalTrackMuted)
-      .off(ParticipantEvent.TrackUnmuted, this.onLocalTrackUnmuted)
-      .off(ParticipantEvent.LocalTrackPublished, this.onLocalTrackPublished)
-      .off(ParticipantEvent.LocalTrackUnpublished, this.onLocalTrackUnpublished)
-      .off(ParticipantEvent.ConnectionQualityChanged, this.onLocalConnectionQualityChanged)
-      .off(ParticipantEvent.MediaDevicesError, this.onMediaDevicesError)
-      .off(
-        ParticipantEvent.ParticipantPermissionsChanged,
-        this.onLocalParticipantPermissionsChanged,
-      );
-
-    this.localParticipant.tracks.clear();
-    this.localParticipant.videoTracks.clear();
-    this.localParticipant.audioTracks.clear();
-
-    this.participants.clear();
-    this.activeSpeakers = [];
-    if (this.audioContext && typeof this.options.expWebAudioMix === 'boolean') {
-      this.audioContext.close();
-      this.audioContext = undefined;
+    } finally {
+      this.setAndEmitConnectionState(ConnectionState.Disconnected);
+      this.emit(RoomEvent.Disconnected, reason);
     }
-    if (isWeb()) {
-      window.removeEventListener('beforeunload', this.onPageLeave);
-      window.removeEventListener('pagehide', this.onPageLeave);
-      navigator.mediaDevices?.removeEventListener('devicechange', this.handleDeviceChange);
-    }
-    this.setAndEmitConnectionState(ConnectionState.Disconnected);
-    this.emit(RoomEvent.Disconnected, reason);
   }
 
   private handleParticipantUpdates = (participantInfos: ParticipantInfo[]) => {
@@ -1338,6 +1352,37 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           pub.emitTrackUpdate();
         }
       }
+    }
+  }
+
+  private registerConnectionReconcile() {
+    this.clearConnectionReconcile();
+    let consecutiveFailures = 0;
+    this.connectionReconcileInterval = CriticalTimers.setInterval(() => {
+      if (
+        // ensure we didn't tear it down
+        !this.engine ||
+        // engine detected close, but Room missed it
+        this.engine.isClosed ||
+        // transports failed without notifying engine
+        !this.engine.verifyTransport()
+      ) {
+        consecutiveFailures++;
+        log.warn('detected connection state mismatch', { numFailures: consecutiveFailures });
+        if (consecutiveFailures >= 3)
+          this.handleDisconnect(
+            this.options.stopLocalTrackOnUnpublish,
+            DisconnectReason.UNKNOWN_REASON,
+          );
+      } else {
+        consecutiveFailures = 0;
+      }
+    }, connectionReconcileFrequency);
+  }
+
+  private clearConnectionReconcile() {
+    if (this.connectionReconcileInterval) {
+      CriticalTimers.clearInterval(this.connectionReconcileInterval);
     }
   }
 


### PR DESCRIPTION
It's possible for Room's connection state to get out of sync with the underlying transport. This is rare but could happen when the computer is going to sleep. For example, when the computer sleeps, PeerConnection would go straight to "closed" without firing the callbacks.

We have also seen rare conditions where RTCEngine went to close without our knowledge.

This PR adds a last line of defense to ensure Room's state is always correct.