### PR TITLE
Only check for setSinkId support on AudioContext if webaudiomix is enabled

### DIFF
--- a/.changeset/tame-drinks-arrive.md
+++ b/.changeset/tame-drinks-arrive.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Only check for setSinkId support on AudioContext if webaudiomix is enabled

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -834,7 +834,7 @@ class Room extends EventEmitter<RoomEventCallbacks> {
     } else if (kind === 'audiooutput') {
       if (
         (!supportsSetSinkId() && !this.options.expWebAudioMix) ||
-        (this.audioContext && !('setSinkId' in this.audioContext))
+        (this.options.expWebAudioMix && this.audioContext && !('setSinkId' in this.audioContext))
       ) {
         throw new Error('cannot switch audio output, setSinkId not supported');
       }


### PR DESCRIPTION
`audioContext.setSinkId` is only supported in recent Chrome versions. We only want to raise an error in that case, if `expWebAudioMix` is actually enabled