### PR TITLE
Fix replaceTrack sync issue

### DIFF
--- a/.changeset/blue-poets-repair.md
+++ b/.changeset/blue-poets-repair.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix missing await for async setMediaStreamTrack calls

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -182,7 +182,7 @@ export default abstract class LocalTrack extends Track {
     }
 
     log.debug('replace MediaStreamTrack');
-    this.setMediaStreamTrack(track);
+    await this.setMediaStreamTrack(track);
     // this must be synced *after* setting mediaStreamTrack above, since it relies
     // on the previous state in order to cleanup
     this.providedByUser = userProvidedTrack;
@@ -227,7 +227,7 @@ export default abstract class LocalTrack extends Track {
     newTrack.addEventListener('ended', this.handleEnded);
     log.debug('re-acquired MediaStreamTrack');
 
-    this.setMediaStreamTrack(newTrack);
+    await this.setMediaStreamTrack(newTrack);
     this.constraints = constraints;
     if (this.processor) {
       const processor = this.processor;


### PR DESCRIPTION
Hey, is there a reason why there's no await in front of the `this.setMediaStreamTrack(track);` ?

I was facing the following issue :

```
await videoTrack.track.restartTrack({ resolution })
console.log(videoTrack.track.dimensions) => undefined
```

which is solved with the await
