### PR TITLE
Make peerconnection private on PCTransport

### DIFF
--- a/.changeset/moody-nails-flash.md
+++ b/.changeset/moody-nails-flash.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Make peerconnection private on PCTransport

--- a/src/connectionHelper/checks/webrtc.ts
+++ b/src/connectionHelper/checks/webrtc.ts
@@ -39,7 +39,7 @@ export class WebRTCCheck extends Checker {
       };
 
       if (this.room.engine.subscriber) {
-        this.room.engine.subscriber.pc.onicecandidateerror = (ev) => {
+        this.room.engine.subscriber.onIceCandidateError = (ev) => {
           if (ev instanceof RTCPeerConnectionIceErrorEvent) {
             this.appendWarning(
               `error with ICE candidate: ${ev.errorCode} ${ev.errorText} ${ev.url}`,

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -53,6 +53,8 @@ export default class PCTransport extends EventEmitter {
 
   onIceCandidate?: (candidate: RTCIceCandidate) => void;
 
+  onIceCandidateError?: (ev: Event) => void;
+
   onConnectionStateChange?: (state: RTCPeerConnectionState) => void;
 
   onDataChannel?: (ev: RTCDataChannelEvent) => void;
@@ -68,6 +70,9 @@ export default class PCTransport extends EventEmitter {
     this._pc.onicecandidate = (ev) => {
       if (!ev.candidate) return;
       this.onIceCandidate?.(ev.candidate);
+    };
+    this._pc.onicecandidateerror = (ev) => {
+      this.onIceCandidateError?.(ev);
     };
     this._pc.onconnectionstatechange = () => {
       this.onConnectionStateChange?.(this._pc?.connectionState ?? 'closed');

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1546,14 +1546,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   }
 
   private sendSyncState() {
-    if (
-      this.engine.subscriber === undefined ||
-      this.engine.subscriber.pc.localDescription === null
-    ) {
+    const previousAnswer = this.engine.subscriber?.getLocalDescription();
+    const previousOffer = this.engine.subscriber?.getRemoteDescription();
+
+    if (!previousAnswer) {
       return;
     }
-    const previousAnswer = this.engine.subscriber.pc.localDescription;
-    const previousOffer = this.engine.subscriber.pc.remoteDescription;
 
     /* 1. autosubscribe on, so subscribed tracks = all tracks - unsub tracks,
           in this case, we send unsub tracks, so server add all tracks to this

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -889,6 +889,7 @@ export default class LocalParticipant extends Participant {
         {
           codec: opts.videoCodec,
           cid: simulcastTrack.mediaStreamTrack.id,
+          enableSimulcastLayers: opts.simulcast,
         },
       ],
     });

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -799,7 +799,7 @@ export default class LocalParticipant extends Participant {
            fix the issue.
          */
         let trackTransceiver: RTCRtpTransceiver | undefined = undefined;
-        for (const transceiver of this.engine.publisher.pc.getTransceivers()) {
+        for (const transceiver of this.engine.publisher.getTransceivers()) {
           if (transceiver.sender === track.sender) {
             trackTransceiver = transceiver;
             break;
@@ -889,7 +889,6 @@ export default class LocalParticipant extends Participant {
         {
           codec: opts.videoCodec,
           cid: simulcastTrack.mediaStreamTrack.id,
-          enableSimulcastLayers: opts.simulcast,
         },
       ],
     });
@@ -947,11 +946,11 @@ export default class LocalParticipant extends Participant {
     track.sender = undefined;
     if (
       this.engine.publisher &&
-      this.engine.publisher.pc.connectionState !== 'closed' &&
+      this.engine.publisher.getConnectionState() !== 'closed' &&
       trackSender
     ) {
       try {
-        for (const transceiver of this.engine.publisher.pc.getTransceivers()) {
+        for (const transceiver of this.engine.publisher.getTransceivers()) {
           // if sender is not currently sending (after replaceTrack(null))
           // removeTrack would have no effect.
           // to ensure we end up successfully removing the track, manually set


### PR DESCRIPTION
First preparation step for connection handling refactor. 
Aim of this PR is to make access to the underlying PC of PCTransport explicit by hiding the PC object and exposing dedicated methods for access.