### PR TITLE
Replace event emitter lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,11 @@
   },
   "dependencies": {
     "async-await-queue": "^1.2.1",
-    "events": "^3.3.0",
+    "eventemitter3": "^5.0.1",
     "loglevel": "^1.8.0",
     "protobufjs": "^7.0.0",
     "sdp-transform": "^2.14.1",
     "ts-debounce": "^4.0.0",
-    "typed-emitter": "^2.1.0",
     "ua-parser-js": "^1.0.2",
     "webrtc-adapter": "^8.1.1"
   },

--- a/src/connectionHelper/ConnectionCheck.ts
+++ b/src/connectionHelper/ConnectionCheck.ts
@@ -1,5 +1,4 @@
-import EventEmitter from 'events';
-import type TypedEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import { CheckInfo, CheckStatus, Checker, InstantiableCheck } from './checks/Checker';
 import { PublishAudioCheck } from './checks/publishAudio';
 import { PublishVideoCheck } from './checks/publishVideo';
@@ -10,7 +9,7 @@ import { WebSocketCheck } from './checks/websocket';
 
 export type { CheckInfo, CheckStatus };
 
-export class ConnectionCheck extends (EventEmitter as new () => TypedEmitter<ConnectionCheckCallbacks>) {
+export class ConnectionCheck extends EventEmitter<ConnectionCheckCallbacks> {
   token: string;
 
   url: string;

--- a/src/connectionHelper/checks/Checker.ts
+++ b/src/connectionHelper/checks/Checker.ts
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-import type TypedEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import type { RoomConnectOptions, RoomOptions } from '../../options';
 import type RTCEngine from '../../room/RTCEngine';
 import Room, { ConnectionState } from '../../room/Room';
@@ -30,7 +29,7 @@ export interface CheckerOptions {
   connectOptions?: RoomConnectOptions;
 }
 
-export abstract class Checker extends (EventEmitter as new () => TypedEmitter<CheckerCallbacks>) {
+export abstract class Checker extends EventEmitter<CheckerCallbacks> {
   protected url: string;
 
   protected token: string;

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import EventEmitter from 'eventemitter3';
 import { MediaDescription, parse, write } from 'sdp-transform';
 import { debounce } from 'ts-debounce';
 import log from '../logger';

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-import type TypedEventEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import { SignalClient, SignalOptions } from '../api/SignalClient';
 import log from '../logger';
 import type { InternalRoomOptions } from '../options';
@@ -64,7 +63,7 @@ enum PCState {
 }
 
 /** @internal */
-export default class RTCEngine extends (EventEmitter as new () => TypedEventEmitter<EngineEventCallbacks>) {
+export default class RTCEngine extends EventEmitter<EngineEventCallbacks> {
   publisher?: PCTransport;
 
   subscriber?: PCTransport;
@@ -1039,6 +1038,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       };
       this.once(EngineEvent.Restarted, onRestarted);
       this.once(EngineEvent.Disconnected, onDisconnected);
+      this.once(EngineEvent.Closing, onDisconnected);
     });
   };
 
@@ -1132,7 +1132,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.hasPublished = true;
 
       const handleClosed = () => {
-        log.debug('engine disconnected while negotiation was ongoing');
+        log.warn('engine disconnected while negotiation was ongoing');
         cleanup();
         resolve();
         return;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-import type TypedEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import { toProtoSessionDescription } from '../api/SignalClient';
 import log from '../logger';
 import type {
@@ -84,7 +83,7 @@ export const RoomState = ConnectionState;
  *
  * @noInheritDoc
  */
-class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) {
+class Room extends EventEmitter<RoomEventCallbacks> {
   state: ConnectionState = ConnectionState.Disconnected;
 
   /** map of sid: [[RemoteParticipant]] */
@@ -132,7 +131,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    */
   constructor(options?: RoomOptions) {
     super();
-    this.setMaxListeners(100);
     this.participants = new Map();
     this.cachedParticipantSids = [];
     this.identityToSid = new Map();
@@ -1351,9 +1349,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     return true;
   }
 
-  private emitWhenConnected<E extends keyof RoomEventCallbacks>(
-    event: E,
-    ...args: Parameters<RoomEventCallbacks[E]>
+  private emitWhenConnected<T extends EventEmitter.EventNames<RoomEventCallbacks>>(
+    event: T,
+    ...args: EventEmitter.EventArgs<RoomEventCallbacks, T>
   ): boolean {
     if (this.state === ConnectionState.Connected) {
       return this.emit(event, ...args);
@@ -1530,10 +1528,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   }
 
   // /** @internal */
-  emit<E extends keyof RoomEventCallbacks>(
-    event: E,
-    ...args: Parameters<RoomEventCallbacks[E]>
+  emit<T extends EventEmitter.EventNames<RoomEventCallbacks>>(
+    event: T,
+    ...args: EventEmitter.EventArgs<RoomEventCallbacks, T>
   ): boolean {
+    // emit<E extends keyof RoomEventCallbacks>(
+    //   event: E,
+    //   ...args: Parameters<RoomEventCallbacks[E]>
+    // ): boolean {
     // active speaker updates are too spammy
     if (event !== RoomEvent.ActiveSpeakersChanged) {
       log.debug(`room event ${event}`, { event, args });

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-import type TypedEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import log from '../../logger';
 import {
   DataPacket_Kind,
@@ -34,7 +33,7 @@ function qualityFromProto(q: ProtoQuality): ConnectionQuality {
   }
 }
 
-export default class Participant extends (EventEmitter as new () => TypedEmitter<ParticipantEventCallbacks>) {
+export default class Participant extends EventEmitter<ParticipantEventCallbacks> {
   protected participantInfo?: ParticipantInfo;
 
   audioTracks: Map<string, TrackPublication>;
@@ -71,7 +70,6 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   /** @internal */
   constructor(sid: string, identity: string, name?: string, metadata?: string) {
     super();
-    this.setMaxListeners(100);
     this.sid = sid;
     this.identity = identity;
     this.name = name;

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -1,3 +1,4 @@
+import type EventEmitter from 'eventemitter3';
 import type { SignalClient } from '../../api/SignalClient';
 import log from '../../logger';
 import type { ParticipantInfo } from '../../proto/livekit_models';
@@ -339,9 +340,9 @@ export default class RemoteParticipant extends Participant {
   }
 
   /** @internal */
-  emit<E extends keyof ParticipantEventCallbacks>(
-    event: E,
-    ...args: Parameters<ParticipantEventCallbacks[E]>
+  emit<T extends EventEmitter.EventNames<ParticipantEventCallbacks>>(
+    event: T,
+    ...args: EventEmitter.EventArgs<ParticipantEventCallbacks, T>
   ): boolean {
     log.trace('participant event', { participant: this.sid, event, args });
     return super.emit(event, ...args);

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-import type TypedEventEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import type { SignalClient } from '../../api/SignalClient';
 import log from '../../logger';
 import { TrackSource, TrackType } from '../../proto/livekit_models';
@@ -13,7 +12,7 @@ const BACKGROUND_REACTION_DELAY = 5000;
 // Safari tracks which audio elements have been "blessed" by the user.
 const recycledElements: Array<HTMLAudioElement> = [];
 
-export abstract class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEventCallbacks>) {
+export abstract class Track extends EventEmitter<TrackEventCallbacks> {
   kind: Track.Kind;
 
   attachedElements: HTMLMediaElement[] = [];
@@ -52,7 +51,6 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
 
   protected constructor(mediaTrack: MediaStreamTrack, kind: Track.Kind) {
     super();
-    this.setMaxListeners(100);
     this.kind = kind;
     this._mediaStreamTrack = mediaTrack;
     this._mediaStreamID = mediaTrack.id;

--- a/src/room/track/TrackPublication.ts
+++ b/src/room/track/TrackPublication.ts
@@ -1,5 +1,4 @@
-import { EventEmitter } from 'events';
-import type TypedEventEmitter from 'typed-emitter';
+import EventEmitter from 'eventemitter3';
 import log from '../../logger';
 import type { TrackInfo } from '../../proto/livekit_models';
 import type { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc';
@@ -11,7 +10,7 @@ import type RemoteTrack from './RemoteTrack';
 import RemoteVideoTrack from './RemoteVideoTrack';
 import { Track } from './Track';
 
-export class TrackPublication extends (EventEmitter as new () => TypedEventEmitter<PublicationEventCallbacks>) {
+export class TrackPublication extends EventEmitter<PublicationEventCallbacks> {
   kind: Track.Kind;
 
   trackName: string;
@@ -38,7 +37,6 @@ export class TrackPublication extends (EventEmitter as new () => TypedEventEmitt
 
   constructor(kind: Track.Kind, id: string, name: string) {
     super();
-    this.setMaxListeners(100);
     this.kind = kind;
     this.trackSid = id;
     this.trackName = name;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4123,10 +4123,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-events@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
-  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 execa@^5.0.0:
   version "5.1.1"
@@ -6991,13 +6991,6 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.5.2:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
-  integrity sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==
-  dependencies:
-    tslib "^2.1.0"
-
 safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -7594,11 +7587,6 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
 tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -7677,13 +7665,6 @@ typed-array-length@^1.0.4:
     call-bind "^1.0.2"
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
-
-typed-emitter@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/typed-emitter/-/typed-emitter-2.1.0.tgz#ca78e3d8ef1476f228f548d62e04e3d4d3fd77fb"
-  integrity sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==
-  optionalDependencies:
-    rxjs "^7.5.2"
 
 typedoc-plugin-no-inherit@1.4.0:
   version "1.4.0"


### PR DESCRIPTION
`events` hasn't had an update since 2021, this PR replaces it with `eventemitter3`