### PR TITLE
Update constraints on track creation

### DIFF
--- a/.changeset/spotty-cheetahs-lay.md
+++ b/.changeset/spotty-cheetahs-lay.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Update constraints with actually selected deviceId on track creation

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -57,6 +57,15 @@ export async function createLocalTracks(
     if (typeof conOrBool !== 'boolean') {
       trackConstraints = conOrBool;
     }
+
+    // update the constraints with the device id the user gave permissions to in the permission prompt
+    // otherwise each track restart (e.g. mute - unmute) will try to initialize the device again -> causing additional permission prompts
+    if (trackConstraints) {
+      trackConstraints.deviceId = mediaStreamTrack.getSettings().deviceId;
+    } else {
+      trackConstraints = { deviceId: mediaStreamTrack.getSettings().deviceId };
+    }
+
     const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints);
     if (track.kind === Track.Kind.Video) {
       track.source = Track.Source.Camera;


### PR DESCRIPTION
The constraints can be set to the wrong value causing the device to change on `unmute()`. This happens inside the `createLocalTracks` function if the browser gives access to different devices than the one requested by the `getUserMedia` constraints.
