### PR TITLE
createLocalScreenTracks returns ended tracks

### DIFF
--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -101,7 +101,7 @@ export default abstract class LocalTrack extends Track {
     if (newTrack === this._mediaStreamTrack && !force) {
       return;
     }
-    if (this._mediaStreamTrack) {
+    if (this._mediaStreamTrack && this.mediaTrackSetBy === 'localtrack') {
       // detach
       this.attachedElements.forEach((el) => {
         detachTrack(this._mediaStreamTrack, el);
@@ -130,6 +130,7 @@ export default abstract class LocalTrack extends Track {
       await this.sender.replaceTrack(newTrack);
     }
     this._mediaStreamTrack = newTrack;
+    this.mediaTrackSetBy = 'localtrack';
     if (newTrack) {
       // sync muted state with the enabled state of the newly provided track
       this._mediaStreamTrack.enabled = !this.isMuted;

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -49,10 +49,13 @@ export abstract class Track extends EventEmitter<TrackEventCallbacks> {
 
   protected monitorInterval?: ReturnType<typeof setInterval>;
 
+  protected mediaTrackSetBy: 'track' | 'localtrack' = 'track';
+
   protected constructor(mediaTrack: MediaStreamTrack, kind: Track.Kind) {
     super();
     this.kind = kind;
     this._mediaStreamTrack = mediaTrack;
+    this.mediaTrackSetBy = 'track';
     this._mediaStreamID = mediaTrack.id;
     this.source = Track.Source.Unknown;
   }


### PR DESCRIPTION
@davidzhao @lukasIO This is a workaround that I figured out quickly. I hope it makes it easier to understand issue #770.

Could you take care of it or suggest a better solution that I could implement?