### PR TITLE
Change publishData signature

### DIFF
--- a/.changeset/plenty-sloths-rule.md
+++ b/.changeset/plenty-sloths-rule.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": major
+---
+
+Change publishData signature

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1044,7 +1044,7 @@ export default class LocalParticipant extends Participant {
    */
   async publishData(data: Uint8Array, options: DataPublishOptions = {}): Promise<void> {
     const kind = options.reliable ? DataPacket_Kind.RELIABLE : DataPacket_Kind.LOSSY;
-    const destination = options.destination;
+    const destination = options.destinations;
     const topic = options.topic;
 
     const destinationIdentities: Array<string> = [];

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -44,7 +44,6 @@ import { Future, isFireFox, isSVCCodec, isSafari, isWeb, supportsAV1, supportsVP
 import Participant from './Participant';
 import type { ParticipantTrackPermission } from './ParticipantTrackPermission';
 import { trackPermissionToProto } from './ParticipantTrackPermission';
-import RemoteParticipant from './RemoteParticipant';
 import {
   computeTrackBackupEncodings,
   computeVideoEncodings,
@@ -1044,20 +1043,8 @@ export default class LocalParticipant extends Participant {
    */
   async publishData(data: Uint8Array, options: DataPublishOptions = {}): Promise<void> {
     const kind = options.reliable ? DataPacket_Kind.RELIABLE : DataPacket_Kind.LOSSY;
-    const destination = options.destinations;
+    const destinationIdentities = options.destinationIdentities;
     const topic = options.topic;
-
-    const destinationIdentities: Array<string> = [];
-
-    if (destination !== undefined) {
-      destination.forEach((val) => {
-        if (val instanceof RemoteParticipant) {
-          destinationIdentities.push(val.identity);
-        } else {
-          destinationIdentities.push(val);
-        }
-      });
-    }
 
     const packet = new DataPacket({
       kind: kind,

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1040,64 +1040,33 @@ export default class LocalParticipant extends Participant {
    * participant in the room if the destination field in publishOptions is empty
    *
    * @param data Uint8Array of the payload. To send string data, use TextEncoder.encode
-   * @param kind whether to send this as reliable or lossy.
-   * For data that you need delivery guarantee (such as chat messages), use Reliable.
-   * For data that should arrive as quickly as possible, but you are ok with dropped
-   * packets, use Lossy.
-   * @param publishOptions optionally specify a `topic` and `destination`
+   * @param options optionally specify a `reliable`, `topic` and `destination`
    */
-  async publishData(
-    data: Uint8Array,
-    kind: DataPacket_Kind,
-    publishOptions?: DataPublishOptions,
-  ): Promise<void>;
-  /**
-   * Publish a new data payload to the room. Data will be forwarded to each
-   * participant in the room if the destination argument is empty
-   *
-   * @param data Uint8Array of the payload. To send string data, use TextEncoder.encode
-   * @param kind whether to send this as reliable or lossy.
-   * For data that you need delivery guarantee (such as chat messages), use Reliable.
-   * For data that should arrive as quickly as possible, but you are ok with dropped
-   * packets, use Lossy.
-   * @param destination the participants who will receive the message
-   */
-  async publishData(
-    data: Uint8Array,
-    kind: DataPacket_Kind,
-    destination?: RemoteParticipant[] | string[],
-  ): Promise<void>;
+  async publishData(data: Uint8Array, options: DataPublishOptions = {}): Promise<void> {
+    const kind = options.reliable ? DataPacket_Kind.RELIABLE : DataPacket_Kind.LOSSY;
+    const destination = options.destination;
+    const topic = options.topic;
 
-  async publishData(
-    data: Uint8Array,
-    kind: DataPacket_Kind,
-    publishOptions: DataPublishOptions | RemoteParticipant[] | string[] = {},
-  ) {
-    const destination = Array.isArray(publishOptions)
-      ? publishOptions
-      : publishOptions?.destination;
-    const destinationSids: string[] = [];
-
-    const topic = !Array.isArray(publishOptions) ? publishOptions.topic : undefined;
+    const destinationIdentities: Array<string> = [];
 
     if (destination !== undefined) {
-      destination.forEach((val: any) => {
+      destination.forEach((val) => {
         if (val instanceof RemoteParticipant) {
-          destinationSids.push(val.sid);
+          destinationIdentities.push(val.identity);
         } else {
-          destinationSids.push(val);
+          destinationIdentities.push(val);
         }
       });
     }
 
     const packet = new DataPacket({
-      kind,
+      kind: kind,
       value: {
         case: 'user',
         value: new UserPacket({
-          participantSid: this.sid,
+          participantIdentity: this.identity,
           payload: data,
-          destinationSids: destinationSids,
+          destinationIdentities,
           topic,
         }),
       },

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -22,10 +22,11 @@ export type DataPublishOptions = {
    * packets, use Lossy.
    */
   reliable?: boolean;
-  /** the participants who will receive the message, will be sent to every one if empty
+  /**
+   * the participants who will receive the message, will be sent to every one if empty
    * accepts an array of participant identities or the participant objects
    */
-  destination?: RemoteParticipant[] | string[];
+  destinations?: RemoteParticipant[] | string[];
   /** the topic under which the message gets published */
   topic?: string;
 };

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -1,5 +1,3 @@
-import type RemoteParticipant from './participant/RemoteParticipant';
-
 export type SimulationOptions = {
   publish?: {
     audio?: boolean;
@@ -23,10 +21,9 @@ export type DataPublishOptions = {
    */
   reliable?: boolean;
   /**
-   * the participants who will receive the message, will be sent to every one if empty
-   * accepts an array of participant identities or the participant objects
+   * the identities of participants who will receive the message, will be sent to every one if empty
    */
-  destinations?: RemoteParticipant[] | string[];
+  destinationIdentities?: string[];
   /** the topic under which the message gets published */
   topic?: string;
 };

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -15,7 +15,16 @@ export type SimulationOptions = {
 };
 
 export type DataPublishOptions = {
-  /** the participants who will receive the message, will be sent to every one if empty */
+  /**
+   * whether to send this as reliable or lossy.
+   * For data that you need delivery guarantee (such as chat messages), use Reliable.
+   * For data that should arrive as quickly as possible, but you are ok with dropped
+   * packets, use Lossy.
+   */
+  reliable?: boolean;
+  /** the participants who will receive the message, will be sent to every one if empty
+   * accepts an array of participant identities or the participant objects
+   */
   destination?: RemoteParticipant[] | string[];
   /** the topic under which the message gets published */
   topic?: string;


### PR DESCRIPTION
I think for this one we'll have to live with a hard change as we simultaneously want to switch from using `sids` to `identities` which I don't think we could easily do in a backwards compatible way in a deprecation step. (We'd need to figure out if the user intends to set sids or identities)