### PR TITLE
Add ScreenShareCaptureOptions.contentHint option

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -468,6 +468,9 @@ export default class LocalParticipant extends Participant {
     if (tracks.length === 0) {
       throw new TrackInvalidError('no video track found');
     }
+    if (options.contentHint !== undefined) {
+      tracks[0].contentHint = options.contentHint;
+    }
     const screenVideo = new LocalVideoTrack(tracks[0], undefined, false);
     screenVideo.source = Track.Source.ScreenShare;
     const localTracks: Array<LocalTrack> = [screenVideo];

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -167,6 +167,9 @@ export interface ScreenShareCaptureOptions {
    * local speakers when the tab is captured.
    */
   suppressLocalAudioPlayback?: boolean;
+
+  /** a string that hints at the type of content the track contain. */
+  contentHint?: '' | 'motion' | 'detail' | 'text';
 }
 
 export interface AudioCaptureOptions {


### PR DESCRIPTION
This PR adds one **ScreenShareCaptureOptions** attribute.
When we use shared desktop streams, we may need to set the track's contentHint to accommodate the shared content