### PR TITLE
Apply user provided bitrate to maxaveragebitrates for firefox

### DIFF
--- a/.changeset/lucky-cooks-fly.md
+++ b/.changeset/lucky-cooks-fly.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Apply user setting bitrate to maxaveragebitrates for firefox

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -732,6 +732,13 @@ export default class LocalParticipant extends Participant {
 
     if (encodings) {
       if (isFireFox() && track.kind === Track.Kind.Audio) {
+        /* Refer to RFC https://datatracker.ietf.org/doc/html/rfc7587#section-6.1, 
+           livekit-server uses maxaveragebitrate=510000in the answer sdp to permit client to
+           publish high quality audio track. But firefox always uses this value as the actual 
+           bitrates, causing the audio bitrates to rise to 510Kbps in any stereo case unexpectedly.
+           So the client need to modify maxaverragebitrates in answer sdp to user provided value to 
+           fix the issue.
+         */
         let trackTransceiver: RTCRtpTransceiver | undefined = undefined;
         for (const transceiver of this.engine.publisher.pc.getTransceivers()) {
           if (transceiver.sender === track.sender) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -426,7 +426,6 @@ export default class LocalParticipant extends Participant {
       throw new DeviceUnsupportedError('getDisplayMedia not supported');
     }
 
-    console.log('audio options', options.audio);
     const stream: MediaStream = await navigator.mediaDevices.getDisplayMedia({
       audio: options.audio ?? false,
       video: videoConstraints,
@@ -741,18 +740,18 @@ export default class LocalParticipant extends Participant {
           }
         }
         if (trackTransceiver) {
-          this.engine.publisher.setTrackCodecBitrate(
-            trackTransceiver,
-            'opus',
-            encodings[0]?.maxBitrate ? encodings[0].maxBitrate / 1000 : 0,
-          );
+          this.engine.publisher.setTrackCodecBitrate({
+            transceiver: trackTransceiver,
+            codec: 'opus',
+            maxbr: encodings[0]?.maxBitrate ? encodings[0].maxBitrate / 1000 : 0,
+          });
         }
       } else if (track.codec && isSVCCodec(track.codec) && encodings[0]?.maxBitrate) {
-        this.engine.publisher.setTrackCodecBitrate(
-          req.cid,
-          track.codec,
-          encodings[0].maxBitrate / 1000,
-        );
+        this.engine.publisher.setTrackCodecBitrate({
+          cid: req.cid,
+          codec: track.codec,
+          maxbr: encodings[0].maxBitrate / 1000,
+        });
       }
     }
 


### PR DESCRIPTION
Refer to RFC https://datatracker.ietf.org/doc/html/rfc7587#section-6.1, livekit-server uses `maxaveragebitrate=510000`in the answer sdp to permit client to publish high quality audio track. But firefox always uses this value as the actual bitrates, causing the audio bitrates to rise to 510Kbps in any stereo case unexpectedly. This pr  modify `maxaverragebitrates` in answer sdp to user provided value to fix the issue.

>    maxaveragebitrate:  specifies the maximum average receive bitrate of
      a session in bits per second (bit/s).  The actual value of the
      bitrate can vary, as it is dependent on the characteristics of the
      media in a packet

