### PR TITLE
Increase default adaptiveStream pixelDensity on high-density screens

### DIFF
--- a/src/room/track/types.ts
+++ b/src/room/track/types.ts
@@ -8,7 +8,8 @@ export type VideoTrack = RemoteVideoTrack | LocalVideoTrack;
 
 export type AdaptiveStreamSettings = {
   /**
-   * Set a custom pixel density, defaults to 1
+   * Set a custom pixel density. Defaults to 2 for high density screens (3+) or
+   * 1 otherwise.
    * When streaming videos on a ultra high definition screen this setting
    * let's you account for the devicePixelRatio of those screens.
    * Set it to `screen` to use the actual pixel density of the screen


### PR DESCRIPTION
Mobile devices typically use high density screens (2.5-3+). On these platforms, using default CSS dimensions tends to produce less than ideal streaming quality when using adaptiveStream defaults.
