### PR TITLE
More granularity to getDevices

### DIFF
--- a/src/room/DeviceManager.ts
+++ b/src/room/DeviceManager.ts
@@ -3,6 +3,10 @@ import { isSafari } from './utils';
 
 const defaultId = 'default';
 
+export interface PermittedDevices {
+  audioDeviceId?: string;
+  videoDeviceId?: string;
+}
 export default class DeviceManager {
   private static instance?: DeviceManager;
 
@@ -15,12 +19,13 @@ export default class DeviceManager {
     return this.instance;
   }
 
-  static userMediaPromiseMap: Map<MediaDeviceKind, Promise<MediaStream>> = new Map();
+  static userMediaPromiseMap: Map<string, Promise<MediaStream>> = new Map();
 
   async getDevices(
     kind?: MediaDeviceKind,
+    mediaConstraints?: MediaStreamConstraints,
     requestPermissions: boolean = true,
-  ): Promise<MediaDeviceInfo[]> {
+  ): Promise<[MediaDeviceInfo[], PermittedDevices]> {
     if (DeviceManager.userMediaPromiseMap?.size > 0) {
       log.debug('awaiting getUserMedia promise');
       try {
@@ -33,13 +38,25 @@ export default class DeviceManager {
         log.warn('error waiting for media permissons');
       }
     }
+    console.log('userMediaDevice promises resolved');
     let devices = await navigator.mediaDevices.enumerateDevices();
+    // On firefox the user is given the option to choose which device they want to grant usage permission
+    // selectedDevices stores this so the user choice is accessible
+    let permittedDevices: PermittedDevices = {};
+
+    // For backwards compatibility we set mediaConsraints based on requestPremissions
+    if (!mediaConstraints && requestPermissions) {
+      mediaConstraints = {
+        video: kind !== 'audioinput' && kind !== 'audiooutput',
+        audio: kind !== 'videoinput',
+      };
+    }
 
     if (
-      requestPermissions &&
-      kind &&
+      mediaConstraints &&
+      (mediaConstraints.audio || mediaConstraints.video) &&
       // for safari we need to skip this check, as otherwise it will re-acquire user media and fail on iOS https://bugs.webkit.org/show_bug.cgi?id=179363
-      (!DeviceManager.userMediaPromiseMap.get(kind) || !isSafari())
+      (!DeviceManager.userMediaPromiseMap.get(JSON.stringify(mediaConstraints)) || !isSafari())
     ) {
       const isDummyDeviceOrEmpty =
         devices.length === 0 ||
@@ -50,13 +67,21 @@ export default class DeviceManager {
         });
 
       if (isDummyDeviceOrEmpty) {
-        const permissionsToAcquire = {
-          video: kind !== 'audioinput' && kind !== 'audiooutput',
-          audio: kind !== 'videoinput',
-        };
-        const stream = await navigator.mediaDevices.getUserMedia(permissionsToAcquire);
+        console.log('DeviceManager getUserMedia', mediaConstraints);
+        const streamPromise = navigator.mediaDevices.getUserMedia(mediaConstraints);
+        DeviceManager.userMediaPromiseMap.set(JSON.stringify(mediaConstraints), streamPromise);
+        const stream = await streamPromise;
         devices = await navigator.mediaDevices.enumerateDevices();
+
         stream.getTracks().forEach((track) => {
+          // Determin which devices the browser actually ended up using
+          const deviceId = track.getSettings().deviceId;
+          if (track.kind == 'audio') {
+            permittedDevices.audioDeviceId = deviceId;
+          } else if (track.kind == 'video') {
+            permittedDevices.videoDeviceId = deviceId;
+          }
+          // and stop the tracks (They were only started to enforce the permission prompt.)
           track.stop();
         });
       }
@@ -65,7 +90,7 @@ export default class DeviceManager {
       devices = devices.filter((device) => device.kind === kind);
     }
 
-    return devices;
+    return [devices, permittedDevices];
   }
 
   async normalizeDeviceId(
@@ -79,7 +104,7 @@ export default class DeviceManager {
 
     // resolve actual device id if it's 'default': Chrome returns it when no
     // device has been chosen
-    const devices = await this.getDevices(kind);
+    const [devices] = await this.getDevices(kind);
 
     const device = devices.find((d) => d.groupId === groupId && d.deviceId !== defaultId);
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -31,7 +31,7 @@ import {
   SubscriptionPermissionUpdate,
   SubscriptionResponse,
 } from '../proto/livekit_rtc';
-import DeviceManager from './DeviceManager';
+import DeviceManager, { PermittedDevices } from './DeviceManager';
 import RTCEngine from './RTCEngine';
 import { RegionUrlProvider } from './RegionUrlProvider';
 import {
@@ -281,15 +281,22 @@ class Room extends EventEmitter<RoomEventCallbacks> {
    * getLocalDevices abstracts navigator.mediaDevices.enumerateDevices.
    * In particular, it handles Chrome's unique behavior of creating `default`
    * devices. When encountered, it'll be removed from the list of devices.
+   * Additionally this gives the option to request permissions to devices (also for multiple device types at the same time)
    * The actual default device will be placed at top.
-   * @param kind
-   * @returns a list of available local devices
+   * @param kind if undefined all kinds of local devices will be returned. If mediaConstraints is set, the user will be prompted with a permission request
+   * @param mediaConstraints setting media constraints will prompt the user with the defined device permissions
+   * @param requestPermissions for backwards compatibilty this can be set instead of mediaConstraints. The user will be prompted with the permissions defined with kind.
+   * @returns the list of available local devices and the permitted devices
+   * (permittedDevices will only contain id's if mediaConstraints is set,
+   * be aware, that the permittedDevice id's are not necassarly identlical to the ones set in mediaConstraints.
+   * In some browsers the user is given the option to select a device in the permission prompt)
    */
   static getLocalDevices(
     kind?: MediaDeviceKind,
-    requestPermissions: boolean = true,
-  ): Promise<MediaDeviceInfo[]> {
-    return DeviceManager.getInstance().getDevices(kind, requestPermissions);
+    mediaConstraints?: MediaStreamConstraints,
+    requestPermissions?: boolean,
+  ): Promise<[MediaDeviceInfo[], PermittedDevices]> {
+    return DeviceManager.getInstance().getDevices(kind, mediaConstraints, requestPermissions);
   }
 
   /**

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -124,10 +124,11 @@ export default abstract class LocalTrack extends Track {
     if (this.sender) {
       await this.sender.replaceTrack(newTrack);
     }
+    const previousMuteState = this._mediaStreamTrack.muted;
     this._mediaStreamTrack = newTrack;
     if (newTrack) {
       // sync muted state with the enabled state of the newly provided track
-      this._mediaStreamTrack.enabled = !this.isMuted;
+      this._mediaStreamTrack.enabled = !previousMuteState;
       // when a valid track is replace, we'd want to start producing
       await this.resumeUpstream();
       this.attachedElements.forEach((el) => {


### PR DESCRIPTION
Add the capability to ask for specific devices during the permission request that is caused by `getUserMedia` in `getDevices`.
Additionally this returns the devices the user has selected in the browser permission prompt.

Signed-off-by: Timo K <toger5@hotmail.de>