### PR TITLE
Allow ArrayBuffers to be used for ExternalKeyProvider

### DIFF
--- a/.changeset/hip-brooms-jam.md
+++ b/.changeset/hip-brooms-jam.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Allow ArrayBuffers to be used for ExternalKeyProvider keys

--- a/src/e2ee/KeyProvider.ts
+++ b/src/e2ee/KeyProvider.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
 import { KEY_PROVIDER_DEFAULTS } from './constants';
 import type { KeyInfo, KeyProviderCallbacks, KeyProviderOptions } from './types';
-import { createKeyMaterialFromString } from './utils';
+import { createKeyMaterialFromBuffer, createKeyMaterialFromString } from './utils';
 
 /**
  * @experimental
@@ -68,11 +68,16 @@ export class ExternalE2EEKeyProvider extends BaseKeyProvider {
   }
 
   /**
-   * Accepts a passphrase that's used to create the crypto keys
+   * Accepts a passphrase that's used to create the crypto keys.
+   * When passing in a string, PBKDF2 is used.
+   * Also accepts an Array buffer of cryptographically random numbers that uses HKDF.
    * @param key
    */
-  async setKey(key: string) {
-    const derivedKey = await createKeyMaterialFromString(key);
+  async setKey(key: string | ArrayBuffer) {
+    const derivedKey =
+      typeof key === 'string'
+        ? await createKeyMaterialFromString(key)
+        : await createKeyMaterialFromBuffer(key);
     this.onSetEncryptionKey(derivedKey);
   }
 }

--- a/src/e2ee/utils.ts
+++ b/src/e2ee/utils.ts
@@ -56,6 +56,15 @@ export async function createKeyMaterialFromString(password: string) {
   return keyMaterial;
 }
 
+export async function createKeyMaterialFromBuffer(cryptoBuffer: ArrayBuffer) {
+  const keyMaterial = await crypto.subtle.importKey('raw', cryptoBuffer, 'HKDF', false, [
+    'deriveBits',
+    'deriveKey',
+  ]);
+
+  return keyMaterial;
+}
+
 function getAlgoOptions(algorithmName: string, salt: string) {
   const textEncoder = new TextEncoder();
   const encodedSalt = textEncoder.encode(salt);


### PR DESCRIPTION
This adds a `createKeyMaterialFromBuffer` helper method and allows the `keyProvider.setKey` method to accept a `ArrayBuffer` in addition to a string. 

The string is used for pass phrases and uses `PBKDF2`. (not recommended, but easy to use)
The buffer is used for [cryptographically strong random numbers](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) and uses `HKDF`. (recommended, but needs crypto rand values instead of a easily type-able pass phrase)

