### PR TITLE
Simplify Multi-Codec Simulcast usage by setting backupCodec to true

### DIFF
--- a/.changeset/pretty-geese-draw.md
+++ b/.changeset/pretty-geese-draw.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Simplify multi-codec simulcast usage, backupCodec: true

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -78,7 +78,7 @@ const appActions = {
     const autoSubscribe = (<HTMLInputElement>$('auto-subscribe')).checked;
     const e2eeEnabled = (<HTMLInputElement>$('e2ee')).checked;
 
-    setLogLevel(LogLevel.info);
+    setLogLevel(LogLevel.debug);
     updateSearchParams(url, token, cryptoKey);
 
     const roomOpts: RoomOptions = {
@@ -103,7 +103,7 @@ const appActions = {
       roomOpts.publishDefaults?.videoCodec === 'av1' ||
       roomOpts.publishDefaults?.videoCodec === 'vp9'
     ) {
-      roomOpts.publishDefaults.backupCodec = { codec: 'vp8', encoding: VideoPresets.h720.encoding };
+      roomOpts.publishDefaults.backupCodec = true;
     }
 
     const connectOpts: RoomConnectOptions = {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -692,7 +692,11 @@ export default class LocalParticipant extends Participant {
         ];
 
         // set up backup
+        if (opts.backupCodec === true) {
+          opts.backupCodec = { codec: 'vp8' };
+        }
         if (opts.backupCodec && videoCodec !== opts.backupCodec.codec) {
+          // multi-codec simulcast requires dynacast
           if (!this.roomOptions.dynacast) {
             this.roomOptions.dynacast = true;
           }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -693,7 +693,7 @@ export default class LocalParticipant extends Participant {
 
         // set up backup
         if (opts.backupCodec === true) {
-          opts.backupCodec = { codec: 'vp8' };
+          opts.backupCodec = { codec: defaultVideoCodec };
         }
         if (opts.backupCodec && videoCodec !== opts.backupCodec.codec) {
           // multi-codec simulcast requires dynacast

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -190,7 +190,12 @@ export function computeTrackBackupEncodings(
   videoCodec: BackupVideoCodec,
   opts: TrackPublishOptions,
 ) {
-  if (!opts.backupCodec || opts.backupCodec.codec === opts.videoCodec) {
+  // backupCodec should not be true anymore, default codec is set in LocalParticipant.publish
+  if (
+    !opts.backupCodec ||
+    opts.backupCodec === true ||
+    opts.backupCodec.codec === opts.videoCodec
+  ) {
     // backup codec publishing is disabled
     return;
   }

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -7,9 +7,15 @@ export interface TrackPublishDefaults {
   videoEncoding?: VideoEncoding;
 
   /**
-   * @experimental
+   * Multi-codec Simulcast
+   * VP9 and AV1 are not supported by all browser clients. When backupCodec is
+   * set, when an incompatible client attempts to subscribe to the track, LiveKit
+   * will automatically publish a secondary track encoded with the backup codec.
+   *
+   * You could customize specific encoding parameters of the backup track by
+   * explicitly setting codec and encoding fields.
    */
-  backupCodec?: { codec: BackupVideoCodec; encoding: VideoEncoding } | false;
+  backupCodec?: true | false | { codec: BackupVideoCodec; encoding?: VideoEncoding };
 
   /**
    * encoding parameters for screen share track


### PR DESCRIPTION
Currently it requires too many parameters to turn on the feature. The defaults were also dependent on input resolution. Making this optional and picking sane defaults.