### PR TITLE
Remove googConstraints from RTCPeerConnection constructor

### DIFF
--- a/.changeset/great-impalas-try.md
+++ b/.changeset/great-impalas-try.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Remove googConstraints from RTCPeerConnection constructor

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -5,7 +5,7 @@ import { debounce } from 'ts-debounce';
 import log, { LoggerNames, getLogger } from '../logger';
 import { NegotiationError, UnexpectedConnectionState } from './errors';
 import type { LoggerOptions } from './types';
-import { ddExtensionURI, isChromiumBased, isSVCCodec } from './utils';
+import { ddExtensionURI, isSVCCodec } from './utils';
 
 /** @internal */
 interface TrackBitrateInfo {
@@ -42,8 +42,6 @@ export default class PCTransport extends EventEmitter {
 
   private config?: RTCConfiguration;
 
-  private mediaConstraints: Record<string, unknown>;
-
   private log = log;
 
   private loggerOptions: LoggerOptions;
@@ -76,24 +74,16 @@ export default class PCTransport extends EventEmitter {
 
   onTrack?: (ev: RTCTrackEvent) => void;
 
-  constructor(
-    config?: RTCConfiguration,
-    mediaConstraints: Record<string, unknown> = {},
-    loggerOptions: LoggerOptions = {},
-  ) {
+  constructor(config?: RTCConfiguration, loggerOptions: LoggerOptions = {}) {
     super();
     this.log = getLogger(loggerOptions.loggerName ?? LoggerNames.PCTransport);
     this.loggerOptions = loggerOptions;
     this.config = config;
-    this.mediaConstraints = mediaConstraints;
     this._pc = this.createPC();
   }
 
   private createPC() {
-    const pc = isChromiumBased()
-      ? // @ts-expect-error chrome allows additional media constraints to be passed into the RTCPeerConnection constructor
-        new RTCPeerConnection(this.config, this.mediaConstraints)
-      : new RTCPeerConnection(this.config);
+    const pc = new RTCPeerConnection(this.config);
 
     pc.onicecandidate = (ev) => {
       if (!ev.candidate) return;

--- a/src/room/PCTransportManager.ts
+++ b/src/room/PCTransportManager.ts
@@ -71,8 +71,7 @@ export class PCTransportManager {
 
     this.isPublisherConnectionRequired = !subscriberPrimary;
     this.isSubscriberConnectionRequired = subscriberPrimary;
-    const googConstraints = { optional: [{ googDscp: true }] };
-    this.publisher = new PCTransport(rtcConfig, googConstraints, loggerOptions);
+    this.publisher = new PCTransport(rtcConfig, loggerOptions);
     this.subscriber = new PCTransport(rtcConfig, loggerOptions);
 
     this.publisher.onConnectionStateChange = this.updateState;


### PR DESCRIPTION
These constraints have been deprecated in Chromium since M103 and should be simply ignored by Chrome since then. 
Users reported errors however (coincidentally with Chrome 103) with the error message `Failed to construct 'RTCPeerConnection': Malformed constraints object.` Was not able to repro this error using Chrome 103.

Given that this constraint was only ever used for enabling setting local network priority and has been ignored in Chrome for a long time, it seems like it should be ok to remove it entirely and therefore reducing error potential. Removing it will mean manually setting `networkPriority` will not have any effect on Chrome prior to version 103.

Alternative would be to try/catch RTCPeerConnection instantiation. 