### PR TITLE
Do not constrain screenshare resolution by default

### DIFF
--- a/.changeset/fast-cows-melt.md
+++ b/.changeset/fast-cows-melt.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Do not constrain screenshare resolution by default

--- a/.changeset/fast-cows-melt.md
+++ b/.changeset/fast-cows-melt.md
@@ -1,5 +1,5 @@
 ---
-'livekit-client': patch
+'livekit-client': minor
 ---
 
 Do not constrain screenshare resolution by default

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -33,7 +33,7 @@ import type {
   TrackPublishOptions,
   VideoCaptureOptions,
 } from '../track/options';
-import { ScreenSharePresets, VideoPresets, isBackupCodec, isCodecEqual } from '../track/options';
+import { VideoPresets, isBackupCodec, isCodecEqual } from '../track/options';
 import {
   constraintsForOptions,
   mergeDefaultOptions,
@@ -443,9 +443,6 @@ export default class LocalParticipant extends Participant {
   async createScreenTracks(options?: ScreenShareCaptureOptions): Promise<Array<LocalTrack>> {
     if (options === undefined) {
       options = {};
-    }
-    if (options.resolution === undefined) {
-      options.resolution = ScreenSharePresets.h1080fps15.resolution;
     }
 
     if (navigator.mediaDevices.getDisplayMedia === undefined) {

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -153,7 +153,11 @@ export interface ScreenShareCaptureOptions {
    */
   video?: true | { displaySurface?: 'window' | 'browser' | 'monitor' };
 
-  /** capture resolution, defaults to full HD */
+  /**
+   * capture resolution, defaults to screen resolution
+   * NOTE: In Safari 17, specifying any resolution at all would lead to a low-resolution
+   * capture. https://bugs.webkit.org/show_bug.cgi?id=263015
+   */
   resolution?: VideoResolution;
 
   /** a CaptureController object instance containing methods that can be used to further manipulate the capture session if included. */


### PR DESCRIPTION
This will allow us to capture at the original resolution and avoid resizing. It also helps to workaround a Safari 17 bug where setting a resolution constraint leads to a 480p capture.

https://bugs.webkit.org/show_bug.cgi?id=263015