### PR TITLE
Fix non-appearing remote participant's video in Firefox after entering into call after long idle

### DIFF
--- a/.changeset/real-spoons-grow.md
+++ b/.changeset/real-spoons-grow.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix non-appearing remote participant's video in Firefox after long idle

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -5,7 +5,7 @@ import log from '../../logger';
 import { TrackSource, TrackType } from '../../proto/livekit_models';
 import { StreamState as ProtoStreamState } from '../../proto/livekit_rtc';
 import { TrackEvent } from '../events';
-import { isFireFox, isSafari, isWeb } from '../utils';
+import { isSafari, isWeb } from '../utils';
 
 const BACKGROUND_REACTION_DELAY = 5000;
 
@@ -303,9 +303,7 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
   // avoid flicker
   if (element.srcObject !== mediaStream) {
     element.srcObject = mediaStream;
-    if ((isSafari() || isFireFox()) && element instanceof HTMLVideoElement) {
-      // Firefox also has a timing issue where video doesn't actually get attached unless
-      // performed out-of-band
+    if (isSafari() && element instanceof HTMLVideoElement) {
       // Safari 15 has a bug where in certain layouts, video element renders
       // black until the page is resized or other changes take place.
       // Resetting the src triggers it to render.


### PR DESCRIPTION
Hello!

I experienced very nasty bug for long time:

Using Firefox open my website. Livekit exists in the webpack bundle, but it loads only when user enters into a video call.

Leave a tab opened for roughly 3 hours. (1 hour isn't enough). While waiting you can switch on other tab.

Then, after 3 hours, I start a video call from that tab(previously in "idle") and any other browser on any other device.

In Firefox it won't show the video from other participant, but audio will work (after turning on the microphone).

I don't know why this bug appears only after so long time. I tried to reduce the "appearance time" by "Unload" thru `about:processes` https://support.mozilla.org/en-US/kb/task-manager-tabs-or-extensions-are-slowing-firefox. but actually it didn't help me to "speedup" the appearance of the bug

One day I updated onto client-sdk-js v1.9.6 and noticed that this bug disappeared.

After some time I upgraded client-sdk-js again, onto v1.9.7 and bug appeared again.

I compared https://github.com/livekit/client-sdk-js/compare/v1.9.6...v1.9.7 versions and noticed change in `getBrowser()` function - seems in 1.9.6 the line

`userAgent === undefined` throws an error and it was fixed in 1.9.7. 

I supposed that the error in `getBrowser()` function introduced in 1.9.6 broke some codepath and it eventually eliminated my bug.

I opened "Call hierarchy" in my IntelliJ IDEA, and found the most probably place of source of my bug.
![Screenshot from 2023-06-11 22-39-01](https://github.com/livekit/client-sdk-js/assets/3160384/ba9e82e6-b382-4cf9-a840-e2320bc35f9a)
I found this code ^.

I made an experiment - so, having assumption that error in `isFireFox()` function breaks that codepath and fixes my bug - I just removed `isFireFox()` call from this condition.

Then (after deploying it on server) I left my Firefox tab again for more 3 hours idle, and the bug disappeared. I checked it twice, and it works in both attempts.

So, if you want to validate my patch - you can 

a) `npm install livekit-client@v1.9.7` - the bug presents

b) `npm install livekit-client@v1.9.6` - the bug doesn't present

c) `npm install git://github.com/nkonev/client-sdk-js#fix-non-appearing-video-after-a-long-idle_release` - it is my patched version, the bug doesn't present

I have no any piece of information why this code was added for Firefox, but I didn't notice any problems with my patched client-sdk-js version (where `isFireFox()` was removed from the condition). I think today we don't need it for the modern Firefox versions (I use 112.0.1, but the bug existed somewhere from the last summer, when I migrated from ion-sfu and ion-sdk-js onto livekit stack)