### PR TITLE
Add getStats() to PCTransport

### DIFF
--- a/.changeset/strange-mails-smile.md
+++ b/.changeset/strange-mails-smile.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Add getStats() to PCTransport

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -354,6 +354,10 @@ export default class PCTransport extends EventEmitter {
     return this.pc.remoteDescription;
   }
 
+  getStats() {
+    return this.pc.getStats();
+  }
+
   async getConnectedAddress(): Promise<string | undefined> {
     if (!this._pc) {
       return;


### PR DESCRIPTION
We used to manually collect and analyze PeerConnection stats like this:

```
room.engine.publisher.pc.getStats();
```

However, this became unavailable with the changes in #903, So, we wanted to add a way to call getStats() as an alternative.