### PR TITLE
Fix track processor blips when restarting tracks

### DIFF
--- a/.changeset/serious-boxes-train.md
+++ b/.changeset/serious-boxes-train.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix track processor blips when restarting tracks

--- a/src/room/track/processor/types.ts
+++ b/src/room/track/processor/types.ts
@@ -29,7 +29,8 @@ export interface TrackProcessor<
   U extends ProcessorOptions<T> = ProcessorOptions<T>,
 > {
   name: string;
-  init: (opts: U) => void;
+  init: (opts: U) => Promise<void>;
+  restart: (opts: U) => Promise<void>;
   destroy: () => Promise<void>;
   processedTrack?: MediaStreamTrack;
 }


### PR DESCRIPTION
Only works with processors with this PR https://github.com/livekit/track-processors-js/pull/11

supersedes #739 


@burzomir thank you for all the investigations you did around this, could you test that combination (this branch and the processor main branch) to see if it solves your use case? 