### PR TITLE
prepareConnection to better support Cloud routing and region-pinning

### DIFF
--- a/.changeset/swift-rats-dance.md
+++ b/.changeset/swift-rats-dance.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Support for region pinning with LiveKit Cloud using prepareConnection

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Examples below are in TypeScript, if using JS/CommonJS imports replace import wi
 const livekit = require('livekit-client');
 
 const room = new livekit.Room(...);
+
+room.prepareConnection(url, token);
+
 await room.connect(...);
 ```
 
@@ -78,6 +81,9 @@ const room = new Room({
     resolution: VideoPresets.h720.resolution,
   },
 });
+
+// pre-warm connection, this can be called as early as your page is loaded
+room.prepareConnection(url, token);
 
 // set up event listeners
 room

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -123,7 +123,7 @@ const appActions = {
     const room = new Room(roomOptions);
 
     startTime = Date.now();
-    await room.prepareConnection(url);
+    await room.prepareConnection(url, token);
     const prewarmTime = Date.now() - startTime;
     appendLog(`prewarmed connection in ${prewarmTime}ms`);
 

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -32,7 +32,7 @@ import {
 } from '../proto/livekit_rtc';
 import { ConnectionError, ConnectionErrorReason } from '../room/errors';
 import CriticalTimers from '../room/timers';
-import { Mutex, getClientInfo, isReactNative, sleep } from '../room/utils';
+import { Mutex, getClientInfo, isReactNative, sleep, toWebsocketUrl } from '../room/utils';
 import { AsyncQueue } from '../utils/AsyncQueue';
 
 // internal options
@@ -206,9 +206,7 @@ export class SignalClient {
     abortSignal?: AbortSignal,
   ): Promise<JoinResponse | ReconnectResponse | void> {
     this.connectOptions = opts;
-    if (url.startsWith('http')) {
-      url = url.replace('http', 'ws');
-    }
+    url = toWebsocketUrl(url);
     // strip trailing slash
     url = url.replace(/\/$/, '');
     url += '/rtc';

--- a/src/room/RegionUrlProvider.ts
+++ b/src/room/RegionUrlProvider.ts
@@ -21,6 +21,10 @@ export class RegionUrlProvider {
     this.token = token;
   }
 
+  updateToken(token: string) {
+    this.token = token;
+  }
+
   isCloud() {
     return isCloud(this.serverUrl);
   }

--- a/src/room/RegionUrlProvider.ts
+++ b/src/room/RegionUrlProvider.ts
@@ -53,7 +53,8 @@ export class RegionUrlProvider {
     this.attemptedRegions = [];
   }
 
-  private async fetchRegionSettings(signal?: AbortSignal) {
+  /* @internal */
+  async fetchRegionSettings(signal?: AbortSignal) {
     const regionSettingsResponse = await fetch(`${getCloudConfigUrl(this.serverUrl)}/regions`, {
       headers: { authorization: `Bearer ${this.token}` },
       signal,

--- a/src/room/RegionUrlProvider.ts
+++ b/src/room/RegionUrlProvider.ts
@@ -29,6 +29,10 @@ export class RegionUrlProvider {
     return isCloud(this.serverUrl);
   }
 
+  getServerUrl() {
+    return this.serverUrl;
+  }
+
   async getNextBestRegionUrl(abortSignal?: AbortSignal) {
     if (!this.isCloud()) {
       throw Error('region availability is only supported for LiveKit Cloud domains');

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -351,7 +351,7 @@ class Room extends EventEmitter<RoomEventCallbacks> {
    * the current client to connect to if a token is provided.
    */
   async prepareConnection(url: string, token?: string) {
-    if (this.state !== 'disconnected') {
+    if (this.state !== ConnectionState.Disconnected) {
       return;
     }
     log.debug(`prepareConnection to ${url}`);
@@ -361,7 +361,7 @@ class Room extends EventEmitter<RoomEventCallbacks> {
         const regionUrl = await this.regionUrlProvider.getNextBestRegionUrl();
         // we will not replace the regionUrl if an attempt had already started
         // to avoid overriding regionUrl after a new connection attempt had started
-        if (regionUrl && this.state === 'disconnected') {
+        if (regionUrl && this.state === ConnectionState.Disconnected) {
           this.regionUrl = regionUrl;
           await fetch(toHttpUrl(regionUrl), { method: 'HEAD' });
           log.debug(`prepared connection to ${regionUrl}`);

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -1,6 +1,6 @@
 import { ClientInfo, ClientInfo_SDK } from '../proto/livekit_models';
-import { getBrowser } from '../utils/browserParser';
 import type { DetectableBrowser } from '../utils/browserParser';
+import { getBrowser } from '../utils/browserParser';
 import { protocolVersion, version } from '../version';
 import type LocalAudioTrack from './track/LocalAudioTrack';
 import type RemoteAudioTrack from './track/RemoteAudioTrack';
@@ -482,4 +482,18 @@ export function unwrapConstraint(constraint: ConstrainDOMString): string {
     return constraint.ideal;
   }
   throw Error('could not unwrap constraint');
+}
+
+export function toWebsocketUrl(url: string): string {
+  if (url.startsWith('http')) {
+    return url.replace('http', 'ws');
+  }
+  return url;
+}
+
+export function toHttpUrl(url: string): string {
+  if (url.startsWith('ws')) {
+    return url.replace('ws', 'http');
+  }
+  return url;
 }

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -148,7 +148,9 @@ export function isReactNative(): boolean {
 }
 
 export function isCloud(serverUrl: URL) {
-  return serverUrl.hostname.endsWith('.livekit.cloud');
+  return (
+    serverUrl.hostname.endsWith('.livekit.cloud') || serverUrl.hostname.endsWith('.livekit.run')
+  );
 }
 
 function getLKReactNativeInfo(): LiveKitReactNativeInfo | undefined {


### PR DESCRIPTION
When using Cloud, establish connection to fetch region URL so we have better control of routing decisions.

For projects with region-pinning enabled, `/settings/regions` would only return regions that are allowed. if prepareConnections is not used, Cloud would reject the initial connection if DNS-based routing ends up connecting to a disallowed region.