### PR TITLE
Always catch reconnectFuture rejections

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -143,8 +143,11 @@ export default class LocalParticipant extends Participant {
   };
 
   private handleDisconnected = () => {
-    this.reconnectFuture?.reject?.('Got disconnected during publishing attempt');
-    this.reconnectFuture = undefined;
+    if (this.reconnectFuture) {
+      this.reconnectFuture.promise.catch((e) => log.warn(e));
+      this.reconnectFuture?.reject?.('Got disconnected during reconnection attempt');
+      this.reconnectFuture = undefined;
+    }
   };
 
   /**


### PR DESCRIPTION
Fixes [#721](https://github.com/livekit/client-sdk-js/issues/721)

I'm not entirely sure that this is the right approach to handling the disconnect-during reconnect-during track publish. Maybe adding a method like RTCEnging.waitForPCConnected that returns promise that resolves when engine is connected? Anyway, I did as @lukasIO suggested, tested in my own project, and the fix seem to do the trick.