### PR TITLE
Make sure all client callbacks are set up after reconnect

### DIFF
--- a/.changeset/honest-fans-laugh.md
+++ b/.changeset/honest-fans-laugh.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Make sure all signal client callbacks are set up for a reconnect

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -31,10 +31,12 @@ import {
   type ReconnectResponse,
   SignalTarget,
   type StreamStateUpdate,
+  SubscribedQualityUpdate,
   type SubscriptionPermissionUpdate,
   type SubscriptionResponse,
   SyncState,
   type TrackPublishedResponse,
+  TrackUnpublishedResponse,
   UpdateSubscription,
 } from '../proto/livekit_rtc_pb';
 import PCTransport, { PCEvents } from './PCTransport';
@@ -439,6 +441,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     this.client.onTokenRefresh = (token: string) => {
       this.token = token;
+    };
+
+    this.client.onRemoteMuteChanged = (trackSid: string, muted: boolean) => {
+      this.emit(EngineEvent.RemoteMute, trackSid, muted);
+    };
+
+    this.client.onSubscribedQualityUpdate = (update: SubscribedQualityUpdate) => {
+      this.emit(EngineEvent.SubscribedQualityUpdate, update);
     };
 
     this.client.onClose = () => {
@@ -1320,4 +1330,7 @@ export type EngineEventCallbacks = {
   streamStateChanged: (update: StreamStateUpdate) => void;
   subscriptionError: (resp: SubscriptionResponse) => void;
   subscriptionPermissionUpdate: (update: SubscriptionPermissionUpdate) => void;
+  subscribedQualityUpdate: (update: SubscribedQualityUpdate) => void;
+  localTrackUnpublished: (unpublishedResponse: TrackUnpublishedResponse) => void;
+  remoteMute: (trackSid: string, muted: boolean) => void;
 };

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -486,6 +486,9 @@ export enum EngineEvent {
   ConnectionQualityUpdate = 'connectionQualityUpdate',
   SubscriptionError = 'subscriptionError',
   SubscriptionPermissionUpdate = 'subscriptionPermissionUpdate',
+  RemoteMute = 'remoteMute',
+  SubscribedQualityUpdate = 'subscribedQualityUpdate',
+  LocalTrackUnpublished = 'localTrackUnpublished',
 }
 
 export enum TrackEvent {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -127,7 +127,7 @@ export default class LocalParticipant extends Participant {
    */
   setupEngine(engine: RTCEngine) {
     this.engine = engine;
-    this.engine.client.onRemoteMuteChanged = (trackSid: string, muted: boolean) => {
+    this.engine.on(EngineEvent.RemoteMute, (trackSid: string, muted: boolean) => {
       const pub = this.tracks.get(trackSid);
       if (!pub || !pub.track) {
         return;
@@ -137,11 +137,7 @@ export default class LocalParticipant extends Participant {
       } else {
         pub.unmute();
       }
-    };
-
-    this.engine.client.onSubscribedQualityUpdate = this.handleSubscribedQualityUpdate;
-
-    this.engine.client.onLocalTrackUnpublished = this.handleLocalTrackUnpublished;
+    });
 
     this.engine
       .on(EngineEvent.Connected, this.handleReconnected)
@@ -149,6 +145,8 @@ export default class LocalParticipant extends Participant {
       .on(EngineEvent.SignalResumed, this.handleReconnected)
       .on(EngineEvent.Restarting, this.handleReconnecting)
       .on(EngineEvent.Resuming, this.handleReconnecting)
+      .on(EngineEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished)
+      .on(EngineEvent.SubscribedQualityUpdate, this.handleSubscribedQualityUpdate)
       .on(EngineEvent.Disconnected, this.handleDisconnected);
   }
 


### PR DESCRIPTION
closes #965, attempts to fix the same issue without compromising on the cleanup of the callbacks. 