### PR TITLE
Revert "Fix track is not ended correctly with new stream id"

### DIFF
--- a/.changeset/soft-terms-wait.md
+++ b/.changeset/soft-terms-wait.md
@@ -1,5 +1,0 @@
----
-'livekit-client': patch
----
-
-Fix track is not end correctly with new stream id

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -29,16 +29,14 @@ export default abstract class RemoteTrack extends Track {
   /** @internal */
   setMediaStream(stream: MediaStream) {
     // this is needed to determine when the track is finished
+    // we send each track down in its own MediaStream, so we can assume the
+    // current track is the only one that can be removed.
     this.mediaStream = stream;
-    const onRemoveTrack = (event: MediaStreamTrackEvent) => {
-      if (event.track === this._mediaStreamTrack) {
-        stream.removeEventListener('removetrack', onRemoveTrack);
-        this.receiver = undefined;
-        this._currentBitrate = 0;
-        this.emit(TrackEvent.Ended, this);
-      }
+    stream.onremovetrack = () => {
+      this.receiver = undefined;
+      this._currentBitrate = 0;
+      this.emit(TrackEvent.Ended, this);
     };
-    stream.addEventListener('removetrack', onRemoveTrack);
   }
 
   start() {


### PR DESCRIPTION
Reverts livekit/client-sdk-js#843