### PR TITLE
Use default video dimensions when they are not available

### DIFF
--- a/.changeset/three-drinks-attack.md
+++ b/.changeset/three-drinks-attack.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Use default video dimensions when they are not available

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -17,7 +17,6 @@ import LocalTrack from '../track/LocalTrack';
 import LocalTrackPublication from '../track/LocalTrackPublication';
 import LocalVideoTrack, { videoLayersFromEncodings } from '../track/LocalVideoTrack';
 import { Track } from '../track/Track';
-import { ScreenSharePresets, isBackupCodec, isCodecEqual } from '../track/options';
 import type {
   AudioCaptureOptions,
   BackupVideoCodec,
@@ -26,12 +25,13 @@ import type {
   TrackPublishOptions,
   VideoCaptureOptions,
 } from '../track/options';
+import { ScreenSharePresets, VideoPresets, isBackupCodec, isCodecEqual } from '../track/options';
 import { constraintsForOptions, mergeDefaultOptions } from '../track/utils';
 import type { DataPublishOptions } from '../types';
 import { Future, isFireFox, isSVCCodec, isSafari, isWeb, supportsAV1, supportsVP9 } from '../utils';
 import Participant from './Participant';
-import { trackPermissionToProto } from './ParticipantTrackPermission';
 import type { ParticipantTrackPermission } from './ParticipantTrackPermission';
+import { trackPermissionToProto } from './ParticipantTrackPermission';
 import RemoteParticipant from './RemoteParticipant';
 import {
   computeTrackBackupEncodings,
@@ -608,8 +608,16 @@ export default class LocalParticipant extends Participant {
       try {
         dims = await track.waitForDimensions();
       } catch (e) {
+        // use defaults, it's quite painful for congestion control without simulcast
+        // so using default dims according to publish settings
+        const defaultRes =
+          this.roomOptions.videoCaptureDefaults?.resolution ?? VideoPresets.h720.resolution;
+        dims = {
+          width: defaultRes.width,
+          height: defaultRes.height,
+        };
         // log failure
-        log.error('could not determine track dimensions');
+        log.error('could not determine track dimensions, using defaults', dims);
       }
       // width and height should be defined for video
       req.width = dims.width;

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -12,7 +12,7 @@ import {
 import { Track, attachToElement, detachTrack } from './Track';
 import type { VideoCodec } from './options';
 
-const defaultDimensionsTimeout = 2 * 1000;
+const defaultDimensionsTimeout = 1000;
 
 export default abstract class LocalTrack extends Track {
   /** @internal */


### PR DESCRIPTION
When a custom MediaStreamTrack is provided, sometimes width and height are not available in `getSettings()`. In those cases we would fail to publish simulcast layers

Not having simulcast is detrimental to our ability to reduce a subscriber's bitrate in order to avoid congestion.