### PR TITLE
Guard against overriding newly set key when auto-ratcheting

### DIFF
--- a/.changeset/curvy-rules-worry.md
+++ b/.changeset/curvy-rules-worry.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Guard against overriding newly set key when auto-ratcheting

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -447,7 +447,7 @@ export class FrameCryptor extends BaseFrameCryptor {
            * yet and ratcheting, of course, did not solve the problem. So if we fail RATCHET_WINDOW_SIZE times,
            * we come back to the initial key.
            */
-          if (initialMaterial) {
+          if (initialMaterial && keySet === this.keys.getKeySet(keyIndex)) {
             workerLogger.debug('resetting to initial material');
             this.keys.setKeyFromMaterial(initialMaterial.material, keyIndex);
           }

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -431,9 +431,13 @@ export class FrameCryptor extends BaseFrameCryptor {
             encryptionKey: ratchetedKeySet?.encryptionKey,
           });
           if (frame && ratchetedKeySet) {
-            this.keys.setKeySet(ratchetedKeySet, keyIndex, true);
-            // decryption was successful, set the new key index to reflect the ratcheted key set
-            this.keys.setCurrentKeyIndex(keyIndex);
+            // before updating the keys, make sure that the keySet used for this frame is still the same as the currently set key
+            // if it's not, a new key might have been set already, which we don't want to override
+            if (keySet === this.keys.getKeySet(keyIndex)) {
+              this.keys.setKeySet(ratchetedKeySet, keyIndex, true);
+              // decryption was successful, set the new key index to reflect the ratcheted key set
+              this.keys.setCurrentKeyIndex(keyIndex);
+            }
           }
           return frame;
         } else {

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -418,7 +418,7 @@ export class FrameCryptor extends BaseFrameCryptor {
           );
 
           let ratchetedKeySet: KeySet | undefined;
-          if (keySet === this.keys.getKeySet(keyIndex)) {
+          if ((initialMaterial ?? keySet) === this.keys.getKeySet(keyIndex)) {
             // only ratchet if the currently set key is still the same as the one used to decrypt this frame
             // if not, it might be that a different frame has already ratcheted and we try with that one first
             const newMaterial = await this.keys.ratchetKey(keyIndex, false);
@@ -433,7 +433,7 @@ export class FrameCryptor extends BaseFrameCryptor {
           if (frame && ratchetedKeySet) {
             // before updating the keys, make sure that the keySet used for this frame is still the same as the currently set key
             // if it's not, a new key might have been set already, which we don't want to override
-            if (keySet === this.keys.getKeySet(keyIndex)) {
+            if ((initialMaterial ?? keySet) === this.keys.getKeySet(keyIndex)) {
               this.keys.setKeySet(ratchetedKeySet, keyIndex, true);
               // decryption was successful, set the new key index to reflect the ratcheted key set
               this.keys.setCurrentKeyIndex(keyIndex);
@@ -442,15 +442,10 @@ export class FrameCryptor extends BaseFrameCryptor {
           return frame;
         } else {
           /**
-           * Since the key it is first send and only afterwards actually used for encrypting, there were
-           * situations when the decrypting failed due to the fact that the received frame was not encrypted
-           * yet and ratcheting, of course, did not solve the problem. So if we fail RATCHET_WINDOW_SIZE times,
-           * we come back to the initial key.
+           * Because we only set a new key once decryption has been successful,
+           * we can be sure that we don't need to reset the key to the initial material at this point
+           * as the key has not been updated on the keyHandler instance
            */
-          if (initialMaterial && keySet === this.keys.getKeySet(keyIndex)) {
-            workerLogger.debug('resetting to initial material');
-            this.keys.setKeyFromMaterial(initialMaterial.material, keyIndex);
-          }
 
           workerLogger.warn('maximum ratchet attempts exceeded');
           throw new CryptorError(


### PR DESCRIPTION
Before updating the keys after auto-ratcheting, we want to make sure that the keySet used for this frame is still the same as the currently set key. If it's not the same, a new key might have been set already, which we don't want to override with a ratcheted version. 