### PR TITLE
Fixed missed event listeners on MediaStreamTrack

### DIFF
--- a/.changeset/fuzzy-taxis-turn.md
+++ b/.changeset/fuzzy-taxis-turn.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fixed missed event listeners on MediaStreamTrack

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -90,6 +90,7 @@ const appActions = {
         videoCodec: preferredCodec || 'vp8',
         dtx: true,
         red: true,
+        forceStereo: false,
       },
       videoCaptureDefaults: {
         resolution: VideoPresets.h720.resolution,
@@ -201,6 +202,13 @@ const appActions = {
       })
       .on(RoomEvent.ParticipantEncryptionStatusChanged, () => {
         updateButtonsForPublishState();
+      })
+      .on(RoomEvent.TrackStreamStateChanged, (pub, streamState, participant) => {
+        appendLog(
+          `stream state changed for ${pub.trackSid} (${
+            participant.identity
+          }) to ${streamState.toString()}`,
+        );
       });
 
     try {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -791,11 +791,11 @@ export default class LocalParticipant extends Participant {
 
     if (encodings) {
       if (isFireFox() && track.kind === Track.Kind.Audio) {
-        /* Refer to RFC https://datatracker.ietf.org/doc/html/rfc7587#section-6.1, 
+        /* Refer to RFC https://datatracker.ietf.org/doc/html/rfc7587#section-6.1,
            livekit-server uses maxaveragebitrate=510000in the answer sdp to permit client to
-           publish high quality audio track. But firefox always uses this value as the actual 
+           publish high quality audio track. But firefox always uses this value as the actual
            bitrates, causing the audio bitrates to rise to 510Kbps in any stereo case unexpectedly.
-           So the client need to modify maxaverragebitrates in answer sdp to user provided value to 
+           So the client need to modify maxaverragebitrates in answer sdp to user provided value to
            fix the issue.
          */
         let trackTransceiver: RTCRtpTransceiver | undefined = undefined;

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -58,7 +58,7 @@ export default abstract class LocalTrack extends Track {
     this.processorLock = new Mutex();
     // added to satisfy TS compiler, constraints are synced with MediaStreamTrack
     this._constraints = mediaTrack.getConstraints();
-    this.setMediaStreamTrack(mediaTrack);
+    this.setMediaStreamTrack(mediaTrack, true);
     if (constraints) {
       this._constraints = constraints;
     }
@@ -97,8 +97,8 @@ export default abstract class LocalTrack extends Track {
     return this.processor?.processedTrack ?? this._mediaStreamTrack;
   }
 
-  private async setMediaStreamTrack(newTrack: MediaStreamTrack) {
-    if (newTrack === this._mediaStreamTrack) {
+  private async setMediaStreamTrack(newTrack: MediaStreamTrack, force?: boolean) {
+    if (newTrack === this._mediaStreamTrack && !force) {
       return;
     }
     if (this._mediaStreamTrack) {


### PR DESCRIPTION
My previous attempt to consolidate `setMediaStreamTrack` missed the constructor case, so event listeners were missed the first run around.