### PR TITLE
Use replaceTrack(null) for pauseUpstream

### DIFF
--- a/.changeset/clean-parents-drum.md
+++ b/.changeset/clean-parents-drum.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Use replaceTrack(null) for pauseUpstream

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -834,6 +834,13 @@ export default class LocalParticipant extends Participant {
     track.off(TrackEvent.UpstreamPaused, this.onTrackUpstreamPaused);
     track.off(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
 
+    // when pauseUpstream is used, the transceiver is stopped locally and will
+    // not be correctly removed, so we must mitigate it and replace it back to
+    // the original track, while keeping publisherMute to true
+    if (track.isUpstreamPaused && track.mediaStreamTrack) {
+      await track.replaceTrack(track.mediaStreamTrack);
+    }
+
     if (stopOnUnpublish === undefined) {
       stopOnUnpublish = this.roomOptions?.stopLocalTrackOnUnpublish ?? true;
     }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -834,11 +834,14 @@ export default class LocalParticipant extends Participant {
     track.off(TrackEvent.UpstreamPaused, this.onTrackUpstreamPaused);
     track.off(TrackEvent.UpstreamResumed, this.onTrackUpstreamResumed);
 
+    const trackSender = track.sender;
+    track.sender = undefined;
+
     // when pauseUpstream is used, the transceiver is stopped locally and will
     // not be correctly removed, so we must mitigate it and replace it back to
     // the original track, while keeping publisherMute to true
-    if (track.isUpstreamPaused && track.mediaStreamTrack) {
-      await track.replaceTrack(track.mediaStreamTrack);
+    if (track.isUpstreamPaused && track.mediaStreamTrack && trackSender) {
+      await trackSender.replaceTrack(track.mediaStreamTrack);
     }
 
     if (stopOnUnpublish === undefined) {
@@ -849,8 +852,6 @@ export default class LocalParticipant extends Participant {
     }
 
     let negotiationNeeded = false;
-    const trackSender = track.sender;
-    track.sender = undefined;
     if (
       this.engine.publisher &&
       this.engine.publisher.pc.connectionState !== 'closed' &&

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -248,10 +248,12 @@ export default abstract class LocalTrack extends Track {
     this.emit(TrackEvent.Ended, this);
   };
 
-  // pauses publishing to the server without disabling the local MediaStreamTrack
-  // this is used to display a user's own video locally while pausing publishing to
-  // the server.
-  // this API is unsupported on Safari < 12 due to a bug
+  /**
+   * pauses publishing to the server without disabling the local MediaStreamTrack
+   * this is used to display a user's own video locally while pausing publishing to
+   * the server.
+   * this API is unsupported on Safari < 12 due to a bug
+   **/
   async pauseUpstream() {
     const unlock = await this.pauseUpstreamLock.lock();
     try {

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -1,14 +1,9 @@
 import log from '../../logger';
+import { getBrowser } from '../../utils/browserParser';
 import DeviceManager from '../DeviceManager';
-import { TrackInvalidError } from '../errors';
+import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
 import { TrackEvent } from '../events';
-import {
-  Mutex,
-  getEmptyAudioStreamTrack,
-  getEmptyVideoStreamTrack,
-  isMobile,
-  sleep,
-} from '../utils';
+import { Mutex, compareVersions, isMobile, sleep } from '../utils';
 import { Track, attachToElement, detachTrack } from './Track';
 import type { VideoCodec } from './options';
 
@@ -253,6 +248,10 @@ export default abstract class LocalTrack extends Track {
     this.emit(TrackEvent.Ended, this);
   };
 
+  // pauses publishing to the server without disabling the local MediaStreamTrack
+  // this is used to display a user's own video locally while pausing publishing to
+  // the server.
+  // this API is unsupported on Safari < 12 due to a bug
   async pauseUpstream() {
     const unlock = await this.pauseUpstreamLock.lock();
     try {
@@ -266,9 +265,12 @@ export default abstract class LocalTrack extends Track {
 
       this._isUpstreamPaused = true;
       this.emit(TrackEvent.UpstreamPaused, this);
-      const emptyTrack =
-        this.kind === Track.Kind.Audio ? getEmptyAudioStreamTrack() : getEmptyVideoStreamTrack();
-      await this.sender.replaceTrack(emptyTrack);
+      const browser = getBrowser();
+      if (browser?.name === 'Safari' && compareVersions(browser.version, '12.0') < 0) {
+        // https://bugs.webkit.org/show_bug.cgi?id=184911
+        throw new DeviceUnsupportedError('pauseUpstream is not supported on Safari < 12.');
+      }
+      await this.sender.replaceTrack(null);
     } finally {
       unlock();
     }


### PR DESCRIPTION
Previously we were creating placeholder tracks, that is not compatible
with react-native.

This is the second attempt. With the previous attempt in #712, paused tracks were not unpublished correctly.