### PR TITLE
Send worker loglevel in init message

### DIFF
--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import type TypedEventEmitter from 'typed-emitter';
-import log from '../logger';
+import log, { LogLevel, workerLogger } from '../logger';
 import { Encryption_Type, TrackInfo } from '../proto/livekit_models_pb';
 import type RTCEngine from '../room/RTCEngine';
 import type Room from '../room/Room';
@@ -68,6 +68,7 @@ export class E2EEManager extends (EventEmitter as new () => TypedEventEmitter<E2
         kind: 'init',
         data: {
           keyProviderOptions: this.keyProvider.getOptions(),
+          loglevel: workerLogger.getLevel() as LogLevel,
         },
       };
       if (this.worker) {

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -1,3 +1,4 @@
+import type { LogLevel } from '../logger';
 import type { VideoCodec } from '../room/track/options';
 import type { BaseKeyProvider } from './KeyProvider';
 
@@ -10,6 +11,7 @@ export interface InitMessage extends BaseMessage {
   kind: 'init';
   data: {
     keyProviderOptions: KeyProviderOptions;
+    loglevel: LogLevel;
   };
 }
 
@@ -90,6 +92,13 @@ export interface ErrorMessage extends BaseMessage {
   };
 }
 
+export interface LogLvlMessage extends BaseMessage {
+  kind: 'loglevel';
+  data: {
+    level: string;
+  };
+}
+
 export interface EnableMessage extends BaseMessage {
   kind: 'enable';
   data: {
@@ -117,7 +126,8 @@ export type E2EEWorkerMessage =
   | RatchetRequestMessage
   | RatchetMessage
   | SifTrailerMessage
-  | InitAck;
+  | InitAck
+  | LogLvlMessage;
 
 export type KeySet = { material: CryptoKey; encryptionKey: CryptoKey };
 

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -32,6 +32,7 @@ onmessage = (ev) => {
 
   switch (kind) {
     case 'init':
+      workerLogger.setLevel(data.loglevel);
       workerLogger.info('worker initialized');
       keyProviderOptions = data.keyProviderOptions;
       useSharedKey = !!data.keyProviderOptions.sharedKey;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -31,6 +31,8 @@ export type StructuredLogger = {
   warn: (msg: string, context?: object) => void;
   error: (msg: string, context?: object) => void;
   setDefaultLevel: (level: log.LogLevelDesc) => void;
+  setLevel: (level: log.LogLevelDesc) => void;
+  getLevel: () => number;
 };
 
 let livekitLogger = log.getLogger('livekit');


### PR DESCRIPTION
Calling `setLevel` for the worker logger doesn't have any influence by default for the logger being loaded within a webworker. There's no shared scope and also webworkers don't have access to localstorage. 
This PR simply sends the current loglevel with the `init` message to the worker. This allows the level to be set at least once on initialization. 