### PR TITLE
Use JSdocs instead of warning for mediastreamtrack access

### DIFF
--- a/.changeset/friendly-grapes-thank.md
+++ b/.changeset/friendly-grapes-thank.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Use JSdocs instead of warning for mediastreamtrack access

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -23,8 +23,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
 
   private lastDimensions?: Track.Dimensions;
 
-  private isObserved: boolean = false;
-
   constructor(
     mediaTrack: MediaStreamTrack,
     sid: string,
@@ -104,7 +102,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
       // the tab comes into focus for the first time.
       this.debouncedHandleResize();
       this.updateVisibility();
-      this.isObserved = true;
     } else {
       log.warn('visibility resize observer not triggered');
     }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -39,12 +39,10 @@ export default class RemoteVideoTrack extends RemoteTrack {
     return this.adaptiveStreamSettings !== undefined;
   }
 
+  /**
+   * Note: When using adaptiveStream, you need to use remoteVideoTrack.attach() to add the track to a HTMLVideoElement, otherwise your video tracks might never start
+   */
   get mediaStreamTrack() {
-    if (this.isAdaptiveStream && !this.isObserved) {
-      log.warn(
-        'When using adaptiveStream, you need to use remoteVideoTrack.attach() to add the track to a HTMLVideoElement, otherwise your video tracks might never start',
-      );
-    }
     return this._mediaStreamTrack;
   }
 


### PR DESCRIPTION
closes #744 
Previously we would log a warning when `track.mediaStreamTrack` got accessed _before_ an `attach` call has been made and adaptiveStream was enabled.

In order to keep the track processors API tidy, we have to call `attachToElement` with `this.mediaStreamTrack` which automatically determines whether the track is either the processed one or the original mediaStreamTrack. This would in turn log a warning whenever that attach call is happening, as the track is in fact not yet attached when that happens.

The easiest solution seems to be to remove the warning and make it a js doc comment instead. 
Alternatives to this PR would be:
- make the logic in `attachToElement` dependent on the `processedTrack` directly instead of using the `mediaStreamTrack` getter
- figure out via stack trace if the access to the `mediaStreamTrack` getter happened from within the library or from outside and only log the warning if it came from outside

