### PR TITLE
Stronger kind type for Tracks to improve processor support

### DIFF
--- a/.changeset/honest-fireants-perform.md
+++ b/.changeset/honest-fireants-perform.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Stronger kind type for Tracks to improve processor support

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1776,7 +1776,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   };
 
   private onLocalTrackPublished = async (pub: LocalTrackPublication) => {
+    pub.track?.getProcessor()?.onPublish?.(this);
+
     this.emit(RoomEvent.LocalTrackPublished, pub, this.localParticipant);
+
     if (pub.track instanceof LocalAudioTrack) {
       const trackIsSilent = await pub.track.checkForSilence();
       if (trackIsSilent) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -888,7 +888,6 @@ export default class LocalParticipant extends Participant {
     }
 
     this.addTrackPublication(publication);
-    publication.track?.onTrackPublished(this.engine);
     // send event for publication
     this.emit(ParticipantEvent.LocalTrackPublished, publication);
     return publication;

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -888,7 +888,7 @@ export default class LocalParticipant extends Participant {
     }
 
     this.addTrackPublication(publication);
-
+    publication.track?.onTrackPublished(this.engine);
     // send event for publication
     this.emit(ParticipantEvent.LocalTrackPublished, publication);
     return publication;

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -13,8 +13,6 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
   /** @internal */
   stopOnMute: boolean = false;
 
-  private audioContext?: AudioContext;
-
   private prevStats?: AudioSenderStats;
 
   protected processor?: TrackProcessor<Track.Kind.Audio, AudioProcessorOptions> | undefined;

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -6,16 +6,18 @@ import { isWeb, unwrapConstraint } from '../utils';
 import LocalTrack from './LocalTrack';
 import { Track } from './Track';
 import type { AudioCaptureOptions } from './options';
-import type { TrackProcessor } from './processor/types';
+import type { AudioProcessorOptions, TrackProcessor } from './processor/types';
 import { constraintsForOptions, detectSilence } from './utils';
 
-export default class LocalAudioTrack extends LocalTrack {
+export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
   /** @internal */
   stopOnMute: boolean = false;
 
   private audioContext?: AudioContext;
 
   private prevStats?: AudioSenderStats;
+
+  protected processor?: TrackProcessor<Track.Kind.Audio, AudioProcessorOptions> | undefined;
 
   /**
    *
@@ -48,7 +50,7 @@ export default class LocalAudioTrack extends LocalTrack {
     );
   }
 
-  async mute(): Promise<LocalAudioTrack> {
+  async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
     try {
       // disabled special handling as it will cause BT headsets to switch communication modes
@@ -64,7 +66,7 @@ export default class LocalAudioTrack extends LocalTrack {
     }
   }
 
-  async unmute(): Promise<LocalAudioTrack> {
+  async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
     try {
       const deviceHasChanged =
@@ -99,7 +101,7 @@ export default class LocalAudioTrack extends LocalTrack {
     await this.restart(constraints);
   }
 
-  protected async restart(constraints?: MediaTrackConstraints): Promise<LocalTrack> {
+  protected async restart(constraints?: MediaTrackConstraints): Promise<typeof this> {
     const track = await super.restart(constraints);
     this.checkForSilence();
     return track;
@@ -139,7 +141,7 @@ export default class LocalAudioTrack extends LocalTrack {
     this.prevStats = stats;
   };
 
-  async setProcessor(processor: TrackProcessor<this['kind']>) {
+  async setProcessor(processor: TrackProcessor<Track.Kind.Audio, AudioProcessorOptions>) {
     const unlock = await this.processorLock.lock();
     try {
       if (!this.audioContext) {
@@ -149,9 +151,6 @@ export default class LocalAudioTrack extends LocalTrack {
       }
       if (this.processor) {
         await this.stopProcessor();
-      }
-      if (this.kind === 'unknown') {
-        throw TypeError('cannot set processor on track of unknown kind');
       }
 
       const processorOptions = {

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -1,7 +1,6 @@
 import { debounce } from 'ts-debounce';
 import { getBrowser } from '../../utils/browserParser';
 import DeviceManager from '../DeviceManager';
-import type RTCEngine from '../RTCEngine';
 import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
 import { TrackEvent } from '../events';
 import type { LoggerOptions } from '../types';
@@ -487,20 +486,6 @@ export default abstract class LocalTrack<
     this.processorElement = undefined;
 
     await this.restart();
-  }
-
-  /**
-   * @internal
-   */
-  async onTrackPublished(engine: RTCEngine) {
-    if (this.processor) {
-      const unlock = await this.processorLock.lock();
-      try {
-        await this.processor.onPublish?.(engine);
-      } finally {
-        unlock();
-      }
-    }
   }
 
   protected abstract monitorSender(): void;

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -30,7 +30,7 @@ export class SimulcastTrackInfo {
 
 const refreshSubscribedCodecAfterNewCodec = 5000;
 
-export default class LocalVideoTrack extends LocalTrack {
+export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
   /* @internal */
   signalClient?: SignalClient;
 
@@ -115,7 +115,7 @@ export default class LocalVideoTrack extends LocalTrack {
     }
   }
 
-  async mute(): Promise<LocalVideoTrack> {
+  async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
     try {
       if (this.source === Track.Source.Camera && !this.isUserProvided) {
@@ -130,7 +130,7 @@ export default class LocalVideoTrack extends LocalTrack {
     }
   }
 
-  async unmute(): Promise<LocalVideoTrack> {
+  async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
     try {
       if (this.source === Track.Source.Camera && !this.isUserProvided) {

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -7,7 +7,7 @@ import RemoteTrack from './RemoteTrack';
 import { Track } from './Track';
 import type { AudioOutputOptions } from './options';
 
-export default class RemoteAudioTrack extends RemoteTrack {
+export default class RemoteAudioTrack extends RemoteTrack<Track.Kind.Audio> {
   private prevStats?: AudioReceiverStats;
 
   private elementVolume: number | undefined;

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -3,14 +3,16 @@ import { monitorFrequency } from '../stats';
 import type { LoggerOptions } from '../types';
 import { Track } from './Track';
 
-export default abstract class RemoteTrack extends Track {
+export default abstract class RemoteTrack<
+  TrackKind extends Track.Kind = Track.Kind,
+> extends Track<TrackKind> {
   /** @internal */
   receiver?: RTCRtpReceiver;
 
   constructor(
     mediaTrack: MediaStreamTrack,
     sid: string,
-    kind: Track.Kind,
+    kind: TrackKind,
     receiver?: RTCRtpReceiver,
     loggerOptions?: LoggerOptions,
   ) {

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -12,7 +12,7 @@ import type { AdaptiveStreamSettings } from './types';
 
 const REACTION_DELAY = 100;
 
-export default class RemoteVideoTrack extends RemoteTrack {
+export default class RemoteVideoTrack extends RemoteTrack<Track.Kind.Video> {
   private prevStats?: VideoReceiverStats;
 
   private elementInfos: ElementInfo[] = [];

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -24,8 +24,10 @@ export enum VideoQuality {
   MEDIUM = ProtoQuality.MEDIUM,
   HIGH = ProtoQuality.HIGH,
 }
-export abstract class Track extends (EventEmitter as new () => TypedEventEmitter<TrackEventCallbacks>) {
-  kind: Track.Kind;
+export abstract class Track<
+  TrackKind extends Track.Kind = Track.Kind,
+> extends (EventEmitter as new () => TypedEventEmitter<TrackEventCallbacks>) {
+  readonly kind: TrackKind;
 
   attachedElements: HTMLMediaElement[] = [];
 
@@ -67,7 +69,7 @@ export abstract class Track extends (EventEmitter as new () => TypedEventEmitter
 
   protected constructor(
     mediaTrack: MediaStreamTrack,
-    kind: Track.Kind,
+    kind: TrackKind,
     loggerOptions: LoggerOptions = {},
   ) {
     super();

--- a/src/room/track/processor/types.ts
+++ b/src/room/track/processor/types.ts
@@ -7,6 +7,7 @@ export type ProcessorOptions<T extends Track.Kind> = {
   kind: T;
   track: MediaStreamTrack;
   element?: HTMLMediaElement;
+  audioContext?: AudioContext;
 };
 
 /**

--- a/src/room/track/processor/types.ts
+++ b/src/room/track/processor/types.ts
@@ -1,3 +1,4 @@
+import type RTCEngine from '../../RTCEngine';
 import type { Track } from '../Track';
 
 /**
@@ -34,4 +35,6 @@ export interface TrackProcessor<
   restart: (opts: U) => Promise<void>;
   destroy: () => Promise<void>;
   processedTrack?: MediaStreamTrack;
+  onPublish?: (engine: RTCEngine) => Promise<void>;
+  onUnpublish?: () => Promise<void>;
 }

--- a/src/room/track/processor/types.ts
+++ b/src/room/track/processor/types.ts
@@ -1,4 +1,4 @@
-import type RTCEngine from '../../RTCEngine';
+import type Room from '../../Room';
 import type { Track } from '../Track';
 
 /**
@@ -35,6 +35,6 @@ export interface TrackProcessor<
   restart: (opts: U) => Promise<void>;
   destroy: () => Promise<void>;
   processedTrack?: MediaStreamTrack;
-  onPublish?: (engine: RTCEngine) => Promise<void>;
+  onPublish?: (room: Room) => Promise<void>;
   onUnpublish?: () => Promise<void>;
 }


### PR DESCRIPTION
this makes `kind` of `Track`s readonly and makes it easier to deal with different options needed for different processor types (e.g. video vs. audio). 

This should not break any existing types.