### PR TITLE
Log websocket close code

### DIFF
--- a/.changeset/giant-dots-deny.md
+++ b/.changeset/giant-dots-deny.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Log websocket close code

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -394,6 +394,7 @@ export class SignalClient {
           this.log.warn(`websocket closed`, {
             ...this.logContext,
             reason: ev.reason,
+            code: ev.code,
             state: this.state,
           });
           this.handleOnClose(ev.reason);

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -395,6 +395,7 @@ export class SignalClient {
             ...this.logContext,
             reason: ev.reason,
             code: ev.code,
+            wasClean: ev.wasClean,
             state: this.state,
           });
           this.handleOnClose(ev.reason);


### PR DESCRIPTION
So far we've only been logging the human readable close `reason` which is empty most of the time. 
Both `code` and `reason` should be provided by the server, according to https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close_event#event_properties