### PR TITLE
Make KeyProvider and ParticipantKeyHandler work consistently for shared key and sender key scenarios (e2ee)

### DIFF
--- a/.changeset/quiet-buses-appear.md
+++ b/.changeset/quiet-buses-appear.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Make KeyProvider and ParticipantKeyHandler work consistently for shared key and sender key scenarios (e2ee)

--- a/src/e2ee/KeyProvider.ts
+++ b/src/e2ee/KeyProvider.ts
@@ -24,12 +24,12 @@ export class BaseKeyProvider extends (EventEmitter as new () => TypedEventEmitte
   /**
    * callback to invoke once a key has been set for a participant
    * @param key
-   * @param participantId
+   * @param participantIdentity
    * @param keyIndex
    */
-  protected onSetEncryptionKey(key: CryptoKey, participantId?: string, keyIndex?: number) {
-    const keyInfo: KeyInfo = { key, participantId, keyIndex };
-    this.keyInfoMap.set(`${participantId ?? 'shared'}-${keyIndex ?? 0}`, keyInfo);
+  protected onSetEncryptionKey(key: CryptoKey, participantIdentity?: string, keyIndex?: number) {
+    const keyInfo: KeyInfo = { key, participantIdentity, keyIndex };
+    this.keyInfoMap.set(`${participantIdentity ?? 'shared'}-${keyIndex ?? 0}`, keyInfo);
     this.emit(KeyProviderEvent.SetKey, keyInfo);
   }
 
@@ -51,8 +51,8 @@ export class BaseKeyProvider extends (EventEmitter as new () => TypedEventEmitte
     return this.options;
   }
 
-  ratchetKey(participantId?: string, keyIndex?: number) {
-    this.emit(KeyProviderEvent.RatchetRequest, participantId, keyIndex);
+  ratchetKey(participantIdentity?: string, keyIndex?: number) {
+    this.emit(KeyProviderEvent.RatchetRequest, participantIdentity, keyIndex);
   }
 }
 
@@ -80,7 +80,7 @@ export class ExternalE2EEKeyProvider extends BaseKeyProvider {
   /**
    * Accepts a passphrase that's used to create the crypto keys.
    * When passing in a string, PBKDF2 is used.
-   * Also accepts an Array buffer of cryptographically random numbers that uses HKDF.
+   * When passing in an Array buffer of cryptographically random numbers, HKDF is being used. (recommended)
    * @param key
    */
   async setKey(key: string | ArrayBuffer) {

--- a/src/e2ee/KeyProvider.ts
+++ b/src/e2ee/KeyProvider.ts
@@ -40,7 +40,7 @@ export class BaseKeyProvider extends (EventEmitter as new () => TypedEventEmitte
    * @param keyIndex
    */
   protected onKeyRatcheted = (material: CryptoKey, keyIndex?: number) => {
-    log.debug('key ratcheted event received', material, keyIndex);
+    log.debug('key ratcheted event received', { material, keyIndex });
   };
 
   getKeys() {

--- a/src/e2ee/KeyProvider.ts
+++ b/src/e2ee/KeyProvider.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
+import log from '../logger';
 import { KEY_PROVIDER_DEFAULTS } from './constants';
 import { type KeyProviderCallbacks, KeyProviderEvent } from './events';
 import type { KeyInfo, KeyProviderOptions } from './types';
@@ -39,7 +40,7 @@ export class BaseKeyProvider extends (EventEmitter as new () => TypedEventEmitte
    * @param keyIndex
    */
   protected onKeyRatcheted = (material: CryptoKey, keyIndex?: number) => {
-    console.debug('key ratcheted event received', material, keyIndex);
+    log.debug('key ratcheted event received', material, keyIndex);
   };
 
   getKeys() {
@@ -69,6 +70,7 @@ export class ExternalE2EEKeyProvider extends BaseKeyProvider {
       sharedKey: true,
       // for a shared key provider failing to decrypt for a specific participant
       // should not mark the key as invalid, so we accept wrong keys forever
+      // and won't try to auto-ratchet
       ratchetWindowSize: 0,
       failureTolerance: -1,
     };

--- a/src/e2ee/events.ts
+++ b/src/e2ee/events.ts
@@ -10,7 +10,7 @@ export enum KeyProviderEvent {
 
 export type KeyProviderCallbacks = {
   [KeyProviderEvent.SetKey]: (keyInfo: KeyInfo) => void;
-  [KeyProviderEvent.RatchetRequest]: (participantId?: string, keyIndex?: number) => void;
+  [KeyProviderEvent.RatchetRequest]: (participantIdentity?: string, keyIndex?: number) => void;
   [KeyProviderEvent.KeyRatcheted]: (material: CryptoKey, keyIndex?: number) => void;
 };
 
@@ -21,7 +21,7 @@ export enum KeyHandlerEvent {
 export type ParticipantKeyHandlerCallbacks = {
   [KeyHandlerEvent.KeyRatcheted]: (
     material: CryptoKey,
-    participantId: string,
+    participantIdentity: string,
     keyIndex?: number,
   ) => void;
 };

--- a/src/e2ee/events.ts
+++ b/src/e2ee/events.ts
@@ -1,0 +1,48 @@
+import type Participant from '../room/participant/Participant';
+import type { CryptorError } from './errors';
+import type { KeyInfo } from './types';
+
+export enum KeyProviderEvent {
+  SetKey = 'setKey',
+  RatchetRequest = 'ratchetRequest',
+  KeyRatcheted = 'keyRatcheted',
+}
+
+export type KeyProviderCallbacks = {
+  [KeyProviderEvent.SetKey]: (keyInfo: KeyInfo) => void;
+  [KeyProviderEvent.RatchetRequest]: (participantId?: string, keyIndex?: number) => void;
+  [KeyProviderEvent.KeyRatcheted]: (material: CryptoKey, keyIndex?: number) => void;
+};
+
+export enum KeyHandlerEvent {
+  KeyRatcheted = 'keyRatcheted',
+}
+
+export type ParticipantKeyHandlerCallbacks = {
+  [KeyHandlerEvent.KeyRatcheted]: (
+    material: CryptoKey,
+    participantId: string,
+    keyIndex?: number,
+  ) => void;
+};
+
+export enum EncryptionEvent {
+  ParticipantEncryptionStatusChanged = 'participantEncryptionStatusChanged',
+  EncryptionError = 'encryptionError',
+}
+
+export type E2EEManagerCallbacks = {
+  [EncryptionEvent.ParticipantEncryptionStatusChanged]: (
+    enabled: boolean,
+    participant: Participant,
+  ) => void;
+  [EncryptionEvent.EncryptionError]: (error: Error) => void;
+};
+
+export type CryptorCallbacks = {
+  [CryptorEvent.Error]: (error: CryptorError) => void;
+};
+
+export enum CryptorEvent {
+  Error = 'cryptorError',
+}

--- a/src/e2ee/index.ts
+++ b/src/e2ee/index.ts
@@ -1,3 +1,4 @@
 export * from './KeyProvider';
 export * from './utils';
 export * from './types';
+export * from './events';

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -16,7 +16,7 @@ export interface InitMessage extends BaseMessage {
 export interface SetKeyMessage extends BaseMessage {
   kind: 'setKey';
   data: {
-    participantId?: string;
+    participantIdentity?: string;
     isPublisher: boolean;
     key: CryptoKey;
     keyIndex?: number;
@@ -27,7 +27,7 @@ export interface RTPVideoMapMessage extends BaseMessage {
   kind: 'setRTPMap';
   data: {
     map: Map<number, VideoCodec>;
-    participantId: string;
+    participantIdentity: string;
   };
 }
 
@@ -41,7 +41,7 @@ export interface SifTrailerMessage extends BaseMessage {
 export interface EncodeMessage extends BaseMessage {
   kind: 'decode' | 'encode';
   data: {
-    participantId: string;
+    participantIdentity: string;
     readableStream: ReadableStream;
     writableStream: WritableStream;
     trackId: string;
@@ -52,7 +52,7 @@ export interface EncodeMessage extends BaseMessage {
 export interface RemoveTransformMessage extends BaseMessage {
   kind: 'removeTransform';
   data: {
-    participantId: string;
+    participantIdentity: string;
     trackId: string;
   };
 }
@@ -60,7 +60,7 @@ export interface RemoveTransformMessage extends BaseMessage {
 export interface UpdateCodecMessage extends BaseMessage {
   kind: 'updateCodec';
   data: {
-    participantId: string;
+    participantIdentity: string;
     trackId: string;
     codec: VideoCodec;
   };
@@ -69,7 +69,7 @@ export interface UpdateCodecMessage extends BaseMessage {
 export interface RatchetRequestMessage extends BaseMessage {
   kind: 'ratchetRequest';
   data: {
-    participantId?: string;
+    participantIdentity?: string;
     keyIndex?: number;
   };
 }
@@ -77,7 +77,7 @@ export interface RatchetRequestMessage extends BaseMessage {
 export interface RatchetMessage extends BaseMessage {
   kind: 'ratchetKey';
   data: {
-    participantId: string;
+    participantIdentity: string;
     keyIndex?: number;
     material: CryptoKey;
   };
@@ -93,7 +93,7 @@ export interface ErrorMessage extends BaseMessage {
 export interface EnableMessage extends BaseMessage {
   kind: 'enable';
   data: {
-    participantId: string;
+    participantIdentity: string;
     enabled: boolean;
   };
 }
@@ -130,7 +130,7 @@ export type KeyProviderOptions = {
 
 export type KeyInfo = {
   key: CryptoKey;
-  participantId?: string;
+  participantIdentity?: string;
   keyIndex?: number;
 };
 

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -1,7 +1,5 @@
-import type Participant from '../room/participant/Participant';
 import type { VideoCodec } from '../room/track/options';
 import type { BaseKeyProvider } from './KeyProvider';
-import type { CryptorError } from './errors';
 
 export interface BaseMessage {
   kind: string;
@@ -19,6 +17,7 @@ export interface SetKeyMessage extends BaseMessage {
   kind: 'setKey';
   data: {
     participantId?: string;
+    isPublisher: boolean;
     key: CryptoKey;
     keyIndex?: number;
   };
@@ -28,6 +27,7 @@ export interface RTPVideoMapMessage extends BaseMessage {
   kind: 'setRTPMap';
   data: {
     map: Map<number, VideoCodec>;
+    participantId: string;
   };
 }
 
@@ -69,7 +69,7 @@ export interface UpdateCodecMessage extends BaseMessage {
 export interface RatchetRequestMessage extends BaseMessage {
   kind: 'ratchetRequest';
   data: {
-    participantId: string | undefined;
+    participantId?: string;
     keyIndex?: number;
   };
 }
@@ -77,7 +77,7 @@ export interface RatchetRequestMessage extends BaseMessage {
 export interface RatchetMessage extends BaseMessage {
   kind: 'ratchetKey';
   data: {
-    // participantId: string | undefined;
+    participantId: string;
     keyIndex?: number;
     material: CryptoKey;
   };
@@ -93,8 +93,14 @@ export interface ErrorMessage extends BaseMessage {
 export interface EnableMessage extends BaseMessage {
   kind: 'enable';
   data: {
-    // if no participant id is set it indicates publisher encryption enable/disable
-    participantId?: string;
+    participantId: string;
+    enabled: boolean;
+  };
+}
+
+export interface InitAck extends BaseMessage {
+  kind: 'initAck';
+  data: {
     enabled: boolean;
   };
 }
@@ -110,7 +116,8 @@ export type E2EEWorkerMessage =
   | UpdateCodecMessage
   | RatchetRequestMessage
   | RatchetMessage
-  | SifTrailerMessage;
+  | SifTrailerMessage
+  | InitAck;
 
 export type KeySet = { material: CryptoKey; encryptionKey: CryptoKey };
 
@@ -120,35 +127,6 @@ export type KeyProviderOptions = {
   ratchetWindowSize: number;
   failureTolerance: number;
 };
-
-export type KeyProviderCallbacks = {
-  setKey: (keyInfo: KeyInfo) => void;
-  ratchetRequest: (participantId?: string, keyIndex?: number) => void;
-  /** currently only emitted for local participant */
-  keyRatcheted: (material: CryptoKey, keyIndex?: number) => void;
-};
-
-export type ParticipantKeyHandlerCallbacks = {
-  keyRatcheted: (material: CryptoKey, keyIndex?: number, participantId?: string) => void;
-};
-
-export type E2EEManagerCallbacks = {
-  participantEncryptionStatusChanged: (enabled: boolean, participant?: Participant) => void;
-  encryptionError: (error: Error) => void;
-};
-
-export const EncryptionEvent = {
-  ParticipantEncryptionStatusChanged: 'participantEncryptionStatusChanged',
-  Error: 'encryptionError',
-} as const;
-
-export type CryptorCallbacks = {
-  cryptorError: (error: CryptorError) => void;
-};
-
-export const CryptorEvent = {
-  Error: 'cryptorError',
-} as const;
 
 export type KeyInfo = {
   key: CryptoKey;

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -48,7 +48,7 @@ export class BaseFrameCryptor extends (EventEmitter as new () => TypedEventEmitt
 export class FrameCryptor extends BaseFrameCryptor {
   private sendCounts: Map<number, number>;
 
-  private participantId: string | undefined;
+  private participantIdentity: string | undefined;
 
   private trackId: string | undefined;
 
@@ -69,14 +69,14 @@ export class FrameCryptor extends BaseFrameCryptor {
 
   constructor(opts: {
     keys: ParticipantKeyHandler;
-    participantId: string;
+    participantIdentity: string;
     keyProviderOptions: KeyProviderOptions;
     sifTrailer?: Uint8Array;
   }) {
     super();
     this.sendCounts = new Map();
     this.keys = opts.keys;
-    this.participantId = opts.participantId;
+    this.participantIdentity = opts.participantIdentity;
     this.rtpMap = new Map();
     this.keyProviderOptions = opts.keyProviderOptions;
     this.sifTrailer = opts.sifTrailer ?? Uint8Array.from([]);
@@ -90,25 +90,25 @@ export class FrameCryptor extends BaseFrameCryptor {
    * @param keys
    */
   setParticipant(id: string, keys: ParticipantKeyHandler) {
-    this.participantId = id;
+    this.participantIdentity = id;
     this.keys = keys;
     this.sifGuard.reset();
   }
 
   unsetParticipant() {
-    this.participantId = undefined;
+    this.participantIdentity = undefined;
   }
 
   isEnabled() {
-    if (this.participantId) {
-      return encryptionEnabledMap.get(this.participantId);
+    if (this.participantIdentity) {
+      return encryptionEnabledMap.get(this.participantIdentity);
     } else {
       return undefined;
     }
   }
 
-  getParticipantId() {
-    return this.participantId;
+  getParticipantIdentity() {
+    return this.participantIdentity;
   }
 
   getTrackId() {
@@ -198,7 +198,9 @@ export class FrameCryptor extends BaseFrameCryptor {
     const keySet = this.keys.getKeySet();
     if (!keySet) {
       throw new TypeError(
-        `key set not found for ${this.participantId} at index ${this.keys.getCurrentKeyIndex()}`,
+        `key set not found for ${
+          this.participantIdentity
+        } at index ${this.keys.getCurrentKeyIndex()}`,
       );
     }
     const { encryptionKey } = keySet;
@@ -313,7 +315,7 @@ export class FrameCryptor extends BaseFrameCryptor {
             this.emit(
               CryptorEvent.Error,
               new CryptorError(
-                `invalid key for participant ${this.participantId}`,
+                `invalid key for participant ${this.participantIdentity}`,
                 CryptorErrorReason.InvalidKey,
               ),
             );
@@ -329,7 +331,7 @@ export class FrameCryptor extends BaseFrameCryptor {
       this.emit(
         CryptorEvent.Error,
         new CryptorError(
-          `missing key at index for participant ${this.participantId}`,
+          `missing key at index for participant ${this.participantIdentity}`,
           CryptorErrorReason.MissingKey,
         ),
       );
@@ -348,7 +350,7 @@ export class FrameCryptor extends BaseFrameCryptor {
   ): Promise<RTCEncodedVideoFrame | RTCEncodedAudioFrame | undefined> {
     const keySet = this.keys.getKeySet(keyIndex);
     if (!ratchetOpts.encryptionKey && !keySet) {
-      throw new TypeError(`no encryption key found for decryption of ${this.participantId}`);
+      throw new TypeError(`no encryption key found for decryption of ${this.participantIdentity}`);
     }
 
     // Construct frame trailer. Similar to the frame header described in
@@ -440,7 +442,7 @@ export class FrameCryptor extends BaseFrameCryptor {
 
           workerLogger.warn('maximum ratchet attempts exceeded');
           throw new CryptorError(
-            `valid key missing for participant ${this.participantId}`,
+            `valid key missing for participant ${this.participantIdentity}`,
             CryptorErrorReason.InvalidKey,
           );
         }

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -6,16 +6,13 @@ import { workerLogger } from '../../logger';
 import type { VideoCodec } from '../../room/track/options';
 import { ENCRYPTION_ALGORITHM, IV_LENGTH, UNENCRYPTED_BYTES } from '../constants';
 import { CryptorError, CryptorErrorReason } from '../errors';
-import {
-  CryptorCallbacks,
-  CryptorEvent,
-  DecodeRatchetOptions,
-  KeyProviderOptions,
-  KeySet,
-} from '../types';
+import { CryptorCallbacks, CryptorEvent } from '../events';
+import type { DecodeRatchetOptions, KeyProviderOptions, KeySet } from '../types';
 import { deriveKeys, isVideoFrame } from '../utils';
 import type { ParticipantKeyHandler } from './ParticipantKeyHandler';
 import { SifGuard } from './SifGuard';
+
+export const encryptionEnabledMap: Map<string, boolean> = new Map();
 
 export interface FrameCryptorConstructor {
   new (opts?: unknown): BaseFrameCryptor;
@@ -29,14 +26,14 @@ export interface TransformerInfo {
 }
 
 export class BaseFrameCryptor extends (EventEmitter as new () => TypedEventEmitter<CryptorCallbacks>) {
-  encodeFunction(
+  protected encodeFunction(
     encodedFrame: RTCEncodedVideoFrame | RTCEncodedAudioFrame,
     controller: TransformStreamDefaultController,
   ): Promise<any> {
     throw Error('not implemented for subclass');
   }
 
-  decodeFunction(
+  protected decodeFunction(
     encodedFrame: RTCEncodedVideoFrame | RTCEncodedAudioFrame,
     controller: TransformStreamDefaultController,
   ): Promise<any> {
@@ -102,6 +99,14 @@ export class FrameCryptor extends BaseFrameCryptor {
     this.participantId = undefined;
   }
 
+  isEnabled() {
+    if (this.participantId) {
+      return encryptionEnabledMap.get(this.participantId);
+    } else {
+      return undefined;
+    }
+  }
+
   getParticipantId() {
     return this.participantId;
   }
@@ -148,9 +153,13 @@ export class FrameCryptor extends BaseFrameCryptor {
       .pipeTo(writable)
       .catch((e) => {
         workerLogger.warn(e);
-        this.emit('cryptorError', e instanceof CryptorError ? e : new CryptorError(e.message));
+        this.emit(CryptorEvent.Error, e instanceof CryptorError ? e : new CryptorError(e.message));
       });
     this.trackId = trackId;
+  }
+
+  setSifTrailer(trailer: Uint8Array) {
+    this.sifTrailer = trailer;
   }
 
   /**
@@ -175,19 +184,24 @@ export class FrameCryptor extends BaseFrameCryptor {
    * 8) Append a single byte for the key identifier.
    * 9) Enqueue the encrypted frame for sending.
    */
-  async encodeFunction(
+  protected async encodeFunction(
     encodedFrame: RTCEncodedVideoFrame | RTCEncodedAudioFrame,
     controller: TransformStreamDefaultController,
   ) {
     if (
-      !this.keys.isEnabled() ||
+      !this.isEnabled() ||
       // skip for encryption for empty dtx frames
       encodedFrame.data.byteLength === 0
     ) {
       return controller.enqueue(encodedFrame);
     }
-
-    const { encryptionKey } = this.keys.getKeySet();
+    const keySet = this.keys.getKeySet();
+    if (!keySet) {
+      throw new TypeError(
+        `key set not found for ${this.participantId} at index ${this.keys.getCurrentKeyIndex()}`,
+      );
+    }
+    const { encryptionKey } = keySet;
     const keyIndex = this.keys.getCurrentKeyIndex();
 
     if (encryptionKey) {
@@ -258,12 +272,12 @@ export class FrameCryptor extends BaseFrameCryptor {
    * @param {RTCEncodedVideoFrame|RTCEncodedAudioFrame} encodedFrame - Encoded video frame.
    * @param {TransformStreamDefaultController} controller - TransportStreamController.
    */
-  async decodeFunction(
+  protected async decodeFunction(
     encodedFrame: RTCEncodedVideoFrame | RTCEncodedAudioFrame,
     controller: TransformStreamDefaultController,
   ) {
     if (
-      !this.keys.isEnabled() ||
+      !this.isEnabled() ||
       // skip for decryption for empty dtx frames
       encodedFrame.data.byteLength === 0
     ) {
@@ -296,7 +310,6 @@ export class FrameCryptor extends BaseFrameCryptor {
       } catch (error) {
         if (error instanceof CryptorError && error.reason === CryptorErrorReason.InvalidKey) {
           if (this.keys.hasValidKey) {
-            workerLogger.warn('invalid key');
             this.emit(
               CryptorEvent.Error,
               new CryptorError(
@@ -327,13 +340,16 @@ export class FrameCryptor extends BaseFrameCryptor {
    * Function that will decrypt the given encoded frame. If the decryption fails, it will
    * ratchet the key for up to RATCHET_WINDOW_SIZE times.
    */
-  async decryptFrame(
+  private async decryptFrame(
     encodedFrame: RTCEncodedVideoFrame | RTCEncodedAudioFrame,
     keyIndex: number,
     initialMaterial: KeySet | undefined = undefined,
     ratchetOpts: DecodeRatchetOptions = { ratchetCount: 0 },
   ): Promise<RTCEncodedVideoFrame | RTCEncodedAudioFrame | undefined> {
     const keySet = this.keys.getKeySet(keyIndex);
+    if (!ratchetOpts.encryptionKey && !keySet) {
+      throw new TypeError(`no encryption key found for decryption of ${this.participantId}`);
+    }
 
     // Construct frame trailer. Similar to the frame header described in
     // https://tools.ietf.org/html/draft-omara-sframe-00#section-4.2
@@ -369,7 +385,7 @@ export class FrameCryptor extends BaseFrameCryptor {
           iv,
           additionalData: new Uint8Array(encodedFrame.data, 0, frameHeader.byteLength),
         },
-        ratchetOpts.encryptionKey ?? keySet.encryptionKey,
+        ratchetOpts.encryptionKey ?? keySet!.encryptionKey,
         new Uint8Array(encodedFrame.data, cipherTextStart, cipherTextLength),
       );
 
@@ -422,7 +438,7 @@ export class FrameCryptor extends BaseFrameCryptor {
             this.keys.setKeyFromMaterial(initialMaterial.material, keyIndex);
           }
 
-          workerLogger.warn('maximum ratchet attempts exceeded, resetting key');
+          workerLogger.warn('maximum ratchet attempts exceeded');
           throw new CryptorError(
             `valid key missing for participant ${this.participantId}`,
             CryptorErrorReason.InvalidKey,
@@ -477,7 +493,7 @@ export class FrameCryptor extends BaseFrameCryptor {
     return iv;
   }
 
-  getUnencryptedBytes(frame: RTCEncodedVideoFrame | RTCEncodedAudioFrame): number {
+  private getUnencryptedBytes(frame: RTCEncodedVideoFrame | RTCEncodedAudioFrame): number {
     if (isVideoFrame(frame)) {
       let detectedCodec = this.getVideoCodec(frame) ?? this.videoCodec;
 
@@ -526,7 +542,7 @@ export class FrameCryptor extends BaseFrameCryptor {
   /**
    * inspects frame payloadtype if available and maps it to the codec specified in rtpMap
    */
-  getVideoCodec(frame: RTCEncodedVideoFrame): VideoCodec | undefined {
+  private getVideoCodec(frame: RTCEncodedVideoFrame): VideoCodec | undefined {
     if (this.rtpMap.size === 0) {
       return undefined;
     }
@@ -534,10 +550,6 @@ export class FrameCryptor extends BaseFrameCryptor {
     const payloadType = frame.getMetadata().payloadType;
     const codec = payloadType ? this.rtpMap.get(payloadType) : undefined;
     return codec;
-  }
-
-  setSifTrailer(trailer: Uint8Array) {
-    this.sifTrailer = trailer;
   }
 }
 

--- a/src/e2ee/worker/ParticipantKeyHandler.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.ts
@@ -87,10 +87,6 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
     }
     const ratchetPromise = new Promise<CryptoKey>(async (resolve, reject) => {
       try {
-        console.log(
-          `accessing key set for ${this.participantId}: at index ${currentKeyIndex}`,
-          this.cryptoKeyRing[currentKeyIndex],
-        );
         const keySet = this.getKeySet(currentKeyIndex);
         if (!keySet) {
           throw new TypeError(
@@ -147,7 +143,6 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
 
   setKeySet(keySet: KeySet, keyIndex: number, emitRatchetEvent = false) {
     this.cryptoKeyRing[keyIndex % this.cryptoKeyRing.length] = keySet;
-    console.log('set kexy', this.cryptoKeyRing[keyIndex]);
 
     if (emitRatchetEvent) {
       this.emit(KeyHandlerEvent.KeyRatcheted, keySet.material, this.participantId, keyIndex);

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -77,10 +77,8 @@ onmessage = (ev) => {
       if (useSharedKey) {
         workerLogger.debug('set shared key');
         setSharedKey(data.key, data.keyIndex);
-      } else if (data.participantId) {
-        getParticipantKeyHandler(data.participantId).setKey(data.key, data.keyIndex);
       } else {
-        workerLogger.error('no participant Id was provided and shared key usage is disabled');
+        getParticipantKeyHandler(data.participantId).setKey(data.key, data.keyIndex);
       }
       break;
     case 'removeTransform':

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -211,7 +211,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
 
       this.clientConfiguration = joinResponse.clientConfiguration;
-
+      console.log('joinresp', joinResponse);
       return joinResponse;
     } catch (e) {
       if (e instanceof ConnectionError) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -211,7 +211,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
 
       this.clientConfiguration = joinResponse.clientConfiguration;
-      console.log('joinresp', joinResponse);
       return joinResponse;
     } catch (e) {
       if (e instanceof ConnectionError) {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -209,10 +209,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    */
   async setE2EEEnabled(enabled: boolean) {
     if (this.e2eeManager) {
-      await Promise.all([
-        this.localParticipant.setE2EEEnabled(enabled),
-        this.e2eeManager.setParticipantCryptorEnabled(enabled),
-      ]);
+      await Promise.all([this.localParticipant.setE2EEEnabled(enabled)]);
+      if (this.localParticipant.identity !== '') {
+        this.e2eeManager.setParticipantCryptorEnabled(enabled, this.localParticipant.identity);
+      }
     } else {
       throw Error('e2ee not configured, please set e2ee settings within the room options');
     }
@@ -230,7 +230,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           this.emit(RoomEvent.ParticipantEncryptionStatusChanged, enabled, participant);
         },
       );
-      this.e2eeManager.on(EncryptionEvent.Error, (error) =>
+      this.e2eeManager.on(EncryptionEvent.EncryptionError, (error) =>
         this.emit(RoomEvent.EncryptionError, error),
       );
       this.e2eeManager?.setup(this);

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -104,6 +104,10 @@ export default class LocalParticipant extends Participant {
     return this.microphoneError;
   }
 
+  get isE2EEEnabled(): boolean {
+    return this.encryptionType !== Encryption_Type.NONE;
+  }
+
   getTrack(source: Track.Source): LocalTrackPublication | undefined {
     const track = super.getTrack(source);
     if (track) {


### PR DESCRIPTION
main motivation for these fixes was an inconsistency in setting the local participant's keys, which expected the participantId to be `undefined`. This caused a bug when trying to set individual sender keys instead of using a shared-key provider.
Initially this was done because when `setKey` on a KeyProvider was called, we had no way of figuring out whether or not that participant is actually the local participant, until we're connected to the server and have the participant identity info. 

This PR
- replaces strings with dedicated event enums in e2ee event emitters
- introduces a `enabledEncryptionMap` that tracks whether or not encryption is enabled for a specific participant (previously this was handled as part of the `ParticipantKeyHandler`)
- updates local participant encryption keys on `SignalConnected` (the earliest we know the identity without manually parsing the token)
- introduces a dedicated `initAck` worker message in order not to have to mis-use the existing `enable` message for that purpose
- uses a dedicated `sharedKeyHandler` that handles all key interactions when `sharedKey` is set to true. Previously an instance was created for each participant, but in the shared key scenario that makes less sense. the only downside is that ratcheting doesn't work independently now, but I don't really see a reason in the shared key scenario for ratcheting anyways.