### PR TITLE
Fix callback loop with metadata updates

### DIFF
--- a/.changeset/violet-ants-help.md
+++ b/.changeset/violet-ants-help.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix infinite metadata loop when canUpdateOwnMetadata is granted

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -178,7 +178,7 @@ export default class LocalParticipant extends Participant {
    * @param metadata
    */
   setMetadata(metadata: string): void {
-    super.setMetadata(metadata);
+    this.metadata = metadata;
     this.engine.client.sendUpdateLocalMetadata(metadata, this.name ?? '');
   }
 
@@ -188,7 +188,7 @@ export default class LocalParticipant extends Participant {
    * @param metadata
    */
   setName(name: string): void {
-    super.setName(name);
+    this.name = name;
     this.engine.client.sendUpdateLocalMetadata(this.metadata ?? '', name);
   }
 

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -169,8 +169,8 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     }
     this.identity = info.identity;
     this.sid = info.sid;
-    this.setName(info.name);
-    this.setMetadata(info.metadata);
+    this._setName(info.name);
+    this._setMetadata(info.metadata);
     if (info.permission) {
       this.setPermissions(info.permission);
     }
@@ -180,8 +180,10 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     return true;
   }
 
-  /** @internal */
-  setMetadata(md: string) {
+  /**
+   * Updates metadata from server
+   **/
+  protected _setMetadata(md: string) {
     const changed = this.metadata !== md;
     const prevMetadata = this.metadata;
     this.metadata = md;
@@ -191,7 +193,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     }
   }
 
-  protected setName(name: string) {
+  protected _setName(name: string) {
     const changed = this.name !== name;
     this.name = name;
 

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -183,7 +183,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   /**
    * Updates metadata from server
    **/
-  protected _setMetadata(md: string) {
+  private _setMetadata(md: string) {
     const changed = this.metadata !== md;
     const prevMetadata = this.metadata;
     this.metadata = md;
@@ -193,7 +193,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     }
   }
 
-  protected _setName(name: string) {
+  private _setName(name: string) {
     const changed = this.name !== name;
     this.name = name;
 


### PR DESCRIPTION
When canUpdateOwnMetadata grant is given to the participant, and metadata is updated remotely, it would throw the client into an invite loop in updating metadata with previous and current value.

This was really tricky to root cause. The way it happened was:
* RoomService.UpdateParticipant is called
* Participant.updateInfo called with new metadata
* LocalParticipant.setName called with the same name
  * setName triggers a `sendUpdateLocalMetadata` with previous metadata
* LocalParticipant.setMetadata called with new metadata
  * setMetadata triggers a `sendUpdateLocalMetadata` with new metadata
* Participant.updateInfo called with old metadata....