### PR TITLE
Ability to simulate subscriber-bandwidth

### DIFF
--- a/.changeset/selfish-olives-compete.md
+++ b/.changeset/selfish-olives-compete.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ability to simulate subscriber-bandwidth

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -698,7 +698,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   /**
    * @internal for testing
    */
-  async simulateScenario(scenario: SimulationScenario) {
+  async simulateScenario(scenario: SimulationScenario, arg?: any) {
     let postAction = () => {};
     let req: SimulateScenario | undefined;
     switch (scenario) {
@@ -767,6 +767,17 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             );
           }
         };
+        break;
+      case 'subscriber-bandwidth':
+        if (arg === undefined || typeof arg !== 'number') {
+          throw new Error('subscriber-bandwidth requires a number as argument');
+        }
+        req = new SimulateScenario({
+          scenario: {
+            case: 'subscriberBandwidth',
+            value: BigInt(arg),
+          },
+        });
         break;
       default:
     }

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -36,4 +36,8 @@ export type SimulationScenario =
   | 'resume-reconnect'
   | 'force-tcp'
   | 'force-tls'
-  | 'full-reconnect';
+  | 'full-reconnect'
+  // overrides server-side bandwidth estimator with set bandwidth
+  // this can be used to test application behavior when congested or
+  // to disable congestion control entirely (by setting bandwidth to 100Mbps)
+  | 'subscriber-bandwidth';


### PR DESCRIPTION
By using `room.simulateScenario('subscriber-bandwidth', bitrate)`, one could override server-side bandwidth estimator with set bandwidth.

This can be used to test application behavior when congested or to disable congestion control entirely (by setting bandwidth to 100Mbps)