### PR TITLE
feat: add resuming state to room events

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -347,6 +347,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         this.registerConnectionReconcile();
         this.isResuming = false;
         this.log.info('Resumed signal connection', this.logContext);
+        this.setAndEmitConnectionState(ConnectionState.Connected);
         this.updateSubscriptions();
         this.emitBufferedEvents();
       })

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -88,6 +88,7 @@ export enum ConnectionState {
   Connecting = 'connecting',
   Connected = 'connected',
   Reconnecting = 'reconnecting',
+  Resuming = 'resuming',
 }
 
 const connectionReconcileFrequency = 2 * 1000;
@@ -340,6 +341,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         this.clearConnectionReconcile();
         this.isResuming = true;
         this.log.info('Resuming signal connection', this.logContext);
+        this.setAndEmitConnectionState(ConnectionState.Resuming);
       })
       .on(EngineEvent.Resumed, () => {
         this.registerConnectionReconcile();


### PR DESCRIPTION
I want to give users feedback about network events ASAP.
Currently, if network access is temporarily lost, the first event that gets emitted is a Reconnected event.
Having access to the internal Resuming event, we can show the users that something is up. This should help to avoid repeated "Hello? Can you hear me?" that nobody will ever hear ;)

WDYT?