### PR TITLE
Only set priority on first layer for Safari and Chrome

### DIFF
--- a/.changeset/wild-news-teach.md
+++ b/.changeset/wild-news-teach.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Only set priority on Firefox

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -118,6 +118,7 @@ export function computeVideoEncodings(
     height,
     videoEncoding.maxBitrate,
     videoEncoding.maxFramerate,
+    videoEncoding.priority,
   );
 
   if (scalabilityMode && isSVCCodec(videoCodec)) {
@@ -311,7 +312,8 @@ function encodingsFromPresets(
     if (preset.encoding.maxFramerate) {
       encoding.maxFramerate = preset.encoding.maxFramerate;
     }
-    if (preset.encoding.priority && isFireFox()) {
+    const canSetPriority = isFireFox() || idx === 0;
+    if (preset.encoding.priority && canSetPriority) {
       encoding.priority = preset.encoding.priority;
       encoding.networkPriority = preset.encoding.priority;
     }

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -10,7 +10,7 @@ import type {
   VideoCodec,
   VideoEncoding,
 } from '../track/options';
-import { getReactNativeOs, isReactNative, isSVCCodec } from '../utils';
+import { getReactNativeOs, isFireFox, isReactNative, isSVCCodec } from '../utils';
 
 /** @internal */
 export function mediaTrackToLocalTrack(
@@ -311,7 +311,7 @@ function encodingsFromPresets(
     if (preset.encoding.maxFramerate) {
       encoding.maxFramerate = preset.encoding.maxFramerate;
     }
-    if (preset.encoding.priority) {
+    if (preset.encoding.priority && isFireFox()) {
       encoding.priority = preset.encoding.priority;
       encoding.networkPriority = preset.encoding.priority;
     }


### PR DESCRIPTION
the priority settings throw an exception on Chrome and Safari, if a layer other then the first one sets priority parameters.