### PR TITLE
Fix vp9 svc encode failed for screenshare

### DIFF
--- a/.changeset/silver-swans-build.md
+++ b/.changeset/silver-swans-build.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix vp9 svc failed for screenshare

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -682,6 +682,10 @@ export default class LocalParticipant extends Participant {
       // for svc codecs, disable simulcast and use vp8 for backup codec
       if (track instanceof LocalVideoTrack) {
         if (isSVCCodec(opts.videoCodec)) {
+          // vp9 svc with screenshare has problem to encode, always use L1T3 here
+          if (track.source === Track.Source.ScreenShare && opts.videoCodec === 'vp9') {
+            opts.scalabilityMode = 'L1T3';
+          }
           // set scalabilityMode to 'L3T3_KEY' by default
           opts.scalabilityMode = opts.scalabilityMode ?? 'L3T3_KEY';
         }

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -298,9 +298,9 @@ export function isCodecEqual(c1: string | undefined, c2: string | undefined): bo
 }
 
 /**
- * scalability modes for svc, only supprot l3t3 now.
+ * scalability modes for svc.
  */
-export type ScalabilityMode = 'L3T3' | 'L3T3_KEY';
+export type ScalabilityMode = 'L1T3' | 'L2T3' | 'L2T3_KEY' | 'L3T3' | 'L3T3_KEY';
 
 export namespace AudioPresets {
   export const telephone: AudioPreset = {


### PR DESCRIPTION
VP9 SVC for screenshare has problem to encode with error `Failed to initialize the encoder associated with codec type: VP9 (2)`, use L1T3 mode for screenshare video track to fix it.