### PR TITLE
Add failureTolerance to KeyProvider options

### DIFF
--- a/.changeset/long-doors-push.md
+++ b/.changeset/long-doors-push.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Add failureTolerance to KeyProvider options (E2EE)

--- a/src/e2ee/constants.ts
+++ b/src/e2ee/constants.ts
@@ -7,6 +7,9 @@ export const ENCRYPTION_ALGORITHM = 'AES-GCM';
 // in the frame trailer.
 export const KEYRING_SIZE = 16;
 
+// How many consecutive frames can fail decrypting before a particular key gets marked as invalid
+export const DECRYPTION_FAILURE_TOLERANCE = 10;
+
 // We copy the first bytes of the VP8 payload unencrypted.
 // For keyframes this is 10 bytes, for non-keyframes (delta) 3. See
 //   https://tools.ietf.org/html/rfc6386#section-9.1
@@ -37,4 +40,5 @@ export const KEY_PROVIDER_DEFAULTS: KeyProviderOptions = {
   sharedKey: false,
   ratchetSalt: SALT,
   ratchetWindowSize: 8,
+  failureTolerance: DECRYPTION_FAILURE_TOLERANCE,
 } as const;

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -110,6 +110,7 @@ export type KeyProviderOptions = {
   sharedKey: boolean;
   ratchetSalt: string;
   ratchetWindowSize: number;
+  failureTolerance: number;
 };
 
 export type KeyProviderCallbacks = {

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -271,6 +271,7 @@ export class FrameCryptor extends BaseFrameCryptor {
     if (this.keys.getKeySet(keyIndex) && this.keys.hasValidKey) {
       try {
         const decodedFrame = await this.decryptFrame(encodedFrame, keyIndex);
+        this.keys.decryptionSuccess();
         if (decodedFrame) {
           return controller.enqueue(decodedFrame);
         }
@@ -285,7 +286,7 @@ export class FrameCryptor extends BaseFrameCryptor {
                 CryptorErrorReason.InvalidKey,
               ),
             );
-            this.keys.hasValidKey = false;
+            this.keys.decryptionFailure();
           }
         } else {
           workerLogger.warn('decoding frame failed', { error });
@@ -394,8 +395,6 @@ export class FrameCryptor extends BaseFrameCryptor {
             workerLogger.debug('resetting to initial material');
             this.keys.setKeyFromMaterial(initialMaterial.material, keyIndex);
           }
-
-          this.keys.hasValidKey = false;
 
           workerLogger.warn('maximum ratchet attempts exceeded, resetting key');
           this.emit(

--- a/src/e2ee/worker/ParticipantKeyHandler.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'eventemitter3';
 import { workerLogger } from '../../logger';
-import { DECRYPTION_FAILURE_TOLERANCE, KEYRING_SIZE } from '../constants';
+import { KEYRING_SIZE } from '../constants';
 import type { KeyProviderOptions, KeySet, ParticipantKeyHandlerCallbacks } from '../types';
 import { deriveKeys, importKey, ratchet } from '../utils';
 

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -102,7 +102,7 @@ onmessage = (ev) => {
 async function handleRatchetRequest(data: RatchetRequestMessage['data']) {
   const keyHandler = getParticipantKeyHandler(data.participantId);
   await keyHandler.ratchetKey(data.keyIndex);
-  keyHandler.hasValidKey = true;
+  keyHandler.resetKeyStatus();
 }
 
 function getTrackCryptor(participantId: string, trackId: string) {


### PR DESCRIPTION
Adding `failureTolerance` as an option allows us to 
- specify how sensitive key invalidation should be (also helps with multiple tracks of the same participant not all being marked as invalid)
- setting it to `-1` just means a key never gets marked as invalid