### PR TITLE
Always add codec info to AddTrackRequest

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -647,6 +647,16 @@ export default class LocalParticipant extends Participant {
               enableSimulcastLayers: true,
             },
           ];
+        } else if (opts.videoCodec) {
+          // pass codec info to sfu so it can prefer codec for the client which doesn't support
+          // setCodecPreferences
+          req.simulcastCodecs = [
+            {
+              codec: opts.videoCodec,
+              cid: track.mediaStreamTrack.id,
+              enableSimulcastLayers: opts.simulcast ?? false,
+            },
+          ];
         }
       }
 


### PR DESCRIPTION
Add codec info to AddTrackRequest so the sfu can prefer codec for client which don't support setCodecPreferences. Previously, we only add codec info for the publication that have both videoCodec and backup Codec settled.

@lukasIO The subscriptionFailure e2e can't work for firefox as it actually publishes a vp8 codec.