### PR TITLE
Treat all signal messages as ping response

### DIFF
--- a/.changeset/healthy-pillows-own.md
+++ b/.changeset/healthy-pillows-own.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Treat all signal messages as ping response

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -558,6 +558,8 @@ export class SignalClient {
       log.debug('received unsupported message');
       return;
     }
+
+    let pingHandled = false;
     if (msg.case === 'answer') {
       const sd = fromProtoSessionDescription(msg.value);
       if (this.onAnswer) {
@@ -626,12 +628,16 @@ export class SignalClient {
         this.onSubscriptionError(msg.value);
       }
     } else if (msg.case === 'pong') {
-      this.resetPingTimeout();
     } else if (msg.case === 'pongResp') {
       this.rtt = Date.now() - Number.parseInt(msg.value.lastPingTimestamp.toString());
       this.resetPingTimeout();
+      pingHandled = true;
     } else {
       log.debug('unsupported message', msg);
+    }
+
+    if (!pingHandled) {
+      this.resetPingTimeout();
     }
   }
 


### PR DESCRIPTION
In cases of rooms that are highly active, it's possible to have a lot of signal messages queued that it blocks the ping messages for awhile.

Since the purpose of ping/pong is to ensure signal channel is active, it makes sense to use any type of signal traffic as that indicator of liveliness.