### PR TITLE
Un-comment red option

### DIFF
--- a/.changeset/strange-ears-collect.md
+++ b/.changeset/strange-ears-collect.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix opus RED publishing option not taking effect

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -312,13 +312,7 @@ export class FrameCryptor extends BaseFrameCryptor {
       } catch (error) {
         if (error instanceof CryptorError && error.reason === CryptorErrorReason.InvalidKey) {
           if (this.keys.hasValidKey) {
-            this.emit(
-              CryptorEvent.Error,
-              new CryptorError(
-                `invalid key for participant ${this.participantIdentity}`,
-                CryptorErrorReason.InvalidKey,
-              ),
-            );
+            this.emit(CryptorEvent.Error, error);
             this.keys.decryptionFailure();
           }
         } else {
@@ -448,7 +442,7 @@ export class FrameCryptor extends BaseFrameCryptor {
         }
       } else {
         throw new CryptorError(
-          'Decryption failed, most likely because of an invalid key',
+          `Decryption failed: ${error.message}`,
           CryptorErrorReason.InvalidKey,
         );
       }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -649,7 +649,7 @@ export default class LocalParticipant extends Participant {
       disableDtx: !(opts.dtx ?? true),
       encryption: this.encryptionType,
       stereo: isStereo,
-      // disableRed: !(opts.red ?? true),
+      disableRed: !(opts.red ?? true),
     });
 
     // compute encodings and layers for video


### PR DESCRIPTION
This has been wrongfully commented out since the big e2ee PR was merged. 

Cryptor change is only about emitting the actual error message.