### PR TITLE
Set encodedInsertableStreams also for reconnect response

### DIFF
--- a/.changeset/soft-sheep-occur.md
+++ b/.changeset/soft-sheep-occur.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix reconnect when E2EE is enabled

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -997,6 +997,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       const res = await this.client.reconnect(this.url, this.token, this.participantSid, reason);
       if (res) {
         const rtcConfig = this.makeRTCConfiguration(res);
+        if (this.signalOpts?.e2eeEnabled) {
+          log.debug('E2EE - setting up transports with insertable streams for reconnect');
+          //  this makes sure that no data is sent before the transforms are ready
+          // @ts-ignore
+          rtcConfig.encodedInsertableStreams = true;
+        }
         this.publisher.setConfiguration(rtcConfig);
         this.subscriber.setConfiguration(rtcConfig);
       }
@@ -1004,6 +1010,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       let message = '';
       if (e instanceof Error) {
         message = e.message;
+        log.error(e.message);
       }
       if (e instanceof ConnectionError && e.reason === ConnectionErrorReason.NotAllowed) {
         throw new UnexpectedConnectionState('could not reconnect, token might be expired');

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -523,7 +523,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   private makeRTCConfiguration(serverResponse: JoinResponse | ReconnectResponse): RTCConfiguration {
     const rtcConfig = { ...this.rtcConfig };
     if (this.signalOpts?.e2eeEnabled) {
-      log.debug('E2EE - setting up transports with insertable streams for reconnect');
+      log.debug('E2EE - setting up transports with insertable streams');
       //  this makes sure that no data is sent before the transforms are ready
       // @ts-ignore
       rtcConfig.encodedInsertableStreams = true;

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -374,13 +374,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     const rtcConfig = this.makeRTCConfiguration(joinResponse);
 
-    if (this.signalOpts?.e2eeEnabled) {
-      log.debug('E2EE - setting up transports with insertable streams');
-      //  this makes sure that no data is sent before the transforms are ready
-      // @ts-ignore
-      rtcConfig.encodedInsertableStreams = true;
-    }
-
     const googConstraints = { optional: [{ googDscp: true }] };
     this.publisher = new PCTransport(rtcConfig, googConstraints);
     this.subscriber = new PCTransport(rtcConfig);
@@ -529,6 +522,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
   private makeRTCConfiguration(serverResponse: JoinResponse | ReconnectResponse): RTCConfiguration {
     const rtcConfig = { ...this.rtcConfig };
+    if (this.signalOpts?.e2eeEnabled) {
+      log.debug('E2EE - setting up transports with insertable streams for reconnect');
+      //  this makes sure that no data is sent before the transforms are ready
+      // @ts-ignore
+      rtcConfig.encodedInsertableStreams = true;
+    }
 
     // update ICE servers before creating PeerConnection
     if (serverResponse.iceServers && !rtcConfig.iceServers) {
@@ -997,12 +996,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       const res = await this.client.reconnect(this.url, this.token, this.participantSid, reason);
       if (res) {
         const rtcConfig = this.makeRTCConfiguration(res);
-        if (this.signalOpts?.e2eeEnabled) {
-          log.debug('E2EE - setting up transports with insertable streams for reconnect');
-          //  this makes sure that no data is sent before the transforms are ready
-          // @ts-ignore
-          rtcConfig.encodedInsertableStreams = true;
-        }
+
         this.publisher.setConfiguration(rtcConfig);
         this.subscriber.setConfiguration(rtcConfig);
       }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -996,7 +996,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       const res = await this.client.reconnect(this.url, this.token, this.participantSid, reason);
       if (res) {
         const rtcConfig = this.makeRTCConfiguration(res);
-
         this.publisher.setConfiguration(rtcConfig);
         this.subscriber.setConfiguration(rtcConfig);
       }


### PR DESCRIPTION
chrome would throw a DOM exception `Failed to execute 'setConfiguration' on 'RTCPeerConnection': Attempted to modify the PeerConnection's configuration in an unsupported way` if `setConfiguration` doesn't include the `encodedInsertableStrams` option when updated at a later time and when it was initially present when setting up the PC. 
This caused reconnects to fail when e2ee is enabled.
This PR moves setting the option into `makeRTCConfiguration` in order to also set it on the reconnect response if e2ee is enabled. 