### PR TITLE
Add camera facing mode detection

### DIFF
--- a/.changeset/small-tools-shout.md
+++ b/.changeset/small-tools-shout.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Add helper function to detect camera `facingMode`.

--- a/src/room/track/utils.test.ts
+++ b/src/room/track/utils.test.ts
@@ -110,8 +110,30 @@ describe('constraintsForOptions', () => {
 });
 
 describe('Test facingMode detection', () => {
-  it('OBS virtual camera should be detected.', () => {
-    const facingMode = facingModeFromDeviceLabel('OBS Virtual Camera');
-    expect(facingMode).toEqual('environment');
+  test('OBS virtual camera should be detected.', () => {
+    const result = facingModeFromDeviceLabel('OBS Virtual Camera');
+    expect(result?.facingMode).toEqual('environment');
+    expect(result?.confidence).toEqual('medium');
+  });
+
+  test.each([
+    ['Peter’s iPhone Camera', { facingMode: 'environment', confidence: 'medium' }],
+    ['iPhone de Théo Camera', { facingMode: 'environment', confidence: 'medium' }],
+  ])(
+    'Device labels that contain "iphone" should return facingMode "environment".',
+    (label, expected) => {
+      const result = facingModeFromDeviceLabel(label);
+      expect(result?.facingMode).toEqual(expected.facingMode);
+      expect(result?.confidence).toEqual(expected.confidence);
+    },
+  );
+
+  test.each([
+    ['Peter’s iPad Camera', { facingMode: 'environment', confidence: 'medium' }],
+    ['iPad de Théo Camera', { facingMode: 'environment', confidence: 'medium' }],
+  ])('Device label that contain "ipad" should detect.', (label, expected) => {
+    const result = facingModeFromDeviceLabel(label);
+    expect(result?.facingMode).toEqual(expected.facingMode);
+    expect(result?.confidence).toEqual(expected.confidence);
   });
 });

--- a/src/room/track/utils.test.ts
+++ b/src/room/track/utils.test.ts
@@ -110,10 +110,6 @@ describe('constraintsForOptions', () => {
 });
 
 describe('Test facingMode detection', () => {
-  it('Known labels should return the expected facingMode.', () => {
-    const facingMode = facingModeFromDeviceLabel("Peter's iPhone Camera");
-    expect(facingMode).toEqual('environment');
-  });
   it('OBS virtual camera should be detected.', () => {
     const facingMode = facingModeFromDeviceLabel('OBS Virtual Camera');
     expect(facingMode).toEqual('environment');

--- a/src/room/track/utils.test.ts
+++ b/src/room/track/utils.test.ts
@@ -1,5 +1,5 @@
 import { AudioCaptureOptions, VideoCaptureOptions, VideoPresets } from './options';
-import { constraintsForOptions, mergeDefaultOptions } from './utils';
+import { constraintsForOptions, facingModeFromDeviceLabel, mergeDefaultOptions } from './utils';
 
 describe('mergeDefaultOptions', () => {
   const audioDefaults: AudioCaptureOptions = {
@@ -106,5 +106,16 @@ describe('constraintsForOptions', () => {
     expect(videoOpts.height).toEqual(VideoPresets.h720.resolution.height);
     expect(videoOpts.frameRate).toEqual(VideoPresets.h720.resolution.frameRate);
     expect(videoOpts.aspectRatio).toEqual(VideoPresets.h720.resolution.aspectRatio);
+  });
+});
+
+describe('Test facingMode detection', () => {
+  it('Known labels should return the expected facingMode.', () => {
+    const facingMode = facingModeFromDeviceLabel("Peter's iPhone Camera");
+    expect(facingMode).toEqual('environment');
+  });
+  it('OBS virtual camera should be detected.', () => {
+    const facingMode = facingModeFromDeviceLabel('OBS Virtual Camera');
+    expect(facingMode).toEqual('environment');
   });
 });

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -163,13 +163,15 @@ export function facingModeFromLocalTrack(
 }
 
 const knownDeviceLabels = new Map<string, FacingMode>([['obs virtual camera', 'environment']]);
-const knownDeviceLabelEndings = new Map<string, FacingMode>([['iphone camera', 'environment']]);
+const knownDeviceLabelEndings = new Map<string, FacingMode>([
+  ['s iphone camera', 'environment'], // `<name>'s iPhone Camera` | Rear-facing iPhone camera used as web cam.
+]);
 /**
  * Attempt to analyze the device label to determine the facing mode.
  *
  * @experimental
  */
-function facingModeFromDeviceLabel(deviceLabel: string): FacingMode | undefined {
+export function facingModeFromDeviceLabel(deviceLabel: string): FacingMode | undefined {
   const label = deviceLabel.trim().toLowerCase();
   // Empty string is a valid device label but we can't infer anything from it.
   if (label === '') {
@@ -182,11 +184,10 @@ function facingModeFromDeviceLabel(deviceLabel: string): FacingMode | undefined 
   }
 
   // Try to match the endings of known device names.
-  knownDeviceLabelEndings.forEach((facingMode, labelEnding) => {
-    if (label.endsWith(labelEnding)) {
-      return facingMode;
-    }
-  });
-
-  // TODO Attempt to analyze the device label to determine the facing mode
+  const endingMatch = Array.from(knownDeviceLabelEndings.entries()).find(([labelEnding]) =>
+    label.endsWith(labelEnding.toLowerCase()),
+  );
+  if (endingMatch) {
+    return endingMatch[1];
+  }
 }

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -116,15 +116,13 @@ export function getNewAudioContext(): AudioContext | void {
 }
 
 type FacingMode = NonNullable<VideoCaptureOptions['facingMode']>;
+type FacingModeFromLocalTrackOptions = {
+  defaultFacingMode?: FacingMode;
+};
 type FacingModeFromLocalTrackReturnValue = {
   facingMode: FacingMode;
   confidence: 'high' | 'medium' | 'low';
 };
-
-function isFacingModeValue(item: string): item is FacingMode {
-  const allowedValues: FacingMode[] = ['user', 'environment', 'left', 'right'];
-  return item === undefined || allowedValues.includes(item as FacingMode);
-}
 
 /**
  * Try to analyze the local MediaStreamTrack or device label to determine the facing mode of a device.
@@ -136,10 +134,14 @@ function isFacingModeValue(item: string): item is FacingMode {
  */
 export function facingModeFromLocalTrack(
   localTrack: LocalTrack | MediaStreamTrack,
+  options: FacingModeFromLocalTrackOptions = {},
 ): FacingModeFromLocalTrackReturnValue {
   const track = localTrack instanceof LocalTrack ? localTrack.mediaStreamTrack : localTrack;
   const trackSettings = track.getSettings();
-  let result: FacingModeFromLocalTrackReturnValue = { facingMode: 'user', confidence: 'low' };
+  let result: FacingModeFromLocalTrackReturnValue = {
+    facingMode: options.defaultFacingMode ?? 'user',
+    confidence: 'low',
+  };
 
   // 1. Try to get facingMode from track settings.
   if ('facingMode' in trackSettings) {
@@ -190,4 +192,9 @@ export function facingModeFromDeviceLabel(deviceLabel: string): FacingMode | und
   if (endingMatch) {
     return endingMatch[1];
   }
+}
+
+function isFacingModeValue(item: string): item is FacingMode {
+  const allowedValues: FacingMode[] = ['user', 'environment', 'left', 'right'];
+  return item === undefined || allowedValues.includes(item as FacingMode);
 }

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -117,19 +117,33 @@ export function getNewAudioContext(): AudioContext | void {
 
 type FacingMode = NonNullable<VideoCaptureOptions['facingMode']>;
 type FacingModeFromLocalTrackOptions = {
+  /**
+   * If no facing mode can be determined, this value will be used.
+   * @defaultValue 'user'
+   */
   defaultFacingMode?: FacingMode;
 };
 type FacingModeFromLocalTrackReturnValue = {
+  /**
+   * The (probable) facingMode of the track.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode | MDN docs on facingMode}
+   */
   facingMode: FacingMode;
+  /**
+   * The confidence that the returned facingMode is correct.
+   */
   confidence: 'high' | 'medium' | 'low';
 };
 
 /**
- * Try to analyze the local MediaStreamTrack or device label to determine the facing mode of a device.
- * There is no accurate and common property supported by all browsers to detect whether a video track is originated from a user- or environment-facing camera device.
- * For this reason, we use the `facingMode` property when available, but will fall back on a string-based analysis of the device label to determine the facing mode.
+ * Try to analyze the local track to determine the facing mode of a track.
  *
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode | MDN docs on facingMode}
+ * @remarks
+ * There is no property supported by all browsers to detect whether a video track originated from a user- or environment-facing camera device.
+ * For this reason, we use the `facingMode` property when available, but will fall back on a string-based analysis of the device label to determine the facing mode.
+ * If both methods fail, the default facing mode will be used.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/facingMode | MDN docs on facingMode}
  * @experimental
  */
 export function facingModeFromLocalTrack(

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -165,9 +165,6 @@ export function facingModeFromLocalTrack(
 }
 
 const knownDeviceLabels = new Map<string, FacingMode>([['obs virtual camera', 'environment']]);
-const knownDeviceLabelEndings = new Map<string, FacingMode>([
-  ['s iphone camera', 'environment'], // `<name>'s iPhone Camera` | Rear-facing iPhone camera used as web cam.
-]);
 /**
  * Attempt to analyze the device label to determine the facing mode.
  *
@@ -183,14 +180,6 @@ export function facingModeFromDeviceLabel(deviceLabel: string): FacingMode | und
   // Can we match against widely known device labels.
   if (knownDeviceLabels.has(label)) {
     return knownDeviceLabels.get(label);
-  }
-
-  // Try to match the endings of known device names.
-  const endingMatch = Array.from(knownDeviceLabelEndings.entries()).find(([labelEnding]) =>
-    label.endsWith(labelEnding.toLowerCase()),
-  );
-  if (endingMatch) {
-    return endingMatch[1];
   }
 }
 


### PR DESCRIPTION
The goal of this PR is to add a unified way to get the facing mode of local camera tracks. Because the `facingMode` property is not available on all browsers, we have to do some extra work to increase the changes to infer the facing mode. 
This is WIP and open for suggestions.

## Approach
Currently we use a 2-step approach to determine the `facingMode`. 
1. Whenever it is available, use the `facingMode` property to get and return the correct facing mode.
2. If the facingMode property is not available, try to parse the device label string for known names or fractions like "backward facing" or something like that.

### Confidence Level
Since this aproche has the possibility to fail, we should return a value indicating how confident we are about the returned result. The first thing that came to mind was `high`, `medium` and `low`. Results from step 1. have a `high` confidence level and should skip step 2. altogether. Results from step 2 could then return an appropriate confidence level.

> Note: If the label detection approach is feasible, we could think of a separate package where we could update and maintain a list of regex/device labels that can also be used by other projects. If anyone knows of an existing list of device names that we could use, that would be great.