### PR TITLE
Add support for async room sid

### DIFF
--- a/.changeset/modern-pandas-exist.md
+++ b/.changeset/modern-pandas-exist.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": major
+---
+
+Add support for async room sid. Removes `room.sid` and replaces it with `await room.getSid()`.

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -265,9 +265,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         }
       };
       this.engine.on(EngineEvent.RoomUpdate, handleRoomUpdate);
-      this.once(RoomEvent.Disconnected, () =>
-        reject('Room disconnected before room server id was available'),
-      );
+      this.once(RoomEvent.Disconnected, () => {
+        this.engine.off(EngineEvent.RoomUpdate, handleRoomUpdate);
+        reject('Room disconnected before room server id was available');
+      });
     });
   }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,4 @@
 import { version as v } from '../package.json';
 
 export const version = v;
-export const protocolVersion = 11;
+export const protocolVersion = 12;


### PR DESCRIPTION
Removes `room.sid` and replaces it with `await room.getSid()`.