### PR TITLE
Convert pauseUpstream and resumeUpstream to regular class methods

### DIFF
--- a/.changeset/mighty-drinks-worry.md
+++ b/.changeset/mighty-drinks-worry.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Convert pauseUpstream and resumeUpstream to regular class methods

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -320,7 +320,7 @@ export default abstract class LocalTrack extends Track {
    * the server.
    * this API is unsupported on Safari < 12 due to a bug
    **/
-  pauseUpstream = async () => {
+  async pauseUpstream() {
     const unlock = await this.pauseUpstreamLock.lock();
     try {
       if (this._isUpstreamPaused === true) {
@@ -342,9 +342,9 @@ export default abstract class LocalTrack extends Track {
     } finally {
       unlock();
     }
-  };
+  }
 
-  resumeUpstream = async () => {
+  async resumeUpstream() {
     const unlock = await this.pauseUpstreamLock.lock();
     try {
       if (this._isUpstreamPaused === false) {
@@ -362,7 +362,7 @@ export default abstract class LocalTrack extends Track {
     } finally {
       unlock();
     }
-  };
+  }
 
   /**
    * Sets a processor on this track.


### PR DESCRIPTION
Until recently we were passing `this.pauseUpstream` directly to an event handler of `track.on('mute', this.pauseUpstream)`. Since we don't do this anymore we can convert them to regular class methods, which allows us to call `super.*Upstream` in child classes. This is needed for a clean implementation of #829. 

This does change binding behaviour when the method is passed around directly to e.g. event handlers, so it warrants a minor version bump.
This change aligns those APIs with how we define `mute` and `unmute`, those are regular class methods, too. 