### PR TITLE
Fix maxJoinAttempts in RTC Engine

### DIFF
--- a/.changeset/hot-pumpkins-dream.md
+++ b/.changeset/hot-pumpkins-dream.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix passing maxRetries connectOption to RTCEngine

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -191,6 +191,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.url = url;
     this.token = token;
     this.signalOpts = opts;
+    this.maxJoinAttempts = opts.maxRetries;
     try {
       this.joinAttempts += 1;
 


### PR DESCRIPTION
Hi.
We have a `maxRetries` property in `RoomConnectOptions`,  but it seems we never use it to retry the connection. On the other hand, we have a `maxJoinAttempts` value in RTCEngine which is hard-coded and cannot be changed by room connect options.
This PR allows to set the `maxJoinAttempts` value through the `maxRetries` property in `RoomConnectOptions`. 