### PR TITLE
Cherry pick release commits from v1 branch

### DIFF
--- a/.changeset/quiet-grapes-relate.md
+++ b/.changeset/quiet-grapes-relate.md
@@ -1,5 +1,0 @@
----
-"livekit-client": patch
----
-
-Await unpublish before re-publishing on signal-reconnect

--- a/.changeset/silver-shoes-rest.md
+++ b/.changeset/silver-shoes-rest.md
@@ -1,5 +1,0 @@
----
-"livekit-client": patch
----
-
-Fix for recovering SignalChannel closing during reconnect

--- a/.changeset/slimy-goats-glow.md
+++ b/.changeset/slimy-goats-glow.md
@@ -1,5 +1,0 @@
----
-"livekit-client": patch
----
-
-Perform full reconnect on leave during reconnect

--- a/.changeset/young-eagles-laugh.md
+++ b/.changeset/young-eagles-laugh.md
@@ -1,5 +1,0 @@
----
-"livekit-client": patch
----
-
-Log server offer sdp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.15.10
+
+### Patch Changes
+
+- Perform full reconnect on leave during reconnect - [`dc95472cca12ad3b150e824da8e3f7e387de0e12`](https://github.com/livekit/client-sdk-js/commit/dc95472cca12ad3b150e824da8e3f7e387de0e12) ([@lukasIO](https://github.com/lukasIO))
+
 ## 1.15.9
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 1.15.9
+
+### Patch Changes
+
+- Fix for recovering SignalChannel closing during reconnect - [`d1fa7554630d9f9fd787784b154eb460c8568894`](https://github.com/livekit/client-sdk-js/commit/d1fa7554630d9f9fd787784b154eb460c8568894) ([@lukasIO](https://github.com/lukasIO))
+
+- Log server offer sdp - [`6cd3ae5f0c3c30ce852d7b3f000f1adf2e08eb96`](https://github.com/livekit/client-sdk-js/commit/6cd3ae5f0c3c30ce852d7b3f000f1adf2e08eb96) ([@lukasIO](https://github.com/lukasIO))
+
 ## 1.15.8
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.15.8
+
+### Patch Changes
+
+- Await unpublish before re-publishing on signal-reconnect - [`eea871c11118ff36a04917dc1008dc9023c662b5`](https://github.com/livekit/client-sdk-js/commit/eea871c11118ff36a04917dc1008dc9023c662b5) ([@lukasIO](https://github.com/lukasIO))
+
 ## 1.15.7
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livekit-client",
-  "version": "1.15.9",
+  "version": "1.15.10",
   "description": "JavaScript/TypeScript client SDK for LiveKit",
   "main": "./dist/livekit-client.umd.js",
   "unpkg": "./dist/livekit-client.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livekit-client",
-  "version": "1.15.8",
+  "version": "1.15.9",
   "description": "JavaScript/TypeScript client SDK for LiveKit",
   "main": "./dist/livekit-client.umd.js",
   "unpkg": "./dist/livekit-client.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livekit-client",
-  "version": "1.15.7",
+  "version": "1.15.8",
   "description": "JavaScript/TypeScript client SDK for LiveKit",
   "main": "./dist/livekit-client.umd.js",
   "unpkg": "./dist/livekit-client.umd.js",


### PR DESCRIPTION
This aligns the changelog for `v2` with the intermediate releases we've done for the `v1` branch. 
Currently changesets (and version numbers) still reflect the state before splitting between `v1` and `v2`. 
This should just align them a bit more for now in terms of code status matching the latest version number