### PR TITLE
Update dimensions when the remote track is detached

### DIFF
--- a/.changeset/funny-dingos-pay.md
+++ b/.changeset/funny-dingos-pay.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Update adaptive stream dimensions when a remote track is being detached

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -198,7 +198,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
     for (const info of stopElementInfos) {
       this.stopObservingElementInfo(info);
     }
-    this.elementInfos = this.elementInfos.filter((info) => info.element !== element);
   }
 
   protected async handleAppVisibilityChanged() {

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -123,7 +123,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
     }
     this.elementInfos = this.elementInfos.filter((info) => info !== elementInfo);
     this.updateVisibility();
-    this.updateDimensions()
+    this.updateDimensions();
   }
 
   detach(): HTMLMediaElement[];

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -131,6 +131,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
     let detachedElements: HTMLMediaElement[] = [];
     if (element) {
       this.stopObservingElement(element);
+      this.updateDimensions();
       return super.detach(element);
     }
     detachedElements = super.detach();
@@ -138,6 +139,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
     for (const e of detachedElements) {
       this.stopObservingElement(e);
     }
+    this.updateDimensions();
 
     return detachedElements;
   }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -123,6 +123,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
     }
     this.elementInfos = this.elementInfos.filter((info) => info !== elementInfo);
     this.updateVisibility();
+    this.updateDimensions()
   }
 
   detach(): HTMLMediaElement[];
@@ -131,7 +132,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
     let detachedElements: HTMLMediaElement[] = [];
     if (element) {
       this.stopObservingElement(element);
-      this.updateDimensions();
       return super.detach(element);
     }
     detachedElements = super.detach();
@@ -139,7 +139,6 @@ export default class RemoteVideoTrack extends RemoteTrack {
     for (const e of detachedElements) {
       this.stopObservingElement(e);
     }
-    this.updateDimensions();
 
     return detachedElements;
   }
@@ -197,7 +196,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
   private stopObservingElement(element: HTMLMediaElement) {
     const stopElementInfos = this.elementInfos.filter((info) => info.element === element);
     for (const info of stopElementInfos) {
-      info.stopObserving();
+      this.stopObservingElementInfo(info);
     }
     this.elementInfos = this.elementInfos.filter((info) => info.element !== element);
   }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -123,7 +123,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
     }
     this.elementInfos = this.elementInfos.filter((info) => info !== elementInfo);
     this.updateVisibility();
-    this.updateDimensions();
+    this.debouncedHandleResize();
   }
 
   detach(): HTMLMediaElement[];


### PR DESCRIPTION
@davidzhao @lukasIO 

Use case for this change:
There are two video elements in the UI. The first is small (480x320) and placed in a participant grid. The second is big (1280x720) and only displays the active speaker. When no one is speaking, then the second video element is removed. In this case, I want to use only the low-resolution simulcast layer. Currently, simulcast layers change only on resize and visibility change events or when a remote track is attached.