### PR TITLE
Fix getDevices permissions when no kind is supplied

### DIFF
--- a/.changeset/smooth-trains-give.md
+++ b/.changeset/smooth-trains-give.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix getDevices permissions when no kind is supplied

--- a/src/room/DeviceManager.ts
+++ b/src/room/DeviceManager.ts
@@ -38,7 +38,7 @@ export default class DeviceManager {
     if (
       requestPermissions &&
       // for safari we need to skip this check, as otherwise it will re-acquire user media and fail on iOS https://bugs.webkit.org/show_bug.cgi?id=179363
-      !(isSafari() && this.hasActiveDevice(kind))
+      !(isSafari() && this.hasDeviceInUse(kind))
     ) {
       const isDummyDeviceOrEmpty =
         devices.length === 0 ||
@@ -85,7 +85,7 @@ export default class DeviceManager {
     return device?.deviceId;
   }
 
-  private hasActiveDevice(kind?: MediaDeviceKind): boolean {
+  private hasDeviceInUse(kind?: MediaDeviceKind): boolean {
     return kind
       ? DeviceManager.userMediaPromiseMap.has(kind)
       : DeviceManager.userMediaPromiseMap.size > 0;

--- a/src/room/DeviceManager.ts
+++ b/src/room/DeviceManager.ts
@@ -37,9 +37,8 @@ export default class DeviceManager {
 
     if (
       requestPermissions &&
-      kind &&
       // for safari we need to skip this check, as otherwise it will re-acquire user media and fail on iOS https://bugs.webkit.org/show_bug.cgi?id=179363
-      (!DeviceManager.userMediaPromiseMap.get(kind) || !isSafari())
+      !(isSafari() && this.hasActiveDevice(kind))
     ) {
       const isDummyDeviceOrEmpty =
         devices.length === 0 ||
@@ -84,5 +83,11 @@ export default class DeviceManager {
     const device = devices.find((d) => d.groupId === groupId && d.deviceId !== defaultId);
 
     return device?.deviceId;
+  }
+
+  private hasActiveDevice(kind?: MediaDeviceKind): boolean {
+    return kind
+      ? DeviceManager.userMediaPromiseMap.has(kind)
+      : DeviceManager.userMediaPromiseMap.size > 0;
   }
 }


### PR DESCRIPTION
The check for active devices for the Safari workaround skips getting permission if no kind is supplied.