### PR TITLE
Debounce mediastreamtrack mute events

### DIFF
--- a/.changeset/brave-shirts-pay.md
+++ b/.changeset/brave-shirts-pay.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Debounce reacting to mediastreamtrack mute events


### PR DESCRIPTION
For OBS virtual cameras (and reportedly also other devices) `mediastreamtrack` `muted` events get emitted in a regular interval, followed by `unmute` events. 
In order to avoid this resulting in a constant `pauseUpstream` -> `resumeUpstream` loop, we debounce the `mute` event so that we only pick it up if the track has been muted consistently for > 5s. 