### PR TITLE
Add class level configurable logger

### DIFF
--- a/.changeset/eleven-poets-own.md
+++ b/.changeset/eleven-poets-own.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Add class level configurable logger

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -1,5 +1,5 @@
 import { protoInt64 } from '@bufbuild/protobuf';
-import log, { getLogger } from '../logger';
+import log, { LoggerNames, getLogger } from '../logger';
 import {
   ClientInfo,
   DisconnectReason,
@@ -174,7 +174,7 @@ export class SignalClient {
 
   private log = log;
 
-  constructor(useJSON: boolean = false, loggerName = 'livekit-signal') {
+  constructor(useJSON: boolean = false, loggerName: string = LoggerNames.Signal) {
     this.log = getLogger(loggerName);
     this.useJSON = useJSON;
     this.requestQueue = new AsyncQueue();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { LogLevel, setLogExtension, setLogLevel } from './logger';
+import { LogLevel, getLogger, setLogExtension, setLogLevel } from './logger';
 import { DataPacket_Kind, DisconnectReason, VideoQuality } from './proto/livekit_models_pb';
 import DefaultReconnectPolicy from './room/DefaultReconnectPolicy';
 import Room, { ConnectionState, RoomState } from './room/Room';
@@ -55,6 +55,7 @@ export {
   supportsVP9,
   createAudioAnalyser,
   LogLevel,
+  getLogger,
   Room,
   ConnectionState,
   RoomState,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,7 +11,7 @@ export enum LogLevel {
 
 type LogLevelString = keyof typeof LogLevel;
 
-type StructuredLogger = {
+export type StructuredLogger = {
   trace: (msg: string, context?: object) => void;
   debug: (msg: string, context?: object) => void;
   info: (msg: string, context?: object) => void;
@@ -20,11 +20,17 @@ type StructuredLogger = {
   setDefaultLevel: (level: log.LogLevelDesc) => void;
 };
 
-const livekitLogger = log.getLogger('livekit');
+let livekitLogger = log.getLogger('livekit');
 
 livekitLogger.setDefaultLevel(LogLevel.info);
 
 export default livekitLogger as StructuredLogger;
+
+export function getLogger(name: string) {
+  const logger = log.getLogger(name);
+  logger.setDefaultLevel(livekitLogger.getLevel());
+  return logger as StructuredLogger;
+}
 
 export function setLogLevel(level: LogLevel | LogLevelString, loggerName?: 'livekit' | 'lk-e2ee') {
   if (loggerName) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,6 +9,19 @@ export enum LogLevel {
   silent = 5,
 }
 
+export enum LoggerNames {
+  Default = 'livekit',
+  Room = 'livekit-room',
+  Participant = 'livekit-participant',
+  Track = 'livekit-track',
+  Publication = 'livekit-track-publication',
+  Engine = 'livekit-engine',
+  Signal = 'livekit-signal',
+  PCManager = 'livekit-pc-manager',
+  PCTransport = 'livekit-pc-transport',
+  E2EE = 'lk-e2ee',
+}
+
 type LogLevelString = keyof typeof LogLevel;
 
 export type StructuredLogger = {
@@ -35,7 +48,7 @@ export function getLogger(name: string) {
   return logger as StructuredLogger;
 }
 
-export function setLogLevel(level: LogLevel | LogLevelString, loggerName?: 'livekit' | 'lk-e2ee') {
+export function setLogLevel(level: LogLevel | LogLevelString, loggerName?: LoggerNames) {
   if (loggerName) {
     log.getLogger(loggerName).setLevel(level);
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -92,6 +92,8 @@ export interface InternalRoomOptions {
    * @experimental
    */
   e2ee?: E2EEOptions;
+
+  loggerName?: string;
 }
 
 /**

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -76,10 +76,10 @@ export default class PCTransport extends EventEmitter {
   constructor(
     config?: RTCConfiguration,
     mediaConstraints: Record<string, unknown> = {},
-    logger: string = LoggerNames.PCTransport,
+    loggerName: string = LoggerNames.PCTransport,
   ) {
     super();
-    this.log = getLogger(logger);
+    this.log = getLogger(loggerName);
     this.config = config;
     this.mediaConstraints = mediaConstraints;
     this._pc = this.createPC();

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import type { MediaDescription } from 'sdp-transform';
 import { parse, write } from 'sdp-transform';
 import { debounce } from 'ts-debounce';
-import log, { getLogger } from '../logger';
+import log, { LoggerNames, getLogger } from '../logger';
 import { NegotiationError, UnexpectedConnectionState } from './errors';
 import { ddExtensionURI, isChromiumBased, isSVCCodec } from './utils';
 
@@ -76,7 +76,7 @@ export default class PCTransport extends EventEmitter {
   constructor(
     config?: RTCConfiguration,
     mediaConstraints: Record<string, unknown> = {},
-    logger = 'livekit-pc-transport',
+    logger: string = LoggerNames.PCTransport,
   ) {
     super();
     this.log = getLogger(logger);

--- a/src/room/PCTransportManager.ts
+++ b/src/room/PCTransportManager.ts
@@ -61,10 +61,10 @@ export class PCTransportManager {
   constructor(
     rtcConfig: RTCConfiguration,
     subscriberPrimary: boolean,
-    logger: string = LoggerNames.PCManager,
+    loggerName: string = LoggerNames.PCManager,
   ) {
-    if (logger) {
-      this.log = getLogger(logger);
+    if (loggerName) {
+      this.log = getLogger(loggerName);
     }
     this.isPublisherConnectionRequired = !subscriberPrimary;
     this.isSubscriberConnectionRequired = subscriberPrimary;

--- a/src/room/PCTransportManager.ts
+++ b/src/room/PCTransportManager.ts
@@ -1,4 +1,4 @@
-import log, { getLogger } from '../logger';
+import log, { LoggerNames, getLogger } from '../logger';
 import { SignalTarget } from '../proto/livekit_rtc_pb';
 import PCTransport, { PCEvents } from './PCTransport';
 import { roomConnectOptionDefaults } from './defaults';
@@ -61,7 +61,7 @@ export class PCTransportManager {
   constructor(
     rtcConfig: RTCConfiguration,
     subscriberPrimary: boolean,
-    logger = 'livekit-transport-manager',
+    logger: string = LoggerNames.PCManager,
   ) {
     if (logger) {
       this.log = getLogger(logger);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -7,7 +7,7 @@ import {
   SignalConnectionState,
   toProtoSessionDescription,
 } from '../api/SignalClient';
-import log from '../logger';
+import log, { getLogger } from '../logger';
 import type { InternalRoomOptions } from '../options';
 import {
   ClientConfigSetting,
@@ -162,9 +162,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
   private regionUrlProvider?: RegionUrlProvider;
 
+  private log = log;
+
   constructor(private options: InternalRoomOptions) {
     super();
-    this.client = new SignalClient();
+    this.log = getLogger(options.loggerName ?? 'livekit-engine');
+    this.client = new SignalClient(undefined, options.loggerName);
     this.client.signalLatency = this.options.expSignalLatency;
     this.reconnectPolicy = this.options.reconnectPolicy;
     this.registerOnLineListener();
@@ -220,7 +223,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     } catch (e) {
       if (e instanceof ConnectionError) {
         if (e.reason === ConnectionErrorReason.ServerUnreachable) {
-          log.warn(
+          this.log.warn(
             `Couldn't connect to server, attempt ${this.joinAttempts} of ${this.maxJoinAttempts}`,
           );
           if (this.joinAttempts < this.maxJoinAttempts) {
@@ -324,7 +327,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.pcManager!.removeTrack(sender);
       return true;
     } catch (e: unknown) {
-      log.warn('failed to remove track', { error: e, method: 'removeTrack' });
+      this.log.warn('failed to remove track', { error: e, method: 'removeTrack' });
     }
     return false;
   }
@@ -370,7 +373,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     this.pcManager.onDataChannel = this.handleDataChannel;
     this.pcManager.onStateChange = async (connectionState, publisherState, subscriberState) => {
-      log.debug(`primary PC state changed ${connectionState}`);
+      this.log.debug(`primary PC state changed ${connectionState}`);
       if (connectionState === PCTransportState.CONNECTED) {
         const shouldEmit = this.pcState === PCState.New;
         this.pcState = PCState.Connected;
@@ -404,7 +407,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       if (!this.pcManager) {
         return;
       }
-      log.debug('received server answer', {
+      this.log.debug('received server answer', {
         RTCSdpType: sd.type,
       });
       await this.pcManager.setPublisherAnswer(sd);
@@ -415,7 +418,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       if (!this.pcManager) {
         return;
       }
-      log.trace('got ICE candidate from peer', { candidate, target });
+      this.log.trace('got ICE candidate from peer', { candidate, target });
       this.pcManager.addIceCandidate(candidate, target);
     };
 
@@ -429,9 +432,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     };
 
     this.client.onLocalTrackPublished = (res: TrackPublishedResponse) => {
-      log.debug('received trackPublishedResponse', res);
+      this.log.debug('received trackPublishedResponse', res);
       if (!this.pendingTrackResolvers[res.cid]) {
-        log.error(`missing track resolver for ${res.cid}`);
+        this.log.error(`missing track resolver for ${res.cid}`);
         return;
       }
       const { resolve } = this.pendingTrackResolvers[res.cid];
@@ -464,7 +467,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         this.emit(EngineEvent.Disconnected, leave?.reason);
         this.close();
       }
-      log.trace('leave request', { leave });
+      this.log.trace('leave request', { leave });
     };
   }
 
@@ -472,7 +475,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     const rtcConfig = { ...this.rtcConfig };
 
     if (this.signalOpts?.e2eeEnabled) {
-      log.debug('E2EE - setting up transports with insertable streams');
+      this.log.debug('E2EE - setting up transports with insertable streams');
       //  this makes sure that no data is sent before the transforms are ready
       // @ts-ignore
       rtcConfig.encodedInsertableStreams = true;
@@ -562,7 +565,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     } else {
       return;
     }
-    log.debug(`on data channel ${channel.id}, ${channel.label}`);
+    this.log.debug(`on data channel ${channel.id}, ${channel.label}`);
     channel.onmessage = this.handleDataMessage;
   };
 
@@ -577,7 +580,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       } else if (message.data instanceof Blob) {
         buffer = await message.data.arrayBuffer();
       } else {
-        log.error('unsupported data type', message.data);
+        this.log.error('unsupported data type', message.data);
         return;
       }
       const dp = DataPacket.fromBinary(new Uint8Array(buffer));
@@ -598,9 +601,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     if (event instanceof ErrorEvent && event.error) {
       const { error } = event.error;
-      log.error(`DataChannel error on ${channelKind}: ${event.message}`, error);
+      this.log.error(`DataChannel error on ${channelKind}: ${event.message}`, error);
     } else {
-      log.error(`Unknown DataChannel error on ${channelKind}`, event);
+      this.log.error(`Unknown DataChannel error on ${channelKind}`, event);
     }
   };
 
@@ -622,7 +625,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
     const cap = RTCRtpSender.getCapabilities(kind);
     if (!cap) return;
-    log.debug('get capabilities', cap);
+    this.log.debug('get capabilities', cap);
     const matched: RTCRtpCodecCapability[] = [];
     const partialMatched: RTCRtpCodecCapability[] = [];
     const unmatched: RTCRtpCodecCapability[] = [];
@@ -666,7 +669,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       return sender;
     }
     if (supportsAddTrack()) {
-      log.warn('using add-track fallback');
+      this.log.warn('using add-track fallback');
       const sender = await this.createRTCRtpSender(track.mediaStreamTrack);
       return sender;
     }
@@ -684,7 +687,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       return this.createSimulcastTransceiverSender(track, simulcastTrack, opts, encodings);
     }
     if (supportsAddTrack()) {
-      log.debug('using add-track fallback');
+      this.log.debug('using add-track fallback');
       return this.createRTCRtpSender(track.mediaStreamTrack);
     }
 
@@ -764,14 +767,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       return;
     }
 
-    log.warn(`${connection} disconnected`);
+    this.log.warn(`${connection} disconnected`);
     if (this.reconnectAttempts === 0) {
       // only reset start time on the first try
       this.reconnectStart = Date.now();
     }
 
     const disconnect = (duration: number) => {
-      log.warn(
+      this.log.warn(
         `could not recover connection after ${this.reconnectAttempts} attempts, ${duration}ms. giving up`,
       );
       this.emit(EngineEvent.Disconnected);
@@ -792,7 +795,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       delay = 0;
     }
 
-    log.debug(`reconnecting in ${delay}ms`);
+    this.log.debug(`reconnecting in ${delay}ms`);
 
     this.clearReconnectTimeout();
     if (this.token && this.regionUrlProvider) {
@@ -836,7 +839,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.reconnectAttempts += 1;
       let recoverable = true;
       if (e instanceof UnexpectedConnectionState) {
-        log.debug('received unrecoverable error', { error: e });
+        this.log.debug('received unrecoverable error', { error: e });
         // unrecoverable
         recoverable = false;
       } else if (!(e instanceof SignalReconnectError)) {
@@ -847,7 +850,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       if (recoverable) {
         this.handleDisconnect('reconnect', ReconnectReason.RR_UNKNOWN);
       } else {
-        log.info(
+        this.log.info(
           `could not recover connection after ${this.reconnectAttempts} attempts, ${
             Date.now() - this.reconnectStart
           }ms. giving up`,
@@ -864,7 +867,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     try {
       return this.reconnectPolicy.nextRetryDelayInMs(context);
     } catch (e) {
-      log.warn('encountered error in reconnect policy', { error: e });
+      this.log.warn('encountered error in reconnect policy', { error: e });
     }
 
     // error in user code with provided reconnect policy, stop reconnecting
@@ -878,7 +881,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         throw new UnexpectedConnectionState('could not reconnect, url or token not saved');
       }
 
-      log.info(`reconnecting, attempt: ${this.reconnectAttempts}`);
+      this.log.info(`reconnecting, attempt: ${this.reconnectAttempts}`);
       this.emit(EngineEvent.Restarting);
 
       if (!this.client.isDisconnected) {
@@ -890,7 +893,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       let joinResponse: JoinResponse;
       try {
         if (!this.signalOpts) {
-          log.warn('attempted connection restart, without signal options present');
+          this.log.warn('attempted connection restart, without signal options present');
           throw new SignalReconnectError();
         }
         // in case a regionUrl is passed, the region URL takes precedence
@@ -937,7 +940,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       throw new UnexpectedConnectionState('publisher and subscriber connections unset');
     }
 
-    log.info(`resuming signal connection, attempt ${this.reconnectAttempts}`);
+    this.log.info(`resuming signal connection, attempt ${this.reconnectAttempts}`);
     this.emit(EngineEvent.Resuming);
 
     try {
@@ -951,7 +954,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       let message = '';
       if (e instanceof Error) {
         message = e.message;
-        log.error(e.message);
+        this.log.error(e.message);
       }
       if (e instanceof ConnectionError && e.reason === ConnectionErrorReason.NotAllowed) {
         throw new UnexpectedConnectionState('could not reconnect, token might be expired');
@@ -990,7 +993,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   private async waitForPCReconnected() {
     this.pcState = PCState.Reconnecting;
 
-    log.debug('waiting for peer connection to reconnect');
+    this.log.debug('waiting for peer connection to reconnect');
     try {
       await sleep(minReconnectWait); // FIXME setTimeout again not ideal for a connection critical path
       if (!this.pcManager) {
@@ -1136,7 +1139,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
       const handleClosed = () => {
         abortController.abort();
-        log.debug('engine disconnected while negotiation was ongoing');
+        this.log.debug('engine disconnected while negotiation was ongoing');
         resolve();
         return;
       };
@@ -1196,7 +1199,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** @internal */
   sendSyncState(remoteTracks: RemoteTrackPublication[], localTracks: LocalTrackPublication[]) {
     if (!this.pcManager) {
-      log.warn('sync state cannot be sent without peer connection setup');
+      this.log.warn('sync state cannot be sent without peer connection setup');
       return;
     }
     const previousAnswer = this.pcManager.subscriber.getLocalDescription();

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -193,7 +193,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.client.onStreamStateUpdate = (update) => this.emit(EngineEvent.StreamStateChanged, update);
   }
 
-  private get logContext() {
+  /** @internal */
+  get logContext() {
     return {
       room: this.latestJoinResponse?.room?.name,
       roomSid: this.latestJoinResponse?.room?.sid,

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -167,7 +167,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   constructor(private options: InternalRoomOptions) {
     super();
     this.log = getLogger(options.loggerName ?? LoggerNames.Engine);
-    this.client = new SignalClient(undefined, options.loggerName);
+    this.client = new SignalClient(undefined, {
+      loggerName: options.loggerName,
+      loggerContextCb: () => this.logContext,
+    });
     this.client.signalLatency = this.options.expSignalLatency;
     this.reconnectPolicy = this.options.reconnectPolicy;
     this.registerOnLineListener();

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -7,7 +7,7 @@ import {
   SignalConnectionState,
   toProtoSessionDescription,
 } from '../api/SignalClient';
-import log, { getLogger } from '../logger';
+import log, { LoggerNames, getLogger } from '../logger';
 import type { InternalRoomOptions } from '../options';
 import {
   ClientConfigSetting,
@@ -166,7 +166,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
   constructor(private options: InternalRoomOptions) {
     super();
-    this.log = getLogger(options.loggerName ?? 'livekit-engine');
+    this.log = getLogger(options.loggerName ?? LoggerNames.Engine);
     this.client = new SignalClient(undefined, options.loggerName);
     this.client.signalLatency = this.options.expSignalLatency;
     this.reconnectPolicy = this.options.reconnectPolicy;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -4,7 +4,7 @@ import type TypedEmitter from 'typed-emitter';
 import 'webrtc-adapter';
 import { EncryptionEvent } from '../e2ee';
 import { E2EEManager } from '../e2ee/E2eeManager';
-import log, { getLogger } from '../logger';
+import log, { LoggerNames, getLogger } from '../logger';
 import type {
   InternalRoomConnectOptions,
   InternalRoomOptions,
@@ -165,9 +165,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     this.identityToSid = new Map();
     this.options = { ...roomOptionDefaults, ...options };
 
-    if (this.options.loggerName) {
-      this.log = getLogger(this.options.loggerName);
-    }
+    this.log = getLogger(this.options.loggerName ?? LoggerNames.Room);
 
     this.options.audioCaptureDefaults = {
       ...audioDefaults,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -4,7 +4,7 @@ import type TypedEmitter from 'typed-emitter';
 import 'webrtc-adapter';
 import { EncryptionEvent } from '../e2ee';
 import { E2EEManager } from '../e2ee/E2eeManager';
-import log from '../logger';
+import log, { getLogger } from '../logger';
 import type {
   InternalRoomConnectOptions,
   InternalRoomOptions,
@@ -151,6 +151,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   private isVideoPlaybackBlocked: boolean = false;
 
+  private log = log;
+
   /**
    * Creates a new Room, the primary construct for a LiveKit session.
    * @param options
@@ -162,6 +164,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     this.cachedParticipantSids = [];
     this.identityToSid = new Map();
     this.options = { ...roomOptionDefaults, ...options };
+
+    if (this.options.loggerName) {
+      this.log = getLogger(this.options.loggerName);
+    }
 
     this.options.audioCaptureDefaults = {
       ...audioDefaults,
@@ -198,7 +204,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       this.switchActiveDevice(
         'audiooutput',
         unwrapConstraint(this.options.audioOutput.deviceId),
-      ).catch((e) => log.warn(`Could not set audio output: ${e.message}`));
+      ).catch((e) => this.log.warn(`Could not set audio output: ${e.message}`));
     }
 
     if (this.options.e2ee) {
@@ -362,7 +368,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.state !== ConnectionState.Disconnected) {
       return;
     }
-    log.debug(`prepareConnection to ${url}`);
+    this.log.debug(`prepareConnection to ${url}`);
     try {
       if (isCloud(new URL(url)) && token) {
         this.regionUrlProvider = new RegionUrlProvider(url, token);
@@ -372,13 +378,13 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         if (regionUrl && this.state === ConnectionState.Disconnected) {
           this.regionUrl = regionUrl;
           await fetch(toHttpUrl(regionUrl), { method: 'HEAD' });
-          log.debug(`prepared connection to ${regionUrl}`);
+          this.log.debug(`prepared connection to ${regionUrl}`);
         }
       } else {
         await fetch(toHttpUrl(url), { method: 'HEAD' });
       }
     } catch (e) {
-      log.warn('could not prepare connection', { error: e });
+      this.log.warn('could not prepare connection', { error: e });
     }
   }
 
@@ -388,7 +394,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
     if (this.state === ConnectionState.Connected) {
       // when the state is reconnecting or connected, this function returns immediately
-      log.info(`already connected to room ${this.name}`);
+      this.log.info(`already connected to room ${this.name}`);
       unlockDisconnect();
       return Promise.resolve();
     }
@@ -413,7 +419,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       // if initial connection fails, this will speed up picking regional url
       // on subsequent runs
       this.regionUrlProvider.fetchRegionSettings().catch((e) => {
-        log.warn('could not fetch region settings', { error: e });
+        this.log.warn('could not fetch region settings', { error: e });
       });
     }
 
@@ -460,7 +466,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             }
           }
           if (nextUrl) {
-            log.info(
+            this.log.info(
               `Initial connection failed with ConnectionError: ${e.message}. Retrying with another region: ${nextUrl}`,
             );
             await connectFn(resolve, reject, nextUrl);
@@ -517,7 +523,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       serverInfo = { version: joinResponse.serverVersion, region: joinResponse.serverRegion };
     }
 
-    log.debug(
+    this.log.debug(
       `connected to Livekit Server ${Object.entries(serverInfo)
         .map(([key, value]) => `${key}: ${value}`)
         .join(', ')}`,
@@ -528,7 +534,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
 
     if (joinResponse.serverVersion === '0.15.1' && this.options.dynacast) {
-      log.debug('disabling dynacast due to server version');
+      this.log.debug('disabling dynacast due to server version');
       // dynacast has a bug in 0.15.1, so we cannot use it then
       roomOptions.dynacast = false;
     }
@@ -561,7 +567,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     abortController: AbortController,
   ) => {
     if (this.state === ConnectionState.Reconnecting) {
-      log.info('Reconnection attempt replaced by new connection attempt');
+      this.log.info('Reconnection attempt replaced by new connection attempt');
       // make sure we close and recreate the existing engine in order to get rid of any potentially ongoing reconnection attempts
       this.recreateEngine();
     } else {
@@ -608,7 +614,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         resultingError.reason = err.reason;
         resultingError.status = err.status;
       }
-      log.debug(`error trying to establish signal connection`, { error: err });
+      this.log.debug(`error trying to establish signal connection`, { error: err });
       throw resultingError;
     }
 
@@ -651,16 +657,16 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     const unlock = await this.disconnectLock.lock();
     try {
       if (this.state === ConnectionState.Disconnected) {
-        log.debug('already disconnected');
+        this.log.debug('already disconnected');
         return;
       }
-      log.info('disconnect from room', { identity: this.localParticipant.identity });
+      this.log.info('disconnect from room', { identity: this.localParticipant.identity });
       if (
         this.state === ConnectionState.Connecting ||
         this.state === ConnectionState.Reconnecting
       ) {
         // try aborting pending connection attempt
-        log.warn('abort connection attempt');
+        this.log.warn('abort connection attempt');
         this.abortController?.abort();
         // in case the abort controller didn't manage to cancel the connection attempt, reject the connect promise explicitly
         this.connectFuture?.reject?.(new ConnectionError('Client initiated disconnect'));
@@ -886,7 +892,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         if (e.name === 'NotAllowedError') {
           this.handleVideoPlaybackFailed();
         } else {
-          log.warn(
+          this.log.warn(
             'Resuming video playback failed, make sure you call `startVideo` directly in a user gesture handler',
           );
         }
@@ -1052,7 +1058,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
     if (this.state === ConnectionState.Disconnected) {
-      log.warn('skipping incoming track after Room disconnected');
+      this.log.warn('skipping incoming track after Room disconnected');
       return;
     }
     const parts = unpackStreamId(stream.id);
@@ -1064,14 +1070,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (streamId && streamId.startsWith('TR')) trackId = streamId;
 
     if (participantId === this.localParticipant.sid) {
-      log.warn('tried to create RemoteParticipant for local participant');
+      this.log.warn('tried to create RemoteParticipant for local participant');
       return;
     }
 
     const participant = this.participants.get(participantId) as RemoteParticipant | undefined;
 
     if (!participant) {
-      log.error(
+      this.log.error(
         `Tried to add a track for a participant, that's not present. Sid: ${participantId}`,
       );
       return;
@@ -1107,7 +1113,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private handleSignalRestarted = async (joinResponse: JoinResponse) => {
-    log.debug(`signal reconnected to server`, {
+    this.log.debug(`signal reconnected to server`, {
       region: joinResponse.serverRegion,
     });
 
@@ -1136,12 +1142,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             ) {
               // we need to restart the track before publishing, often a full reconnect
               // is necessary because computer had gone to sleep.
-              log.debug('restarting existing track', {
+              this.log.debug('restarting existing track', {
                 track: pub.trackSid,
               });
               await track.restartTrack();
             }
-            log.debug('publishing new track', {
+            this.log.debug('publishing new track', {
               track: pub.trackSid,
             });
             await this.localParticipant.publishTrack(track, pub.options);
@@ -1149,12 +1155,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         }),
       );
     } catch (error) {
-      log.error('error trying to re-publish tracks after reconnection', { error });
+      this.log.error('error trying to re-publish tracks after reconnection', { error });
     }
 
     try {
       await this.engine.waitForRestarted();
-      log.debug(`fully reconnected to server`, {
+      this.log.debug(`fully reconnected to server`, {
         region: joinResponse.serverRegion,
       });
     } catch {
@@ -1411,7 +1417,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private handleAudioPlaybackFailed = (e: any) => {
-    log.warn('could not playback audio', e);
+    this.log.warn('could not playback audio', e);
     if (!this.canPlaybackAudio) {
       return;
     }
@@ -1480,7 +1486,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       try {
         await this.audioContext.resume();
       } catch (e: any) {
-        log.warn(e);
+        this.log.warn(e);
       }
     }
 
@@ -1502,7 +1508,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (info) {
       participant = RemoteParticipant.fromParticipantInfo(this.engine.client, info);
     } else {
-      participant = new RemoteParticipant(this.engine.client, id, '', undefined, undefined);
+      participant = new RemoteParticipant(
+        this.engine.client,
+        id,
+        '',
+        undefined,
+        undefined,
+        this.options,
+      );
     }
     if (this.options.expWebAudioMix) {
       participant.setAudioContext(this.audioContext);
@@ -1510,7 +1523,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.options.audioOutput?.deviceId) {
       participant
         .setAudioOutput(this.options.audioOutput)
-        .catch((e) => log.warn(`Could not set audio output: ${e.message}`));
+        .catch((e) => this.log.warn(`Could not set audio output: ${e.message}`));
     }
     return participant;
   }
@@ -1643,7 +1656,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         !this.engine.verifyTransport()
       ) {
         consecutiveFailures++;
-        log.warn('detected connection state mismatch', { numFailures: consecutiveFailures });
+        this.log.warn('detected connection state mismatch', { numFailures: consecutiveFailures });
         if (consecutiveFailures >= 3) {
           this.recreateEngine();
           this.handleDisconnect(
@@ -1799,7 +1812,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
                 true,
                 true,
               ),
+          undefined,
+          false,
+          this.options.loggerName,
         ),
+        this.options.loggerName,
       );
       // @ts-ignore
       this.localParticipant.addTrackPublication(camPub);
@@ -1817,7 +1834,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           publishOptions.useRealTracks
             ? (await navigator.mediaDevices.getUserMedia({ audio: true })).getAudioTracks()[0]
             : getEmptyAudioStreamTrack(),
+          undefined,
+          false,
+          this.audioContext,
+          this.options.loggerName,
         ),
+        this.options.loggerName,
       );
       // @ts-ignore
       this.localParticipant.addTrackPublication(audioPub);
@@ -1870,7 +1892,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   ): boolean {
     // active speaker updates are too spammy
     if (event !== RoomEvent.ActiveSpeakersChanged) {
-      log.debug(`room event ${event}`, { event, args });
+      this.log.debug(`room event ${event}`, { event, args });
     }
     return super.emit(event, ...args);
   }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1534,14 +1534,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (info) {
       participant = RemoteParticipant.fromParticipantInfo(this.engine.client, info);
     } else {
-      participant = new RemoteParticipant(
-        this.engine.client,
-        id,
-        '',
-        undefined,
-        undefined,
-        this.options,
-      );
+      participant = new RemoteParticipant(this.engine.client, id, '', undefined, undefined, {
+        loggerContextCb: () => this.logContext,
+        loggerName: this.options.loggerName,
+      });
     }
     if (this.options.expWebAudioMix) {
       participant.setAudioContext(this.audioContext);

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -534,7 +534,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       `connected to Livekit Server ${Object.entries(serverInfo)
         .map(([key, value]) => `${key}: ${value}`)
         .join(', ')}`,
-      this.logContext,
+      {
+        room: joinResponse.room?.name,
+        roomSid: joinResponse.room?.sid,
+        identity: joinResponse.participant?.identity,
+      },
     );
 
     if (!joinResponse.serverVersion) {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1917,10 +1917,27 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   ): boolean {
     // active speaker updates are too spammy
     if (event !== RoomEvent.ActiveSpeakersChanged) {
-      this.log.debug(`room event ${event}`, { ...this.logContext, event, args });
+      // only extract logContext from arguments in order to avoid logging the whole object tree
+      const minimizedArgs = mapArgs(args).filter((arg: unknown) => arg !== undefined);
+      this.log.debug(`room event ${event}`, { ...this.logContext, event, args: minimizedArgs });
     }
     return super.emit(event, ...args);
   }
+}
+
+function mapArgs(args: unknown[]): any {
+  return args.map((arg: unknown) => {
+    if (!arg) {
+      return;
+    }
+    if (Array.isArray(arg)) {
+      return mapArgs(arg);
+    }
+    if (typeof arg === 'object') {
+      return 'logContext' in arg && arg.logContext;
+    }
+    return arg;
+  });
 }
 
 export default Room;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1839,9 +1839,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
               ),
           undefined,
           false,
-          this.options.loggerName,
+          { loggerName: this.options.loggerName, loggerContextCb: () => this.logContext },
         ),
-        this.options.loggerName,
+        { loggerName: this.options.loggerName, loggerContextCb: () => this.logContext },
       );
       // @ts-ignore
       this.localParticipant.addTrackPublication(camPub);
@@ -1862,9 +1862,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           undefined,
           false,
           this.audioContext,
-          this.options.loggerName,
+          { loggerName: this.options.loggerName, loggerContextCb: () => this.logContext },
         ),
-        this.options.loggerName,
+        { loggerName: this.options.loggerName, loggerContextCb: () => this.logContext },
       );
       // @ts-ignore
       this.localParticipant.addTrackPublication(audioPub);

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -202,7 +202,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       this.switchActiveDevice(
         'audiooutput',
         unwrapConstraint(this.options.audioOutput.deviceId),
-      ).catch((e) => this.log.warn(`Could not set audio output: ${e.message}`));
+      ).catch((e) => this.log.warn(`Could not set audio output: ${e.message}`, this.logContext));
     }
 
     if (this.options.e2ee) {
@@ -241,6 +241,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       );
       this.e2eeManager?.setup(this);
     }
+  }
+
+  private get logContext() {
+    return {
+      room: this.name,
+      roomSid: this.sid,
+      identity: this.localParticipant.identity,
+    };
   }
 
   /**
@@ -366,7 +374,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.state !== ConnectionState.Disconnected) {
       return;
     }
-    this.log.debug(`prepareConnection to ${url}`);
+    this.log.debug(`prepareConnection to ${url}`, this.logContext);
     try {
       if (isCloud(new URL(url)) && token) {
         this.regionUrlProvider = new RegionUrlProvider(url, token);
@@ -376,13 +384,13 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         if (regionUrl && this.state === ConnectionState.Disconnected) {
           this.regionUrl = regionUrl;
           await fetch(toHttpUrl(regionUrl), { method: 'HEAD' });
-          this.log.debug(`prepared connection to ${regionUrl}`);
+          this.log.debug(`prepared connection to ${regionUrl}`, this.logContext);
         }
       } else {
         await fetch(toHttpUrl(url), { method: 'HEAD' });
       }
     } catch (e) {
-      this.log.warn('could not prepare connection', { error: e });
+      this.log.warn('could not prepare connection', { ...this.logContext, error: e });
     }
   }
 
@@ -392,7 +400,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
     if (this.state === ConnectionState.Connected) {
       // when the state is reconnecting or connected, this function returns immediately
-      this.log.info(`already connected to room ${this.name}`);
+      this.log.info(`already connected to room ${this.name}`, this.logContext);
       unlockDisconnect();
       return Promise.resolve();
     }
@@ -417,7 +425,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       // if initial connection fails, this will speed up picking regional url
       // on subsequent runs
       this.regionUrlProvider.fetchRegionSettings().catch((e) => {
-        this.log.warn('could not fetch region settings', { error: e });
+        this.log.warn('could not fetch region settings', { ...this.logContext, error: e });
       });
     }
 
@@ -466,6 +474,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           if (nextUrl) {
             this.log.info(
               `Initial connection failed with ConnectionError: ${e.message}. Retrying with another region: ${nextUrl}`,
+              this.logContext,
             );
             await connectFn(resolve, reject, nextUrl);
           } else {
@@ -525,6 +534,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       `connected to Livekit Server ${Object.entries(serverInfo)
         .map(([key, value]) => `${key}: ${value}`)
         .join(', ')}`,
+      this.logContext,
     );
 
     if (!joinResponse.serverVersion) {
@@ -532,7 +542,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
 
     if (joinResponse.serverVersion === '0.15.1' && this.options.dynacast) {
-      this.log.debug('disabling dynacast due to server version');
+      this.log.debug('disabling dynacast due to server version', this.logContext);
       // dynacast has a bug in 0.15.1, so we cannot use it then
       roomOptions.dynacast = false;
     }
@@ -565,7 +575,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     abortController: AbortController,
   ) => {
     if (this.state === ConnectionState.Reconnecting) {
-      this.log.info('Reconnection attempt replaced by new connection attempt');
+      this.log.info('Reconnection attempt replaced by new connection attempt', this.logContext);
       // make sure we close and recreate the existing engine in order to get rid of any potentially ongoing reconnection attempts
       this.recreateEngine();
     } else {
@@ -612,7 +622,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         resultingError.reason = err.reason;
         resultingError.status = err.status;
       }
-      this.log.debug(`error trying to establish signal connection`, { error: err });
+      this.log.debug(`error trying to establish signal connection`, {
+        ...this.logContext,
+        error: err,
+      });
       throw resultingError;
     }
 
@@ -655,16 +668,18 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     const unlock = await this.disconnectLock.lock();
     try {
       if (this.state === ConnectionState.Disconnected) {
-        this.log.debug('already disconnected');
+        this.log.debug('already disconnected', this.logContext);
         return;
       }
-      this.log.info('disconnect from room', { identity: this.localParticipant.identity });
+      this.log.info('disconnect from room', {
+        ...this.logContext,
+      });
       if (
         this.state === ConnectionState.Connecting ||
         this.state === ConnectionState.Reconnecting
       ) {
         // try aborting pending connection attempt
-        this.log.warn('abort connection attempt');
+        this.log.warn('abort connection attempt', this.logContext);
         this.abortController?.abort();
         // in case the abort controller didn't manage to cancel the connection attempt, reject the connect promise explicitly
         this.connectFuture?.reject?.(new ConnectionError('Client initiated disconnect'));
@@ -892,6 +907,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         } else {
           this.log.warn(
             'Resuming video playback failed, make sure you call `startVideo` directly in a user gesture handler',
+            this.logContext,
           );
         }
       });
@@ -1056,7 +1072,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
     if (this.state === ConnectionState.Disconnected) {
-      this.log.warn('skipping incoming track after Room disconnected');
+      this.log.warn('skipping incoming track after Room disconnected', this.logContext);
       return;
     }
     const parts = unpackStreamId(stream.id);
@@ -1068,7 +1084,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (streamId && streamId.startsWith('TR')) trackId = streamId;
 
     if (participantId === this.localParticipant.sid) {
-      this.log.warn('tried to create RemoteParticipant for local participant');
+      this.log.warn('tried to create RemoteParticipant for local participant', this.logContext);
       return;
     }
 
@@ -1077,6 +1093,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (!participant) {
       this.log.error(
         `Tried to add a track for a participant, that's not present. Sid: ${participantId}`,
+        this.logContext,
       );
       return;
     }
@@ -1111,7 +1128,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private handleSignalRestarted = async (joinResponse: JoinResponse) => {
-    this.log.debug(`signal reconnected to server`, {
+    this.log.debug(`signal reconnected to server, region ${joinResponse.serverRegion}`, {
+      ...this.logContext,
       region: joinResponse.serverRegion,
     });
 
@@ -1141,11 +1159,13 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
               // we need to restart the track before publishing, often a full reconnect
               // is necessary because computer had gone to sleep.
               this.log.debug('restarting existing track', {
+                ...this.logContext,
                 track: pub.trackSid,
               });
               await track.restartTrack();
             }
             this.log.debug('publishing new track', {
+              ...this.logContext,
               track: pub.trackSid,
             });
             await this.localParticipant.publishTrack(track, pub.options);
@@ -1153,12 +1173,16 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         }),
       );
     } catch (error) {
-      this.log.error('error trying to re-publish tracks after reconnection', { error });
+      this.log.error('error trying to re-publish tracks after reconnection', {
+        ...this.logContext,
+        error,
+      });
     }
 
     try {
       await this.engine.waitForRestarted();
       this.log.debug(`fully reconnected to server`, {
+        ...this.logContext,
         region: joinResponse.serverRegion,
       });
     } catch {
@@ -1415,7 +1439,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private handleAudioPlaybackFailed = (e: any) => {
-    this.log.warn('could not playback audio', e);
+    this.log.warn('could not playback audio', { ...this.logContext, error: e });
     if (!this.canPlaybackAudio) {
       return;
     }
@@ -1484,7 +1508,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       try {
         await this.audioContext.resume();
       } catch (e: any) {
-        this.log.warn(e);
+        this.log.warn('Could not resume audio context', { ...this.logContext, error: e });
       }
     }
 
@@ -1521,7 +1545,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.options.audioOutput?.deviceId) {
       participant
         .setAudioOutput(this.options.audioOutput)
-        .catch((e) => this.log.warn(`Could not set audio output: ${e.message}`));
+        .catch((e) => this.log.warn(`Could not set audio output: ${e.message}`, this.logContext));
     }
     return participant;
   }
@@ -1654,7 +1678,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         !this.engine.verifyTransport()
       ) {
         consecutiveFailures++;
-        this.log.warn('detected connection state mismatch', { numFailures: consecutiveFailures });
+        this.log.warn('detected connection state mismatch', {
+          ...this.logContext,
+          numFailures: consecutiveFailures,
+        });
         if (consecutiveFailures >= 3) {
           this.recreateEngine();
           this.handleDisconnect(
@@ -1890,7 +1917,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   ): boolean {
     // active speaker updates are too spammy
     if (event !== RoomEvent.ActiveSpeakersChanged) {
-      this.log.debug(`room event ${event}`, { event, args });
+      this.log.debug(`room event ${event}`, { ...this.logContext, event, args });
     }
     return super.emit(event, ...args);
   }

--- a/src/room/defaults.ts
+++ b/src/room/defaults.ts
@@ -42,7 +42,6 @@ export const roomOptionDefaults: InternalRoomOptions = {
   reconnectPolicy: new DefaultReconnectPolicy(),
   disconnectOnPageLeave: true,
   expWebAudioMix: false,
-  loggerName: 'livekit',
 } as const;
 
 export const roomConnectOptionDefaults: InternalRoomConnectOptions = {

--- a/src/room/defaults.ts
+++ b/src/room/defaults.ts
@@ -42,6 +42,7 @@ export const roomOptionDefaults: InternalRoomOptions = {
   reconnectPolicy: new DefaultReconnectPolicy(),
   disconnectOnPageLeave: true,
   expWebAudioMix: false,
+  loggerName: 'livekit',
 } as const;
 
 export const roomConnectOptionDefaults: InternalRoomConnectOptions = {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -540,6 +540,11 @@ export default class LocalParticipant extends Participant {
         default:
           throw new TrackInvalidError(`unsupported MediaStreamTrack kind ${track.kind}`);
       }
+    } else {
+      track.updateLoggerOptions({
+        loggerName: this.roomOptions.loggerName,
+        loggerContextCb: () => this.logContext,
+      });
     }
 
     if (track instanceof LocalAudioTrack) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -429,7 +429,10 @@ export default class LocalParticipant extends Participant {
       if (typeof conOrBool !== 'boolean') {
         trackConstraints = conOrBool;
       }
-      const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints);
+      const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints, {
+        loggerName: this.roomOptions.loggerName,
+        loggerContextCb: () => this.logContext,
+      });
       if (track.kind === Track.Kind.Video) {
         track.source = Track.Source.Camera;
       } else if (track.kind === Track.Kind.Audio) {
@@ -461,12 +464,10 @@ export default class LocalParticipant extends Participant {
     if (tracks.length === 0) {
       throw new TrackInvalidError('no video track found');
     }
-    const screenVideo = new LocalVideoTrack(
-      tracks[0],
-      undefined,
-      false,
-      this.roomOptions.loggerName,
-    );
+    const screenVideo = new LocalVideoTrack(tracks[0], undefined, false, {
+      loggerName: this.roomOptions.loggerName,
+      loggerContextCb: () => this.logContext,
+    });
     screenVideo.source = Track.Source.ScreenShare;
     const localTracks: Array<LocalTrack> = [screenVideo];
     if (stream.getAudioTracks().length > 0) {
@@ -476,7 +477,7 @@ export default class LocalParticipant extends Participant {
         undefined,
         false,
         this.audioContext,
-        this.roomOptions.loggerName,
+        { loggerName: this.roomOptions.loggerName, loggerContextCb: () => this.logContext },
       );
       screenAudio.source = Track.Source.ScreenShareAudio;
       localTracks.push(screenAudio);
@@ -525,16 +526,16 @@ export default class LocalParticipant extends Participant {
     if (track instanceof MediaStreamTrack) {
       switch (track.kind) {
         case 'audio':
-          track = new LocalAudioTrack(
-            track,
-            defaultConstraints,
-            true,
-            this.audioContext,
-            this.roomOptions.loggerName,
-          );
+          track = new LocalAudioTrack(track, defaultConstraints, true, this.audioContext, {
+            loggerName: this.roomOptions.loggerName,
+            loggerContextCb: () => this.logContext,
+          });
           break;
         case 'video':
-          track = new LocalVideoTrack(track, defaultConstraints, true, this.roomOptions.loggerName);
+          track = new LocalVideoTrack(track, defaultConstraints, true, {
+            loggerName: this.roomOptions.loggerName,
+            loggerContextCb: () => this.logContext,
+          });
           break;
         default:
           throw new TrackInvalidError(`unsupported MediaStreamTrack kind ${track.kind}`);
@@ -803,12 +804,10 @@ export default class LocalParticipant extends Participant {
       }
     }
 
-    const publication = new LocalTrackPublication(
-      track.kind,
-      ti,
-      track,
-      this.roomOptions.loggerName,
-    );
+    const publication = new LocalTrackPublication(track.kind, ti, track, {
+      loggerName: this.roomOptions.loggerName,
+      loggerContextCb: () => this.logContext,
+    });
     // save options for when it needs to be republished again
     publication.options = opts;
     track.sid = ti.sid;

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -88,7 +88,7 @@ export default class LocalParticipant extends Participant {
   constructor(sid: string, identity: string, engine: RTCEngine, options: InternalRoomOptions) {
     super(sid, identity, undefined, undefined, {
       loggerName: options.loggerName,
-      loggerContextCb: () => engine.logContext,
+      loggerContextCb: () => this.engine.logContext,
     });
     this.audioTracks = new Map();
     this.videoTracks = new Map();

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -83,10 +83,14 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
 
   protected log: StructuredLogger = log;
 
-  protected logContextCb?: LoggerOptions['loggerContextCb'];
+  protected loggerOptions?: LoggerOptions;
 
   protected get logContext() {
-    return { ...this.logContextCb?.(), participantSid: this.sid, participantId: this.identity };
+    return {
+      ...this.loggerOptions?.loggerContextCb?.(),
+      participantSid: this.sid,
+      participantId: this.identity,
+    };
   }
 
   get isEncrypted() {
@@ -108,7 +112,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     super();
 
     this.log = getLogger(loggerOptions?.loggerName ?? LoggerNames.Participant);
-    this.logContextCb = loggerOptions?.loggerContextCb;
+    this.loggerOptions = loggerOptions;
 
     this.setMaxListeners(100);
     this.sid = sid;

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 import type TypedEmitter from 'typed-emitter';
-import log from '../../logger';
+import log, { StructuredLogger, getLogger } from '../../logger';
+import type { InternalRoomOptions } from '../../options';
 import {
   DataPacket_Kind,
   ParticipantInfo,
@@ -78,6 +79,8 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
 
   private _connectionQuality: ConnectionQuality = ConnectionQuality.Unknown;
 
+  protected log: StructuredLogger = log;
+
   protected audioContext?: AudioContext;
 
   get isEncrypted() {
@@ -89,8 +92,17 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   }
 
   /** @internal */
-  constructor(sid: string, identity: string, name?: string, metadata?: string) {
+  constructor(
+    sid: string,
+    identity: string,
+    name?: string,
+    metadata?: string,
+    opts?: InternalRoomOptions,
+  ) {
     super();
+
+    this.log = getLogger(opts?.loggerName ?? 'livekit-participant');
+
     this.setMaxListeners(100);
     this.sid = sid;
     this.identity = identity;
@@ -187,7 +199,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     }
     // set this last so setMetadata can detect changes
     this.participantInfo = info;
-    log.trace('update participant info', { info });
+    this.log.trace('update participant info', { info });
     return true;
   }
 

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import type TypedEmitter from 'typed-emitter';
-import log, { StructuredLogger, getLogger } from '../../logger';
+import log, { LoggerNames, StructuredLogger, getLogger } from '../../logger';
 import type { InternalRoomOptions } from '../../options';
 import {
   DataPacket_Kind,
@@ -101,7 +101,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   ) {
     super();
 
-    this.log = getLogger(opts?.loggerName ?? 'livekit-participant');
+    this.log = getLogger(opts?.loggerName ?? LoggerNames.Participant);
 
     this.setMaxListeners(100);
     this.sid = sid;

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -254,6 +254,7 @@ export default class RemoteParticipant extends Participant {
           kind,
           ti,
           this.signalClient.connectOptions?.autoSubscribe,
+          { loggerContextCb: () => this.logContext, loggerName: this.loggerOptions?.loggerName },
         );
         publication.updateInfo(ti);
         newTracks.set(ti.sid, publication);

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -16,12 +16,13 @@ import { getReactNativeOs, isFireFox, isReactNative, isSVCCodec } from '../utils
 export function mediaTrackToLocalTrack(
   mediaStreamTrack: MediaStreamTrack,
   constraints?: MediaTrackConstraints,
+  loggerName?: string,
 ): LocalVideoTrack | LocalAudioTrack {
   switch (mediaStreamTrack.kind) {
     case 'audio':
-      return new LocalAudioTrack(mediaStreamTrack, constraints, false);
+      return new LocalAudioTrack(mediaStreamTrack, constraints, false, undefined, loggerName);
     case 'video':
-      return new LocalVideoTrack(mediaStreamTrack, constraints, false);
+      return new LocalVideoTrack(mediaStreamTrack, constraints, false, loggerName);
     default:
       throw new TrackInvalidError(`unsupported track type: ${mediaStreamTrack.kind}`);
   }

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -10,19 +10,20 @@ import type {
   VideoEncoding,
 } from '../track/options';
 import { ScreenSharePresets, VideoPreset, VideoPresets, VideoPresets43 } from '../track/options';
+import type { LoggerOptions } from '../types';
 import { getReactNativeOs, isFireFox, isReactNative, isSVCCodec } from '../utils';
 
 /** @internal */
 export function mediaTrackToLocalTrack(
   mediaStreamTrack: MediaStreamTrack,
   constraints?: MediaTrackConstraints,
-  loggerName?: string,
+  loggerOptions?: LoggerOptions,
 ): LocalVideoTrack | LocalAudioTrack {
   switch (mediaStreamTrack.kind) {
     case 'audio':
-      return new LocalAudioTrack(mediaStreamTrack, constraints, false, undefined, loggerName);
+      return new LocalAudioTrack(mediaStreamTrack, constraints, false, undefined, loggerOptions);
     case 'video':
-      return new LocalVideoTrack(mediaStreamTrack, constraints, false, loggerName);
+      return new LocalVideoTrack(mediaStreamTrack, constraints, false, loggerOptions);
     default:
       throw new TrackInvalidError(`unsupported track type: ${mediaStreamTrack.kind}`);
   }

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -27,9 +27,9 @@ export default class LocalAudioTrack extends LocalTrack {
     constraints?: MediaTrackConstraints,
     userProvidedTrack = true,
     audioContext?: AudioContext,
-    logger?: string,
+    loggerName?: string,
   ) {
-    super(mediaTrack, Track.Kind.Audio, constraints, userProvidedTrack, logger);
+    super(mediaTrack, Track.Kind.Audio, constraints, userProvidedTrack, loggerName);
     this.audioContext = audioContext;
     this.checkForSilence();
   }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -49,9 +49,9 @@ export default abstract class LocalTrack extends Track {
     kind: Track.Kind,
     constraints?: MediaTrackConstraints,
     userProvidedTrack = false,
-    logger?: string,
+    loggerName?: string,
   ) {
-    super(mediaTrack, kind, logger);
+    super(mediaTrack, kind, loggerName);
     this.reacquireTrack = false;
     this.providedByUser = userProvidedTrack;
     this.muteLock = new Mutex();

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -3,6 +3,7 @@ import { getBrowser } from '../../utils/browserParser';
 import DeviceManager from '../DeviceManager';
 import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
 import { TrackEvent } from '../events';
+import type { LoggerOptions } from '../types';
 import { Mutex, compareVersions, isMobile, sleep } from '../utils';
 import { Track, attachToElement, detachTrack } from './Track';
 import type { VideoCodec } from './options';
@@ -49,9 +50,9 @@ export default abstract class LocalTrack extends Track {
     kind: Track.Kind,
     constraints?: MediaTrackConstraints,
     userProvidedTrack = false,
-    loggerName?: string,
+    loggerOptions?: LoggerOptions,
   ) {
-    super(mediaTrack, kind, loggerName);
+    super(mediaTrack, kind, loggerOptions);
     this.reacquireTrack = false;
     this.providedByUser = userProvidedTrack;
     this.muteLock = new Mutex();
@@ -128,7 +129,7 @@ export default abstract class LocalTrack extends Track {
     }
     let processedTrack: MediaStreamTrack | undefined;
     if (this.processor && newTrack && this.processorElement) {
-      this.log.debug('restarting processor');
+      this.log.debug('restarting processor', this.logContext);
       if (this.kind === 'unknown') {
         throw TypeError('cannot set processor on track of unknown kind');
       }
@@ -214,7 +215,7 @@ export default abstract class LocalTrack extends Track {
       throw new TrackInvalidError('unable to replace an unpublished track');
     }
 
-    this.log.debug('replace MediaStreamTrack');
+    this.log.debug('replace MediaStreamTrack', this.logContext);
     await this.setMediaStreamTrack(track);
     // this must be synced *after* setting mediaStreamTrack above, since it relies
     // on the previous state in order to cleanup
@@ -230,7 +231,7 @@ export default abstract class LocalTrack extends Track {
     if (!constraints) {
       constraints = this._constraints;
     }
-    this.log.debug('restarting track with constraints', constraints);
+    this.log.debug('restarting track with constraints', { ...this.logContext, constraints });
 
     const streamConstraints: MediaStreamConstraints = {
       audio: false,
@@ -258,7 +259,7 @@ export default abstract class LocalTrack extends Track {
     const mediaStream = await navigator.mediaDevices.getUserMedia(streamConstraints);
     const newTrack = mediaStream.getTracks()[0];
     newTrack.addEventListener('ended', this.handleEnded);
-    this.log.debug('re-acquired MediaStreamTrack');
+    this.log.debug('re-acquired MediaStreamTrack', this.logContext);
 
     await this.setMediaStreamTrack(newTrack);
     this._constraints = constraints;
@@ -268,7 +269,7 @@ export default abstract class LocalTrack extends Track {
   }
 
   protected setTrackMuted(muted: boolean) {
-    this.log.debug(`setting ${this.kind} track ${muted ? 'muted' : 'unmuted'}`);
+    this.log.debug(`setting ${this.kind} track ${muted ? 'muted' : 'unmuted'}`, this.logContext);
 
     if (this.isMuted === muted && this._mediaStreamTrack.enabled !== muted) {
       return;
@@ -291,10 +292,10 @@ export default abstract class LocalTrack extends Track {
   protected async handleAppVisibilityChanged() {
     await super.handleAppVisibilityChanged();
     if (!isMobile()) return;
-    this.log.debug(`visibility changed, is in Background: ${this.isInBackground}`);
+    this.log.debug(`visibility changed, is in Background: ${this.isInBackground}`, this.logContext);
 
     if (!this.isInBackground && this.needsReAcquisition && !this.isUserProvided && !this.isMuted) {
-      this.log.debug(`track needs to be reacquired, restarting ${this.source}`);
+      this.log.debug(`track needs to be reacquired, restarting ${this.source}`, this.logContext);
       await this.restart();
       this.reacquireTrack = false;
     }
@@ -302,7 +303,7 @@ export default abstract class LocalTrack extends Track {
 
   private handleTrackMuteEvent = () =>
     this.debouncedTrackMuteHandler().catch(() =>
-      this.log.debug('track mute bounce got cancelled by an unmute event'),
+      this.log.debug('track mute bounce got cancelled by an unmute event', this.logContext),
     );
 
   private debouncedTrackMuteHandler = debounce(async () => {
@@ -346,7 +347,7 @@ export default abstract class LocalTrack extends Track {
         return;
       }
       if (!this.sender) {
-        this.log.warn('unable to pause upstream for an unpublished track');
+        this.log.warn('unable to pause upstream for an unpublished track', this.logContext);
         return;
       }
 
@@ -370,7 +371,7 @@ export default abstract class LocalTrack extends Track {
         return;
       }
       if (!this.sender) {
-        this.log.warn('unable to resume upstream for an unpublished track');
+        this.log.warn('unable to resume upstream for an unpublished track', this.logContext);
         return;
       }
       this._isUpstreamPaused = false;
@@ -410,7 +411,7 @@ export default abstract class LocalTrack extends Track {
   async setProcessor(processor: TrackProcessor<this['kind']>, showProcessedStreamLocally = true) {
     const unlock = await this.processorLock.lock();
     try {
-      this.log.debug('setting up processor');
+      this.log.debug('setting up processor', this.logContext);
       if (this.processor) {
         await this.stopProcessor();
       }
@@ -424,7 +425,9 @@ export default abstract class LocalTrack extends Track {
 
       this.processorElement
         .play()
-        .catch((error) => this.log.error('failed to play processor element', { error }));
+        .catch((error) =>
+          this.log.error('failed to play processor element', { ...this.logContext, error }),
+        );
 
       const processorOptions = {
         kind: this.kind,
@@ -462,7 +465,7 @@ export default abstract class LocalTrack extends Track {
   async stopProcessor() {
     if (!this.processor) return;
 
-    this.log.debug('stopping processor');
+    this.log.debug('stopping processor', this.logContext);
     this.processor.processedTrack?.stop();
     await this.processor.destroy();
     this.processor = undefined;

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -16,8 +16,8 @@ export default class LocalTrackPublication extends TrackPublication {
     return this.track?.isUpstreamPaused;
   }
 
-  constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack) {
-    super(kind, ti.sid, ti.name);
+  constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack, logger?: string) {
+    super(kind, ti.sid, ti.name, logger);
 
     this.updateInfo(ti);
     this.setTrack(track);

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -16,8 +16,8 @@ export default class LocalTrackPublication extends TrackPublication {
     return this.track?.isUpstreamPaused;
   }
 
-  constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack, logger?: string) {
-    super(kind, ti.sid, ti.name, logger);
+  constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack, loggerName?: string) {
+    super(kind, ti.sid, ti.name, loggerName);
 
     this.updateInfo(ti);
     this.setTrack(track);

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -1,5 +1,6 @@
 import type { TrackInfo } from '../../proto/livekit_models_pb';
 import { TrackEvent } from '../events';
+import type { LoggerOptions } from '../types';
 import type LocalAudioTrack from './LocalAudioTrack';
 import type LocalTrack from './LocalTrack';
 import type LocalVideoTrack from './LocalVideoTrack';
@@ -16,8 +17,8 @@ export default class LocalTrackPublication extends TrackPublication {
     return this.track?.isUpstreamPaused;
   }
 
-  constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack, loggerName?: string) {
-    super(kind, ti.sid, ti.name, loggerName);
+  constructor(kind: Track.Kind, ti: TrackInfo, track?: LocalTrack, loggerOptions?: LoggerOptions) {
+    super(kind, ti.sid, ti.name, loggerOptions);
 
     this.updateInfo(ti);
     this.setTrack(track);

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -328,6 +328,7 @@ export default class LocalVideoTrack extends LocalTrack {
             codec.qualities,
             this.senderLock,
             this.log,
+            this.logContext,
           );
         }
       }
@@ -351,6 +352,7 @@ export default class LocalVideoTrack extends LocalTrack {
       qualities,
       this.senderLock,
       this.log,
+      this.logContext,
     );
   }
 
@@ -396,9 +398,10 @@ async function setPublishingLayersForSender(
   qualities: SubscribedQuality[],
   senderLock: Mutex,
   log: StructuredLogger,
+  logContext: Record<string, unknown>,
 ) {
   const unlock = await senderLock.lock();
-  log.debug('setPublishingLayersForSender', { sender, qualities, senderEncodings });
+  log.debug('setPublishingLayersForSender', { ...logContext, sender, qualities, senderEncodings });
   try {
     const params = sender.getParameters();
     const { encodings } = params;
@@ -472,6 +475,7 @@ async function setPublishingLayersForSender(
             `setting layer ${subscribedQuality.quality} to ${
               encoding.active ? 'enabled' : 'disabled'
             }`,
+            logContext,
           );
 
           // FireFox does not support setting encoding.active to false, so we
@@ -495,7 +499,7 @@ async function setPublishingLayersForSender(
 
     if (hasChanged) {
       params.encodings = encodings;
-      log.debug(`setting encodings`, params.encodings);
+      log.debug(`setting encodings`, { ...logContext, encodings: params.encodings });
       await sender.setParameters(params);
     }
   } finally {

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -1,6 +1,7 @@
 import { TrackEvent } from '../events';
 import { computeBitrate } from '../stats';
 import type { AudioReceiverStats } from '../stats';
+import type { LoggerOptions } from '../types';
 import { isReactNative, supportsSetSinkId } from '../utils';
 import RemoteTrack from './RemoteTrack';
 import { Track } from './Track';
@@ -27,8 +28,9 @@ export default class RemoteAudioTrack extends RemoteTrack {
     receiver?: RTCRtpReceiver,
     audioContext?: AudioContext,
     audioOutput?: AudioOutputOptions,
+    loggerOptions?: LoggerOptions,
   ) {
-    super(mediaTrack, sid, Track.Kind.Audio, receiver);
+    super(mediaTrack, sid, Track.Kind.Audio, receiver, loggerOptions);
     this.audioContext = audioContext;
     this.webAudioPluginNodes = [];
     if (audioOutput) {
@@ -106,7 +108,7 @@ export default class RemoteAudioTrack extends RemoteTrack {
       element.setSinkId(this.sinkId);
     }
     if (this.audioContext && needsNewWebAudioConnection) {
-      this.log.debug('using audio context mapping');
+      this.log.debug('using audio context mapping', this.logContext);
       this.connectWebAudio(this.audioContext, element);
       element.volume = 0;
       element.muted = true;

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -1,4 +1,3 @@
-import log from '../../logger';
 import { TrackEvent } from '../events';
 import { computeBitrate } from '../stats';
 import type { AudioReceiverStats } from '../stats';
@@ -107,7 +106,7 @@ export default class RemoteAudioTrack extends RemoteTrack {
       element.setSinkId(this.sinkId);
     }
     if (this.audioContext && needsNewWebAudioConnection) {
-      log.debug('using audio context mapping');
+      this.log.debug('using audio context mapping');
       this.connectWebAudio(this.audioContext, element);
       element.volume = 0;
       element.muted = true;

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -11,8 +11,10 @@ export default abstract class RemoteTrack extends Track {
     sid: string,
     kind: Track.Kind,
     receiver?: RTCRtpReceiver,
+    logger?: string,
   ) {
-    super(mediaTrack, kind);
+    super(mediaTrack, kind, logger);
+
     this.sid = sid;
     this.receiver = receiver;
   }

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -11,9 +11,9 @@ export default abstract class RemoteTrack extends Track {
     sid: string,
     kind: Track.Kind,
     receiver?: RTCRtpReceiver,
-    logger?: string,
+    loggerName?: string,
   ) {
-    super(mediaTrack, kind, logger);
+    super(mediaTrack, kind, loggerName);
 
     this.sid = sid;
     this.receiver = receiver;

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -1,5 +1,6 @@
 import { TrackEvent } from '../events';
 import { monitorFrequency } from '../stats';
+import type { LoggerOptions } from '../types';
 import { Track } from './Track';
 
 export default abstract class RemoteTrack extends Track {
@@ -11,9 +12,9 @@ export default abstract class RemoteTrack extends Track {
     sid: string,
     kind: Track.Kind,
     receiver?: RTCRtpReceiver,
-    loggerName?: string,
+    loggerOptions?: LoggerOptions,
   ) {
-    super(mediaTrack, kind, loggerName);
+    super(mediaTrack, kind, loggerOptions);
 
     this.sid = sid;
     this.receiver = receiver;

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -1,4 +1,3 @@
-import log from '../../logger';
 import {
   ParticipantTracks,
   SubscriptionError,
@@ -252,13 +251,15 @@ export default class RemoteTrackPublication extends TrackPublication {
 
   private isManualOperationAllowed(): boolean {
     if (this.kind === Track.Kind.Video && this.isAdaptiveStream) {
-      log.warn('adaptive stream is enabled, cannot change video track settings', {
+      this.log.warn('adaptive stream is enabled, cannot change video track settings', {
         trackSid: this.trackSid,
       });
       return false;
     }
     if (!this.isDesired) {
-      log.warn('cannot update track settings when not subscribed', { trackSid: this.trackSid });
+      this.log.warn('cannot update track settings when not subscribed', {
+        trackSid: this.trackSid,
+      });
       return false;
     }
     return true;
@@ -274,7 +275,7 @@ export default class RemoteTrackPublication extends TrackPublication {
   }
 
   protected handleVisibilityChange = (visible: boolean) => {
-    log.debug(`adaptivestream video visibility ${this.trackSid}, visible=${visible}`, {
+    this.log.debug(`adaptivestream video visibility ${this.trackSid}, visible=${visible}`, {
       trackSid: this.trackSid,
     });
     this.disabled = !visible;
@@ -282,7 +283,7 @@ export default class RemoteTrackPublication extends TrackPublication {
   };
 
   protected handleVideoDimensionsChange = (dimensions: Track.Dimensions) => {
-    log.debug(`adaptivestream video dimensions ${dimensions.width}x${dimensions.height}`, {
+    this.log.debug(`adaptivestream video dimensions ${dimensions.width}x${dimensions.height}`, {
       trackSid: this.trackSid,
     });
     this.videoDimensions = dimensions;

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -6,6 +6,7 @@ import {
 } from '../../proto/livekit_models_pb';
 import { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc_pb';
 import { TrackEvent } from '../events';
+import type { LoggerOptions } from '../types';
 import type RemoteTrack from './RemoteTrack';
 import RemoteVideoTrack from './RemoteVideoTrack';
 import { Track } from './Track';
@@ -30,8 +31,13 @@ export default class RemoteTrackPublication extends TrackPublication {
 
   protected subscriptionError?: SubscriptionError;
 
-  constructor(kind: Track.Kind, ti: TrackInfo, autoSubscribe: boolean | undefined) {
-    super(kind, ti.sid, ti.name);
+  constructor(
+    kind: Track.Kind,
+    ti: TrackInfo,
+    autoSubscribe: boolean | undefined,
+    loggerOptions?: LoggerOptions,
+  ) {
+    super(kind, ti.sid, ti.name, loggerOptions);
     this.subscribed = autoSubscribe;
     this.updateInfo(ti);
   }
@@ -251,15 +257,14 @@ export default class RemoteTrackPublication extends TrackPublication {
 
   private isManualOperationAllowed(): boolean {
     if (this.kind === Track.Kind.Video && this.isAdaptiveStream) {
-      this.log.warn('adaptive stream is enabled, cannot change video track settings', {
-        trackSid: this.trackSid,
-      });
+      this.log.warn(
+        'adaptive stream is enabled, cannot change video track settings',
+        this.logContext,
+      );
       return false;
     }
     if (!this.isDesired) {
-      this.log.warn('cannot update track settings when not subscribed', {
-        trackSid: this.trackSid,
-      });
+      this.log.warn('cannot update track settings when not subscribed', this.logContext);
       return false;
     }
     return true;
@@ -275,17 +280,19 @@ export default class RemoteTrackPublication extends TrackPublication {
   }
 
   protected handleVisibilityChange = (visible: boolean) => {
-    this.log.debug(`adaptivestream video visibility ${this.trackSid}, visible=${visible}`, {
-      trackSid: this.trackSid,
-    });
+    this.log.debug(
+      `adaptivestream video visibility ${this.trackSid}, visible=${visible}`,
+      this.logContext,
+    );
     this.disabled = !visible;
     this.emitTrackUpdate();
   };
 
   protected handleVideoDimensionsChange = (dimensions: Track.Dimensions) => {
-    this.log.debug(`adaptivestream video dimensions ${dimensions.width}x${dimensions.height}`, {
-      trackSid: this.trackSid,
-    });
+    this.log.debug(
+      `adaptivestream video dimensions ${dimensions.width}x${dimensions.height}`,
+      this.logContext,
+    );
     this.videoDimensions = dimensions;
     this.emitTrackUpdate();
   };

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -3,6 +3,7 @@ import { TrackEvent } from '../events';
 import type { VideoReceiverStats } from '../stats';
 import { computeBitrate } from '../stats';
 import CriticalTimers from '../timers';
+import type { LoggerOptions } from '../types';
 import type { ObservableMediaElement } from '../utils';
 import { getDevicePixelRatio, getIntersectionObserver, getResizeObserver, isWeb } from '../utils';
 import RemoteTrack from './RemoteTrack';
@@ -27,9 +28,9 @@ export default class RemoteVideoTrack extends RemoteTrack {
     sid: string,
     receiver?: RTCRtpReceiver,
     adaptiveStreamSettings?: AdaptiveStreamSettings,
-    loggerName?: string,
+    loggerOptions?: LoggerOptions,
   ) {
-    super(mediaTrack, sid, Track.Kind.Video, receiver, loggerName);
+    super(mediaTrack, sid, Track.Kind.Video, receiver, loggerOptions);
     this.adaptiveStreamSettings = adaptiveStreamSettings;
   }
 
@@ -103,7 +104,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
       this.debouncedHandleResize();
       this.updateVisibility();
     } else {
-      this.log.warn('visibility resize observer not triggered');
+      this.log.warn('visibility resize observer not triggered', this.logContext);
     }
   }
 
@@ -114,7 +115,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
    */
   stopObservingElementInfo(elementInfo: ElementInfo) {
     if (!this.isAdaptiveStream) {
-      this.log.warn('stopObservingElementInfo ignored');
+      this.log.warn('stopObservingElementInfo ignored', this.logContext);
       return;
     }
     const stopElementInfos = this.elementInfos.filter((info) => info === elementInfo);

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -27,9 +27,9 @@ export default class RemoteVideoTrack extends RemoteTrack {
     sid: string,
     receiver?: RTCRtpReceiver,
     adaptiveStreamSettings?: AdaptiveStreamSettings,
-    logger?: string,
+    loggerName?: string,
   ) {
-    super(mediaTrack, sid, Track.Kind.Video, receiver, logger);
+    super(mediaTrack, sid, Track.Kind.Video, receiver, loggerName);
     this.adaptiveStreamSettings = adaptiveStreamSettings;
   }
 

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,5 +1,4 @@
 import { debounce } from 'ts-debounce';
-import log from '../../logger';
 import { TrackEvent } from '../events';
 import type { VideoReceiverStats } from '../stats';
 import { computeBitrate } from '../stats';
@@ -28,8 +27,9 @@ export default class RemoteVideoTrack extends RemoteTrack {
     sid: string,
     receiver?: RTCRtpReceiver,
     adaptiveStreamSettings?: AdaptiveStreamSettings,
+    logger?: string,
   ) {
-    super(mediaTrack, sid, Track.Kind.Video, receiver);
+    super(mediaTrack, sid, Track.Kind.Video, receiver, logger);
     this.adaptiveStreamSettings = adaptiveStreamSettings;
   }
 
@@ -103,7 +103,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
       this.debouncedHandleResize();
       this.updateVisibility();
     } else {
-      log.warn('visibility resize observer not triggered');
+      this.log.warn('visibility resize observer not triggered');
     }
   }
 
@@ -114,7 +114,7 @@ export default class RemoteVideoTrack extends RemoteTrack {
    */
   stopObservingElementInfo(elementInfo: ElementInfo) {
     if (!this.isAdaptiveStream) {
-      log.warn('stopObservingElementInfo ignored');
+      this.log.warn('stopObservingElementInfo ignored');
       return;
     }
     const stopElementInfos = this.elementInfos.filter((info) => info === elementInfo);

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
 import type { SignalClient } from '../../api/SignalClient';
-import log from '../../logger';
+import log, { StructuredLogger, getLogger } from '../../logger';
 import { TrackSource, TrackType } from '../../proto/livekit_models_pb';
 import { StreamState as ProtoStreamState } from '../../proto/livekit_rtc_pb';
 import { TrackEvent } from '../events';
@@ -50,8 +50,11 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
 
   protected monitorInterval?: ReturnType<typeof setInterval>;
 
-  protected constructor(mediaTrack: MediaStreamTrack, kind: Track.Kind) {
+  protected log: StructuredLogger = log;
+
+  protected constructor(mediaTrack: MediaStreamTrack, kind: Track.Kind, logger = 'livekit-track') {
     super();
+    this.log = getLogger(logger);
     this.setMaxListeners(100);
     this.kind = kind;
     this._mediaStreamTrack = mediaTrack;

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -55,7 +55,7 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
   protected constructor(
     mediaTrack: MediaStreamTrack,
     kind: Track.Kind,
-    logger = LoggerNames.Track,
+    logger: string = LoggerNames.Track,
   ) {
     super();
     this.log = getLogger(logger);

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
 import type { SignalClient } from '../../api/SignalClient';
-import log, { StructuredLogger, getLogger } from '../../logger';
+import log, { LoggerNames, StructuredLogger, getLogger } from '../../logger';
 import { TrackSource, TrackType } from '../../proto/livekit_models_pb';
 import { StreamState as ProtoStreamState } from '../../proto/livekit_rtc_pb';
 import { TrackEvent } from '../events';
@@ -52,7 +52,11 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
 
   protected log: StructuredLogger = log;
 
-  protected constructor(mediaTrack: MediaStreamTrack, kind: Track.Kind, logger = 'livekit-track') {
+  protected constructor(
+    mediaTrack: MediaStreamTrack,
+    kind: Track.Kind,
+    logger = LoggerNames.Track,
+  ) {
     super();
     this.log = getLogger(logger);
     this.setMaxListeners(100);

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -63,6 +63,7 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
   ) {
     super();
     this.log = getLogger(loggerOptions.loggerName ?? LoggerNames.Track);
+    this.loggerContextCb = loggerOptions.loggerContextCb;
 
     this.setMaxListeners(100);
     this.kind = kind;
@@ -240,6 +241,16 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
   stopMonitor() {
     if (this.monitorInterval) {
       clearInterval(this.monitorInterval);
+    }
+  }
+
+  /** @internal */
+  updateLoggerOptions(loggerOptions: LoggerOptions) {
+    if (loggerOptions.loggerName) {
+      this.log = getLogger(loggerOptions.loggerName);
+    }
+    if (loggerOptions.loggerContextCb) {
+      this.loggerContextCb = loggerOptions.loggerContextCb;
     }
   }
 

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -55,10 +55,10 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
   protected constructor(
     mediaTrack: MediaStreamTrack,
     kind: Track.Kind,
-    logger: string = LoggerNames.Track,
+    loggerName: string = LoggerNames.Track,
   ) {
     super();
-    this.log = getLogger(logger);
+    this.log = getLogger(loggerName);
     this.setMaxListeners(100);
     this.kind = kind;
     this._mediaStreamTrack = mediaTrack;

--- a/src/room/track/TrackPublication.ts
+++ b/src/room/track/TrackPublication.ts
@@ -45,10 +45,10 @@ export class TrackPublication extends (EventEmitter as new () => TypedEventEmitt
     kind: Track.Kind,
     id: string,
     name: string,
-    logger: string = LoggerNames.Publication,
+    loggerName: string = LoggerNames.Publication,
   ) {
     super();
-    this.log = getLogger(logger);
+    this.log = getLogger(loggerName);
     this.setMaxListeners(100);
     this.kind = kind;
     this.trackSid = id;

--- a/src/room/track/TrackPublication.ts
+++ b/src/room/track/TrackPublication.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
-import log from '../../logger';
+import log, { getLogger } from '../../logger';
 import { Encryption_Type } from '../../proto/livekit_models_pb';
 import type { SubscriptionError, TrackInfo } from '../../proto/livekit_models_pb';
 import type { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc_pb';
@@ -39,8 +39,11 @@ export class TrackPublication extends (EventEmitter as new () => TypedEventEmitt
 
   protected encryption: Encryption_Type = Encryption_Type.NONE;
 
-  constructor(kind: Track.Kind, id: string, name: string) {
+  protected log = log;
+
+  constructor(kind: Track.Kind, id: string, name: string, logger = 'livekit-track-publication') {
     super();
+    this.log = getLogger(logger);
     this.setMaxListeners(100);
     this.kind = kind;
     this.trackSid = id;
@@ -121,7 +124,7 @@ export class TrackPublication extends (EventEmitter as new () => TypedEventEmitt
     }
     this.encryption = info.encryption;
     this.trackInfo = info;
-    log.debug('update publication info', { info });
+    this.log.debug('update publication info', { info });
   }
 }
 

--- a/src/room/track/TrackPublication.ts
+++ b/src/room/track/TrackPublication.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
-import log, { getLogger } from '../../logger';
+import log, { LoggerNames, getLogger } from '../../logger';
 import { Encryption_Type } from '../../proto/livekit_models_pb';
 import type { SubscriptionError, TrackInfo } from '../../proto/livekit_models_pb';
 import type { UpdateSubscription, UpdateTrackSettings } from '../../proto/livekit_rtc_pb';
@@ -41,7 +41,12 @@ export class TrackPublication extends (EventEmitter as new () => TypedEventEmitt
 
   protected log = log;
 
-  constructor(kind: Track.Kind, id: string, name: string, logger = 'livekit-track-publication') {
+  constructor(
+    kind: Track.Kind,
+    id: string,
+    name: string,
+    logger: string = LoggerNames.Publication,
+  ) {
     super();
     this.log = getLogger(logger);
     this.setMaxListeners(100);

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -209,3 +209,23 @@ export function getTrackPublicationInfo<T extends TrackPublication>(
   });
   return infos;
 }
+
+export function getLogContextFromTrack(track: Track | TrackPublication): Record<string, unknown> {
+  if (track instanceof Track) {
+    return {
+      sid: track.sid,
+      source: track.source,
+      muted: track.isMuted,
+      enabled: track.mediaStreamTrack.enabled,
+      kind: track.kind,
+    };
+  } else {
+    return {
+      sid: track.trackSid,
+      name: track.trackName,
+      track: track.track ? getLogContextFromTrack(track.track) : undefined,
+      enabled: track.isEnabled,
+      encrypted: track.isEncrypted,
+    };
+  }
+}

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -213,19 +213,20 @@ export function getTrackPublicationInfo<T extends TrackPublication>(
 export function getLogContextFromTrack(track: Track | TrackPublication): Record<string, unknown> {
   if (track instanceof Track) {
     return {
-      sid: track.sid,
-      source: track.source,
-      muted: track.isMuted,
-      enabled: track.mediaStreamTrack.enabled,
-      kind: track.kind,
+      trackSid: track.sid,
+      trackSource: track.source,
+      trackMuted: track.isMuted,
+      trackEnabled: track.mediaStreamTrack.enabled,
+      trackKind: track.kind,
     };
   } else {
     return {
-      sid: track.trackSid,
-      name: track.trackName,
+      trackSid: track.trackSid,
+      trackName: track.trackName,
       track: track.track ? getLogContextFromTrack(track.track) : undefined,
-      enabled: track.isEnabled,
-      encrypted: track.isEncrypted,
+      trackEnabled: track.isEnabled,
+      trackEncrypted: track.isEncrypted,
+      trackMimeType: track.mimeType,
     };
   }
 }

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -44,5 +44,5 @@ export type SimulationScenario =
 
 export type LoggerOptions = {
   loggerName?: string;
-  loggerContextCb?: () => Object;
+  loggerContextCb?: () => Record<string, unknown>;
 };

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -41,3 +41,8 @@ export type SimulationScenario =
   // this can be used to test application behavior when congested or
   // to disable congestion control entirely (by setting bandwidth to 100Mbps)
   | 'subscriber-bandwidth';
+
+export type LoggerOptions = {
+  loggerName?: string;
+  loggerContextCb?: () => Object;
+};


### PR DESCRIPTION

- By default each (base)class gets its own logger instance that starts with `livekit-` (e.g. `livekit-participant`, `livekit-track`
- This can be overriden by providing a `loggerName` in the roomOpts. If set, this loggerName will be propagated across all objects/classes instantiated within the room and only a single logger instance will be used per room
- this allows for two usage scenarios
   - class based logging and the possibility to set log levels independently for each (base)class
   - room based logging and the possibility to set different log levels and/or extensions for each room
 

