### PR TITLE
Adjust bitrates following WebRTC bitrate guide

### DIFF
--- a/.changeset/smooth-gorillas-sniff.md
+++ b/.changeset/smooth-gorillas-sniff.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Adjust default bitrates according to VMAF results

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -3,13 +3,13 @@ import { TrackInvalidError } from '../errors';
 import LocalAudioTrack from '../track/LocalAudioTrack';
 import LocalVideoTrack from '../track/LocalVideoTrack';
 import { Track } from '../track/Track';
-import { ScreenSharePresets, VideoPreset, VideoPresets, VideoPresets43 } from '../track/options';
 import type {
   BackupVideoCodec,
   TrackPublishOptions,
   VideoCodec,
   VideoEncoding,
 } from '../track/options';
+import { ScreenSharePresets, VideoPreset, VideoPresets, VideoPresets43 } from '../track/options';
 import { getReactNativeOs, isFireFox, isReactNative, isSVCCodec } from '../utils';
 
 /** @internal */
@@ -240,7 +240,9 @@ export function determineAppropriateEncoding(
   }
   // presets are based on the assumption of vp8 as a codec
   // for other codecs we adjust the maxBitrate if no specific videoEncoding has been provided
-  // TODO make the bitrate multipliers configurable per codec
+  // users should override these with ones that are optimized for their use case
+  // NOTE: SVC codec bitrates are inclusive of all scalability layers. while
+  // bitrate for non-SVC codecs does not include other simulcast layers.
   if (codec) {
     switch (codec) {
       case 'av1':

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -327,11 +327,11 @@ export namespace AudioPresets {
  * Sane presets for video resolution/encoding
  */
 export const VideoPresets = {
-  h90: new VideoPreset(160, 90, 60_000, 15),
-  h180: new VideoPreset(320, 180, 120_000, 15),
-  h216: new VideoPreset(384, 216, 180_000, 15),
-  h360: new VideoPreset(640, 360, 300_000, 20),
-  h540: new VideoPreset(960, 540, 600_000, 25),
+  h90: new VideoPreset(160, 90, 90_000, 20),
+  h180: new VideoPreset(320, 180, 160_000, 20),
+  h216: new VideoPreset(384, 216, 180_000, 20),
+  h360: new VideoPreset(640, 360, 450_000, 20),
+  h540: new VideoPreset(960, 540, 800_000, 25),
   h720: new VideoPreset(1280, 720, 1_700_000, 30),
   h1080: new VideoPreset(1920, 1080, 3_000_000, 30),
   h1440: new VideoPreset(2560, 1440, 5_000_000, 30),
@@ -342,21 +342,22 @@ export const VideoPresets = {
  * Four by three presets
  */
 export const VideoPresets43 = {
-  h120: new VideoPreset(160, 120, 80_000, 15),
-  h180: new VideoPreset(240, 180, 100_000, 15),
-  h240: new VideoPreset(320, 240, 150_000, 15),
+  h120: new VideoPreset(160, 120, 70_000, 20),
+  h180: new VideoPreset(240, 180, 125_000, 20),
+  h240: new VideoPreset(320, 240, 140_000, 20),
   h360: new VideoPreset(480, 360, 225_000, 20),
-  h480: new VideoPreset(640, 480, 300_000, 20),
-  h540: new VideoPreset(720, 540, 450_000, 25),
-  h720: new VideoPreset(960, 720, 1_500_000, 30),
-  h1080: new VideoPreset(1440, 1080, 2_500_000, 30),
-  h1440: new VideoPreset(1920, 1440, 3_500_000, 30),
+  h480: new VideoPreset(640, 480, 500_000, 20),
+  h540: new VideoPreset(720, 540, 600_000, 25),
+  h720: new VideoPreset(960, 720, 1_300_000, 30),
+  h1080: new VideoPreset(1440, 1080, 2_300_000, 30),
+  h1440: new VideoPreset(1920, 1440, 3_800_000, 30),
 } as const;
 
 export const ScreenSharePresets = {
   h360fps3: new VideoPreset(640, 360, 200_000, 3, 'medium'),
   h720fps5: new VideoPreset(1280, 720, 400_000, 5, 'medium'),
-  h720fps15: new VideoPreset(1280, 720, 1_000_000, 15, 'medium'),
-  h1080fps15: new VideoPreset(1920, 1080, 1_500_000, 15, 'medium'),
-  h1080fps30: new VideoPreset(1920, 1080, 3_000_000, 30, 'medium'),
+  h720fps15: new VideoPreset(1280, 720, 1_500_000, 15, 'medium'),
+  h720fps30: new VideoPreset(1280, 720, 2_000_000, 30, 'medium'),
+  h1080fps15: new VideoPreset(1920, 1080, 2_500_000, 15, 'medium'),
+  h1080fps30: new VideoPreset(1920, 1080, 4_000_000, 30, 'medium'),
 } as const;


### PR DESCRIPTION
We were previously using incorrect bitrates for 360p and 540p layers

See https://livekit.io/webrtc/bitrate-guide