### PR TITLE
Correctly apply elementVolume on attach for webaudioMix

### DIFF
--- a/.changeset/dirty-parrots-kneel.md
+++ b/.changeset/dirty-parrots-kneel.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Correctly apply elementVolume on attach for webaudioMix

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -101,9 +101,7 @@ export default class RemoteAudioTrack extends RemoteTrack {
     } else {
       super.attach(element);
     }
-    if (this.elementVolume) {
-      element.volume = this.elementVolume;
-    }
+
     if (this.sinkId && supportsSetSinkId(element)) {
       /* @ts-ignore */
       element.setSinkId(this.sinkId);
@@ -114,6 +112,12 @@ export default class RemoteAudioTrack extends RemoteTrack {
       element.volume = 0;
       element.muted = true;
     }
+
+    if (this.elementVolume) {
+      // make sure volume setting is being applied to the newly attached element
+      this.setVolume(this.elementVolume);
+    }
+
     return element;
   }
 


### PR DESCRIPTION
Previously when attaching an element we did not honor the webaudioMix setting and would only set the volume on the element. 
This PR fixes this by calling `setVolume` directly to make sure we set the volume correctly for both modes html audio playback and webaudio mix