### PR TITLE
Ensure play requests are invoked synchronously in startAudio

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -800,7 +800,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    * - `getUserMedia`
    */
   async startAudio() {
-    await this.acquireAudioContext();
     const elements: Array<HTMLMediaElement> = [];
     const browser = getBrowser();
     if (browser && browser.os === 'iOS') {
@@ -849,12 +848,13 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     });
 
     try {
-      await Promise.all(
-        elements.map((e) => {
+      await Promise.all([
+        this.acquireAudioContext(),
+        ...elements.map((e) => {
           e.muted = false;
           return e.play();
         }),
-      );
+      ]);
       this.handleAudioPlaybackStarted();
     } catch (err) {
       this.handleAudioPlaybackFailed(err);


### PR DESCRIPTION
The idea is to aquire audio context in parallel with the play requests. This is done in order to not invoking an "awaited" function before the the play requests are invoked. Some browsers (e.g. iOS Safari) raise an exception if the play request isn't invoked directly from the user gesture. An `await` in the callback handler seems to mess with that. 

Tested this across Desktop browsers and iOS Safari with both `expWebAudioMix` and without. 