### PR TITLE
Remove legacy code paths for tracks arriving before participant info

### DIFF
--- a/.changeset/eight-ravens-enjoy.md
+++ b/.changeset/eight-ravens-enjoy.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Remove legacy code paths for tracks arriving before participant info

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1025,7 +1025,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       log.warn('tried to create RemoteParticipant for local participant');
       return;
     }
-    const participant = this.getOrCreateParticipant(participantId);
+
+    const participant = this.participants.get(participantId) as RemoteParticipant | undefined;
+
+    if (!participant) {
+      throw new TypeError(
+        `Tried to add a track for a participant, that's not present. Sid: ${participantId}`,
+      );
+    }
 
     let adaptiveStreamSettings: AdaptiveStreamSettings | undefined;
     if (this.options.adaptiveStream) {
@@ -1445,20 +1452,17 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     return participant;
   }
 
-  private getOrCreateParticipant(id: string, info?: ParticipantInfo): RemoteParticipant {
+  private getOrCreateParticipant(id: string, info: ParticipantInfo): RemoteParticipant {
     if (this.participants.has(id)) {
       return this.participants.get(id) as RemoteParticipant;
     }
-    // it's possible for the RTC track to arrive before signaling data
-    // when this happens, we'll create the participant and make the track work
     const participant = this.createParticipant(id, info);
     this.participants.set(id, participant);
-    if (info) {
-      this.identityToSid.set(info.identity, info.sid);
-      // if we have valid info and the participant wasn't in the map before, we can assume the participant is new
-      // firing here to make sure that `ParticipantConnected` fires before the initial track events
-      this.emitWhenConnected(RoomEvent.ParticipantConnected, participant);
-    }
+
+    this.identityToSid.set(info.identity, info.sid);
+    // if we have valid info and the participant wasn't in the map before, we can assume the participant is new
+    // firing here to make sure that `ParticipantConnected` fires before the initial track events
+    this.emitWhenConnected(RoomEvent.ParticipantConnected, participant);
 
     // also forward events
     // trackPublished is only fired for tracks added after both local participant

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1029,9 +1029,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     const participant = this.participants.get(participantId) as RemoteParticipant | undefined;
 
     if (!participant) {
-      throw new TypeError(
+      log.error(
         `Tried to add a track for a participant, that's not present. Sid: ${participantId}`,
       );
+      return;
     }
 
     let adaptiveStreamSettings: AdaptiveStreamSettings | undefined;


### PR DESCRIPTION
livekit server ensures that participant info arrives before the media track. This PR removes the code paths that handle tracks arriving first and logs an error if that's not the case. 