### PR TITLE
When restarting a local track only replace a track after track processor initializes

### DIFF
--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -280,7 +280,7 @@ export default abstract class LocalTrack extends Track {
     }
   }
 
-  protected handleEnded = () => {
+  private handleEnded = () => {
     if (this.isInBackground) {
       this.reacquireTrack = true;
     }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -280,7 +280,7 @@ export default abstract class LocalTrack extends Track {
     }
   }
 
-  private handleEnded = () => {
+  protected handleEnded = () => {
     if (this.isInBackground) {
       this.reacquireTrack = true;
     }

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -6,9 +6,8 @@ import { computeBitrate, monitorFrequency } from '../stats';
 import type { VideoSenderStats } from '../stats';
 import { Mutex, isFireFox, isMobile, isWeb, unwrapConstraint } from '../utils';
 import LocalTrack from './LocalTrack';
-import { Track, attachToElement, detachTrack } from './Track';
+import { Track } from './Track';
 import type { VideoCaptureOptions, VideoCodec } from './options';
-import type { TrackProcessor } from './processor/types';
 import { constraintsForOptions } from './utils';
 
 export class SimulcastTrackInfo {
@@ -211,76 +210,6 @@ export default class LocalVideoTrack extends LocalTrack {
       }
     }
     await this.restart(constraints);
-  }
-
-  async switch(options: {
-    facingMode: 'user' | 'environment';
-    trackProcessor?: TrackProcessor<Track.Kind>;
-  }) {
-    this.constraints = { facingMode: options.facingMode };
-
-    const streamConstraints: MediaStreamConstraints = {
-      audio: false,
-      video: this.constraints,
-    };
-
-    // detach first to avoid black video elements after stopping the track
-    this.attachedElements.forEach((el) => {
-      detachTrack(this.mediaStreamTrack, el);
-    });
-
-    // stop the processor
-    this.processor?.processedTrack?.stop();
-    await this.processor?.destroy();
-    this.processor = undefined;
-    this.processorElement?.remove();
-    this.processorElement = undefined;
-
-    // these steps are duplicated from setMediaStreamTrack because we must stop
-    // the previous tracks before new tracks can be acquired
-    this._mediaStreamTrack.removeEventListener('ended', this.handleEnded);
-    // on Safari, the old audio track must be stopped before attempting to acquire
-    // the new track, otherwise the new track will stop with
-    // 'A MediaStreamTrack ended due to a capture failure`
-    this._mediaStreamTrack.stop();
-
-    // create new track
-    const mediaStream = await navigator.mediaDevices.getUserMedia(streamConstraints);
-    this._mediaStreamTrack = mediaStream.getTracks()[0];
-    this._mediaStreamTrack.addEventListener('ended', this.handleEnded);
-    log.debug('re-acquired MediaStreamTrack');
-
-    // init processor on the new track
-    if (options.trackProcessor) {
-      this.processor = options.trackProcessor;
-      if (this.isSettingUpProcessor) {
-        return;
-      }
-      this.isSettingUpProcessor = true;
-
-      this.processorElement = this.processorElement ?? document.createElement(Track.Kind.Video);
-      this.processorElement.muted = true;
-      this.processorElement.play().catch((e) => log.error(e));
-
-      const processorOptions = {
-        kind: this.kind,
-        track: this._mediaStreamTrack,
-        element: this.processorElement,
-      };
-
-      await this.processor.init(processorOptions);
-      if (this.processor.processedTrack) {
-        for (const el of this.attachedElements) {
-          if (el !== this.processorElement) {
-            attachToElement(this.processor.processedTrack, el);
-          }
-        }
-        await this.sender?.replaceTrack(this.processor.processedTrack);
-      }
-      this.isSettingUpProcessor = false;
-    }
-
-    return this;
   }
 
   addSimulcastTrack(codec: VideoCodec, encodings?: RTCRtpEncodingParameters[]): SimulcastTrackInfo {

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -8,6 +8,7 @@ import { Mutex, isFireFox, isMobile, isWeb, unwrapConstraint } from '../utils';
 import LocalTrack from './LocalTrack';
 import { Track } from './Track';
 import type { VideoCaptureOptions, VideoCodec } from './options';
+import type { TrackProcessor } from './processor/types';
 import { constraintsForOptions } from './utils';
 
 export class SimulcastTrackInfo {
@@ -201,7 +202,7 @@ export default class LocalVideoTrack extends LocalTrack {
     );
   }
 
-  async restartTrack(options?: VideoCaptureOptions) {
+  async restartTrack(options?: VideoCaptureOptions, processor?: TrackProcessor<typeof this.kind>) {
     let constraints: MediaTrackConstraints | undefined;
     if (options) {
       const streamConstraints = constraintsForOptions({ video: options });
@@ -209,7 +210,7 @@ export default class LocalVideoTrack extends LocalTrack {
         constraints = streamConstraints.video;
       }
     }
-    await this.restart(constraints);
+    await this.restart(constraints, processor);
   }
 
   addSimulcastTrack(codec: VideoCodec, encodings?: RTCRtpEncodingParameters[]): SimulcastTrackInfo {


### PR DESCRIPTION
Hello @davidzhao @lukasIO 
I created this to handle this specific use case:
Switching from environment to user camera with background replacement applied. 

Currently the only way to achieve that is to call `setProcessor` and then `restart` but it causes multiple calls to `replaceTrack` which in turn produces flickering picture (previous track visible for a moment, then the new track, then the new track with processor applied).

It would be also nice to pass a track processor directly to `restart` call. Currently when I want to restart a track with the new processor I have to call `setProcessor` first which will initialize and run on the current track (I'm transmitting a track with a processor which purpose is to be run only on the new track not the current). Then I call `restart` which leads to the second initialization of the processor on the new track.

I though of simply adding it as a second paramter but it potentially could break the API. What do you think? 