### PR TITLE
Also reset hasValidKey on manual ratchet request

### DIFF
--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -7,6 +7,7 @@ import type {
   ErrorMessage,
   KeyProviderOptions,
   RatchetMessage,
+  RatchetRequestMessage,
 } from '../types';
 import { FrameCryptor } from './FrameCryptor';
 import { ParticipantKeyHandler } from './ParticipantKeyHandler';
@@ -92,12 +93,17 @@ onmessage = (ev) => {
       });
       break;
     case 'ratchetRequest':
-      getParticipantKeyHandler(data.participantId).ratchetKey(data.keyIndex);
-
+      handleRatchetRequest(data);
     default:
       break;
   }
 };
+
+function handleRatchetRequest(data: RatchetRequestMessage['data']) {
+  const keyHandler = getParticipantKeyHandler(data.participantId);
+  keyHandler.ratchetKey(data.keyIndex);
+  keyHandler.hasValidKey = true;
+}
 
 function getTrackCryptor(participantId: string, trackId: string) {
   let cryptor = participantCryptors.find((c) => c.getTrackId() === trackId);


### PR DESCRIPTION
In case the `ratchetWindowSize` is `0`, we need to make sure that manual ratchet requests also reset the `hasValidKey` property on the key handlers.