### PR TITLE
Set a default resolution for createLocalScreenTracks

### DIFF
--- a/.changeset/afraid-moles-change.md
+++ b/.changeset/afraid-moles-change.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Set a default resolution for createLocalScreenTracks

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -7,7 +7,7 @@ import LocalAudioTrack from './LocalAudioTrack';
 import type LocalTrack from './LocalTrack';
 import LocalVideoTrack from './LocalVideoTrack';
 import { Track } from './Track';
-import { ScreenSharePresets, VideoPresets } from './options';
+import { ScreenSharePresets } from './options';
 import type {
   AudioCaptureOptions,
   CreateLocalTracksOptions,

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -2,11 +2,12 @@ import DeviceManager from '../DeviceManager';
 import { audioDefaults, videoDefaults } from '../defaults';
 import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
 import { mediaTrackToLocalTrack } from '../participant/publishUtils';
+import { isSafari } from '../utils';
 import LocalAudioTrack from './LocalAudioTrack';
 import type LocalTrack from './LocalTrack';
 import LocalVideoTrack from './LocalVideoTrack';
 import { Track } from './Track';
-import { VideoPresets } from './options';
+import { ScreenSharePresets, VideoPresets } from './options';
 import type {
   AudioCaptureOptions,
   CreateLocalTracksOptions,
@@ -113,26 +114,38 @@ export async function createLocalScreenTracks(
     options = {};
   }
   if (options.resolution === undefined) {
-    options.resolution = VideoPresets.h1080.resolution;
+    options.resolution = ScreenSharePresets.h1080fps15.resolution;
   }
 
   let videoConstraints: MediaTrackConstraints | boolean = true;
   if (options.resolution) {
-    videoConstraints = {
-      width: options.resolution.width,
-      height: options.resolution.height,
-    };
+    if (isSafari()) {
+      videoConstraints = {
+        width: { max: options.resolution.width },
+        height: { max: options.resolution.height },
+        frameRate: options.resolution.frameRate,
+      };
+    } else {
+      videoConstraints = {
+        width: { ideal: options.resolution.width },
+        height: { ideal: options.resolution.height },
+        frameRate: options.resolution.frameRate,
+      };
+    }
   }
 
   if (navigator.mediaDevices.getDisplayMedia === undefined) {
     throw new DeviceUnsupportedError('getDisplayMedia not supported');
   }
 
-  // typescript definition is missing getDisplayMedia: https://github.com/microsoft/TypeScript/issues/33232
-  // @ts-ignore
   const stream: MediaStream = await navigator.mediaDevices.getDisplayMedia({
     audio: options.audio ?? false,
     video: videoConstraints,
+    // @ts-expect-error support for experimental display media features
+    controller: options.controller,
+    selfBrowserSurface: options.selfBrowserSurface,
+    surfaceSwitching: options.surfaceSwitching,
+    systemAudio: options.systemAudio,
   });
 
   const tracks = stream.getVideoTracks();


### PR DESCRIPTION
This updates `createLocalScreenTracks` to use the same logic as `localParticipant.createScreenTracks`. 

In particular this solves a bug where chrome emits `mediastreamtrack.muted` event when the tab with the shared screen is being backgrounded. It seems like setting a frameRate on the video options avoids this problem. 

The reason why this currently poses a problem is, that we call `pauseUpstream` on mediastreamtrack `muted` events, which results in the remote publication appearing as muted when the shared tab is in the background. 

The right thing to do would probably to keep the frozen frame in this case. 

thanks to @burzomir for the report!