### PR TITLE
Override server injected frame data with empty array buffer

### DIFF
--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -261,8 +261,6 @@ export class FrameCryptor extends BaseFrameCryptor {
       // skip for decryption for empty dtx frames
       encodedFrame.data.byteLength === 0
     ) {
-      // TODO when a frame is detected as being server injected, it would be preferable to construct
-      // an empty frame client-side instead of just passing it to the controller
       return controller.enqueue(encodedFrame);
     }
     if (

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -259,12 +259,17 @@ export class FrameCryptor extends BaseFrameCryptor {
     if (
       !this.keys.isEnabled() ||
       // skip for decryption for empty dtx frames
-      encodedFrame.data.byteLength === 0 ||
-      // skip decryption if frame is server injected
-      isFrameServerInjected(encodedFrame.data, this.sifTrailer)
+      encodedFrame.data.byteLength === 0
     ) {
       // TODO when a frame is detected as being server injected, it would be preferable to construct
       // an empty frame client-side instead of just passing it to the controller
+      return controller.enqueue(encodedFrame);
+    }
+    if (
+      // replace frame data with empty data if frame is server injected
+      isFrameServerInjected(encodedFrame.data, this.sifTrailer)
+    ) {
+      encodedFrame.data = new ArrayBuffer(encodedFrame.data.byteLength);
       return controller.enqueue(encodedFrame);
     }
     const data = new Uint8Array(encodedFrame.data);

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -267,7 +267,9 @@ export class FrameCryptor extends BaseFrameCryptor {
       // replace frame data with empty data if frame is server injected
       isFrameServerInjected(encodedFrame.data, this.sifTrailer)
     ) {
-      encodedFrame.data = new ArrayBuffer(encodedFrame.data.byteLength);
+      encodedFrame.data = new ArrayBuffer(
+        encodedFrame.data.byteLength - this.sifTrailer.byteLength,
+      );
       return controller.enqueue(encodedFrame);
     }
     const data = new Uint8Array(encodedFrame.data);

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -135,7 +135,6 @@ export function computeVideoEncodings(
       encodings.push({
         rid: videoRids[2 - i],
         maxBitrate: videoEncoding.maxBitrate / 3 ** i,
-        /* @ts-ignore */
         maxFramerate: original.encoding.maxFramerate,
       });
     }


### PR DESCRIPTION
based on #812 

this makes sure that the data contents of server injected frames are discarded and replaced with an empty array buffer of the same length client side.