### PR TITLE
Emit activeDeviceChanged when publishing local track

### DIFF
--- a/.changeset/swift-plums-help.md
+++ b/.changeset/swift-plums-help.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Emit activeDeviceChanged when publishing local track

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -58,7 +58,7 @@ import RemoteTrackPublication from './track/RemoteTrackPublication';
 import { Track } from './track/Track';
 import type { TrackPublication } from './track/TrackPublication';
 import type { AdaptiveStreamSettings } from './track/types';
-import { getNewAudioContext } from './track/utils';
+import { getNewAudioContext, sourceToKind } from './track/utils';
 import type { SimulationOptions, SimulationScenario } from './types';
 import {
   Future,
@@ -1566,6 +1566,16 @@ class Room extends EventEmitter<RoomEventCallbacks> {
       if (trackIsSilent) {
         this.emit(RoomEvent.LocalAudioSilenceDetected, pub);
       }
+    }
+    const deviceId = await pub.track?.getDeviceId();
+    const deviceKind = sourceToKind(pub.source);
+    if (
+      deviceKind &&
+      deviceId &&
+      deviceId !== this.localParticipant.activeDeviceMap.get(deviceKind)
+    ) {
+      this.localParticipant.activeDeviceMap.set(deviceKind, deviceId);
+      this.emit(RoomEvent.ActiveDeviceChanged, deviceKind, deviceId);
     }
   };
 

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -1,4 +1,5 @@
 import { sleep } from '../utils';
+import { Track } from './Track';
 import type { AudioCaptureOptions, CreateLocalTracksOptions, VideoCaptureOptions } from './options';
 import type { AudioTrack } from './types';
 
@@ -110,5 +111,31 @@ export function getNewAudioContext(): AudioContext | void {
     typeof window !== 'undefined' && (window.AudioContext || window.webkitAudioContext);
   if (AudioContext) {
     return new AudioContext({ latencyHint: 'interactive' });
+  }
+}
+
+/**
+ * @internal
+ */
+export function kindToSource(kind: MediaDeviceKind) {
+  if (kind === 'audioinput') {
+    return Track.Source.Microphone;
+  } else if (kind === 'videoinput') {
+    return Track.Source.Camera;
+  } else {
+    return Track.Source.Unknown;
+  }
+}
+
+/**
+ * @internal
+ */
+export function sourceToKind(source: Track.Source): MediaDeviceKind | undefined {
+  if (source === Track.Source.Microphone) {
+    return 'audioinput';
+  } else if (source === Track.Source.Camera) {
+    return 'videoinput';
+  } else {
+    return undefined;
   }
 }


### PR DESCRIPTION
In case we have not set an active device previously, at the latest we will know the currently used device in the `LocalTrackPublished` callback. So we can use it to override (and emit) the activeDeviceMap. 

arguably a nicer solution would be if all activeDeviceSwitching was handles on the `LocalParticipant` instead of on the room. this would also allow to extract the active device as soon as the mediaStreamTrack has been acquired. But that'd be a bigger change.