### PR TITLE
Do not fire Disconnected event if engine had been replaced.

### DIFF
--- a/.changeset/thirty-carrots-add.md
+++ b/.changeset/thirty-carrots-add.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Do not fire Disconnected event if engine had been replaced

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
-import { SignalClient } from '../api/SignalClient';
 import type { SignalOptions } from '../api/SignalClient';
+import { SignalClient } from '../api/SignalClient';
 import log from '../logger';
 import type { InternalRoomOptions } from '../options';
 import {
@@ -447,6 +447,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     };
 
     this.client.onLeave = (leave?: LeaveRequest) => {
+      if (this._isClosed) {
+        return;
+      }
       if (leave?.canReconnect) {
         this.fullReconnectOnNext = true;
         this.primaryPC = undefined;


### PR DESCRIPTION
If a new connection attempt comes in while a reconnect is in-progress, The previous websocket connection might not be fully closed. The server would close the old websocket connection with `reason: duplicate_identity`. Due to certain timing, this could cause us to incorrectly fire a `Disconnected` event.

The right behavior is to ignore the leave message, instead of processing it.