### PR TITLE
Do not allow VP9 publishing on FF

### DIFF
--- a/.changeset/seven-carpets-exist.md
+++ b/.changeset/seven-carpets-exist.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Do not support VP9 publishing for FF

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -61,6 +61,9 @@ export function supportsAV1(): boolean {
 
 export function supportsVP9(): boolean {
   if (!('getCapabilities' in RTCRtpSender)) {
+    return false;
+  }
+  if (isFireFox()) {
     // technically speaking FireFox supports VP9, but SVC publishing is broken
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1633876
     return false;


### PR DESCRIPTION
Since FF does not support SVC, and we require SVC for VP9, it will not be able to support VP9 publishing.

Previously FF didn't support `getCapabilities`, so supportsVP9 check was passing for it. As much as I hate browser checks, there isn't another way to check for SVC publishing.