### PR TITLE
Svc compatibility for browsers

### DIFF
--- a/.changeset/gorgeous-toys-provide.md
+++ b/.changeset/gorgeous-toys-provide.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix svc encodings for safari and chrome before 113

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -666,7 +666,12 @@ export default class LocalParticipant extends Participant {
         dims.height,
         opts,
       );
-      req.layers = videoLayersFromEncodings(req.width, req.height, encodings, isSVCCodec(opts.videoCodec));
+      req.layers = videoLayersFromEncodings(
+        req.width,
+        req.height,
+        encodings,
+        isSVCCodec(opts.videoCodec),
+      );
     } else if (track.kind === Track.Kind.Audio) {
       encodings = [
         {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -666,7 +666,7 @@ export default class LocalParticipant extends Participant {
         dims.height,
         opts,
       );
-      req.layers = videoLayersFromEncodings(req.width, req.height, encodings);
+      req.layers = videoLayersFromEncodings(req.width, req.height, encodings, isSVCCodec(opts.videoCodec));
     } else if (track.kind === Track.Kind.Audio) {
       encodings = [
         {

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -133,17 +133,13 @@ export function computeVideoEncodings(
     for (let i = 0; i < sm.spatial; i += 1) {
       encodings.push({
         rid: videoRids[2 - i],
-        active: false,
         maxBitrate: videoEncoding.maxBitrate / 3 ** i,
         /* @ts-ignore */
         maxFramerate: original.encoding.maxFramerate,
-        /* @ts-ignore */
-        // scalabilityMode: scalabilityMode,
       });
     }
     /* @ts-ignore */
     encodings[0].scalabilityMode = scalabilityMode;
-    encodings[0].active = true;
     log.debug('encodings', encodings);
     return encodings;
   }

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -138,8 +138,8 @@ export function computeVideoEncodings(
         /* @ts-ignore */
         maxFramerate: original.encoding.maxFramerate,
         /* @ts-ignore */
-        // scalabilityMode: scalabilityMode, 
-      })
+        // scalabilityMode: scalabilityMode,
+      });
     }
     /* @ts-ignore */
     encodings[0].scalabilityMode = scalabilityMode;

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -123,27 +123,29 @@ export function computeVideoEncodings(
   if (scalabilityMode && isSVCCodec(videoCodec)) {
     log.debug(`using svc with scalabilityMode ${scalabilityMode}`);
 
+    const sm = new ScalabilityMode(scalabilityMode);
+
     const encodings: RTCRtpEncodingParameters[] = [];
 
-    // svc use first encoding as the original, so we sort encoding from high to low
-    switch (scalabilityMode) {
-      case 'L3T3':
-      case 'L3T3_KEY':
-        encodings.push({
-          rid: videoRids[2],
-          maxBitrate: videoEncoding.maxBitrate,
-          /* @ts-ignore */
-          maxFramerate: original.encoding.maxFramerate,
-          /* @ts-ignore */
-          scalabilityMode: scalabilityMode,
-        });
-        log.debug('encodings', encodings);
-        return encodings;
-
-      default:
-        // TODO : support other scalability modes
-        throw new Error(`unsupported scalabilityMode: ${scalabilityMode}`);
+    if (sm.spatial > 3) {
+      throw new Error(`unsupported scalabilityMode: ${scalabilityMode}`);
     }
+    for (let i = 0; i < sm.spatial; i += 1) {
+      encodings.push({
+        rid: videoRids[2 - i],
+        active: false,
+        maxBitrate: videoEncoding.maxBitrate / 3 ** i,
+        /* @ts-ignore */
+        maxFramerate: original.encoding.maxFramerate,
+        /* @ts-ignore */
+        // scalabilityMode: scalabilityMode, 
+      })
+    }
+    /* @ts-ignore */
+    encodings[0].scalabilityMode = scalabilityMode;
+    encodings[0].active = true;
+    log.debug('encodings', encodings);
+    return encodings;
   }
 
   if (!useSimulcast) {

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -351,6 +351,10 @@ async function setPublishingLayersForSender(
 
     let hasChanged = false;
 
+    /* disable closable spatial layer as it has video blur / frozen issue with current server / client
+    1. chrome 113: when switching to up layer with scalability Mode change, it will generate a 
+          low resolution frame and recover very quickly, but noticable
+    2. livekit sfu: additional pli request cause video frozen for a few frames, also noticable */
     const closableSpatial = false;
     /* @ts-ignore */
     if (closableSpatial && encodings[0].scalabilityMode) {
@@ -373,10 +377,7 @@ async function setPublishingLayersForSender(
       } else if (!encoding.active /* || mode.spatial !== maxQuality + 1*/) {
         hasChanged = true;
         encoding.active = true;
-        /* disable closable spatial layer as it has video blur/frozen issue with current server/client
-          1. chrome 113: when switching to up layer with scalability Mode change, it will generate a 
-          low resolution frame and recover very quickly, but noticable
-          2. livekit sfu: additional pli request cause video frozen for a few frames, also noticable
+        /*
         @ts-ignore
         const originalMode = new ScalabilityMode(senderEncodings[0].scalabilityMode)
         mode.spatial = maxQuality + 1;

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -351,8 +351,9 @@ async function setPublishingLayersForSender(
 
     let hasChanged = false;
 
+    const closableSpatial = false;
     /* @ts-ignore */
-    if (encodings.length === 1 && encodings[0].scalabilityMode) {
+    if (closableSpatial && encodings[0].scalabilityMode) {
       // svc dynacast encodings
       const encoding = encodings[0];
       /* @ts-ignore */
@@ -456,6 +457,7 @@ export function videoLayersFromEncodings(
   width: number,
   height: number,
   encodings?: RTCRtpEncodingParameters[],
+  svc?: boolean,
 ): VideoLayer[] {
   // default to a single layer, HQ
   if (!encodings) {
@@ -470,8 +472,7 @@ export function videoLayersFromEncodings(
     ];
   }
 
-  /* @ts-ignore */
-  if (encodings.length === 1 && encodings[0].scalabilityMode) {
+  if (svc) {
     // svc layers
     /* @ts-ignore */
     const sm = new ScalabilityMode(encodings[0].scalabilityMode);


### PR DESCRIPTION
Fix svc encodings for chrome old version and safari. Firefox can't publish simulcast or svc of vp9, and the resolution is very low when publishing non-simulcast vp9, but it can works well as subscriber when decode & render chrome&safari's vp9 track.