### PR TITLE
Fix a race in setKeyFromMaterial

### DIFF
--- a/.changeset/selfish-eagles-learn.md
+++ b/.changeset/selfish-eagles-learn.md
@@ -2,4 +2,4 @@
 'livekit-client': patch
 ---
 
-Fix arace in setKeyFromMaterial that would cause keys to be set at the wrong index if several keys were set in quick succession.
+Fix a race in setKeyFromMaterial that would cause keys to be set at the wrong index if several keys were set in quick succession.

--- a/.changeset/selfish-eagles-learn.md
+++ b/.changeset/selfish-eagles-learn.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix arace in setKeyFromMaterial that would cause keys to be set at the wrong index if several keys were set in quick succession.

--- a/src/e2ee/worker/ParticipantKeyHandler.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.ts
@@ -138,12 +138,11 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
    * also updates the currentKeyIndex
    */
   async setKeyFromMaterial(material: CryptoKey, keyIndex = 0, emitRatchetEvent = false) {
-    workerLogger.debug('setting new key');
-    if (keyIndex >= 0) {
-      this.currentKeyIndex = keyIndex % this.cryptoKeyRing.length;
-    }
+    const newIndex = keyIndex >= 0 ? keyIndex % this.cryptoKeyRing.length : -1;
+    workerLogger.debug(`setting new key with index ${newIndex}`);
     const keySet = await deriveKeys(material, this.keyProviderOptions.ratchetSalt);
-    this.setKeySet(keySet, this.currentKeyIndex, emitRatchetEvent);
+    this.setKeySet(keySet, newIndex >= 0 ? newIndex : this.currentKeyIndex, emitRatchetEvent);
+    if (newIndex >= 0) this.currentKeyIndex = newIndex;
   }
 
   setKeySet(keySet: KeySet, keyIndex: number, emitRatchetEvent = false) {


### PR DESCRIPTION
this.currentKeyIndex was set prior to await-ing, so if several keys were set in quick succession, they would all be set at the index of the last one.

This makes the function a little more complex but maintains the behaviour of setting the key at `this.currentKeyIndex` if the function is called with a negative number, although with this version it will use the value of `this.currentKeyIndex` *after* the await. An alternative fix would be to just move the setting of `this.currentKeyIndex` to after the `await`: I figured perhaps this was a little more explicit, but I don't mind.

Also expanded the log line to include the index being set.