### PR TITLE
Change TS target to es2015

### DIFF
--- a/.changeset/orange-bobcats-tap.md
+++ b/.changeset/orange-bobcats-tap.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Change TS target to es2015

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,13 @@
 // @ts-check
-import typescript from 'rollup-plugin-typescript2';
-import commonjs from '@rollup/plugin-commonjs';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { babel } from '@rollup/plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
-import replace from 'rollup-plugin-re';
-import filesize from 'rollup-plugin-filesize';
 import del from 'rollup-plugin-delete';
-
+import filesize from 'rollup-plugin-filesize';
+import replace from 'rollup-plugin-re';
+import typescript from 'rollup-plugin-typescript2';
 import packageJson from './package.json';
 
 function kebabCaseToPascalCase(string = '') {
@@ -38,14 +37,15 @@ export default {
   plugins: [
     del({ targets: 'dist/*' }),
     nodeResolve({ browser: true, preferBuiltins: false }),
-    typescript({ tsconfig: './tsconfig.json' }),
-    commonjs(),
     json(),
+    commonjs(),
+    typescript({ tsconfig: './tsconfig.json' }),
     babel({
       babelHelpers: 'bundled',
       plugins: ['@babel/plugin-proposal-object-rest-spread'],
       presets: ['@babel/preset-env'],
       extensions: ['.js', '.ts', '.mjs'],
+      babelrc: false,
     }),
     replace({
       patterns: [

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -289,7 +289,7 @@ function ensureVideoDDExtensionForSVC(
     payloads?: string | undefined;
   } & MediaDescription,
 ) {
-  const codec = media.rtp.at(0)?.codec?.toLowerCase();
+  const codec = media.rtp[0]?.codec?.toLowerCase();
   if (!isSVCCodec(codec)) {
     return;
   }

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -153,7 +153,7 @@ export default class LocalVideoTrack extends LocalTrack {
           qualityLimitationResolutionChanges: v.qualityLimitationResolutionChanges,
         };
 
-        // locate the appropriate remote-inbound-rtp item
+        // locate the appropriate remote-inbound-rtp item
         const r = stats.get(v.remoteId);
         if (r) {
           vs.jitter = r.jitter;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "ES2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "rootDir": "./",
     "outDir": "dist",
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "ESNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "rootDir": "./",
     "outDir": "dist",


### PR DESCRIPTION
we had an `array.at` call in the codebase which tripped up a user when using react native. 
Even in browser environments `array.at` isn't well supported. 
I was (wrongly) under the impression that babel would transpile this away, but in order to do that we would have to add a core-js polyfill. 
So instead of adding explicit polyfills for this via core-js, I lowered the target for TS compilation to ES2015 (so that we don't think we can use more recent features that might actually need a polyfill) and removed the `.at` usage (TS compiler still didn't catch that one by itself).