### PR TITLE
Only perform mute/unmute actions if necessary

### DIFF
--- a/.changeset/unlucky-planets-trade.md
+++ b/.changeset/unlucky-planets-trade.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Only perform mute/unmute actions if necessary

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -50,7 +50,6 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
 
   async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-
     try {
       if (this.isMuted) {
         this.log.debug('Track already muted', this.logContext);
@@ -72,7 +71,6 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
 
   async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-
     try {
       if (!this.isMuted) {
         this.log.debug('Track already unmuted', this.logContext);

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -50,11 +50,13 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
 
   async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-    if (this.isMuted) {
-      this.log.debug('Track already muted', this.logContext);
-      return this;
-    }
+
     try {
+      if (this.isMuted) {
+        this.log.debug('Track already muted', this.logContext);
+        return this;
+      }
+
       // disabled special handling as it will cause BT headsets to switch communication modes
       if (this.source === Track.Source.Microphone && this.stopOnMute && !this.isUserProvided) {
         this.log.debug('stopping mic track', this.logContext);
@@ -70,11 +72,13 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
 
   async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-    if (!this.isMuted) {
-      this.log.debug('Track already unmuted', this.logContext);
-      return this;
-    }
+
     try {
+      if (!this.isMuted) {
+        this.log.debug('Track already unmuted', this.logContext);
+        return this;
+      }
+
       const deviceHasChanged =
         this._constraints.deviceId &&
         this._mediaStreamTrack.getSettings().deviceId !==

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -50,6 +50,10 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
 
   async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
+    if (this.isMuted) {
+      this.log.debug('Track already muted', this.logContext);
+      return this;
+    }
     try {
       // disabled special handling as it will cause BT headsets to switch communication modes
       if (this.source === Track.Source.Microphone && this.stopOnMute && !this.isUserProvided) {
@@ -66,6 +70,10 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
 
   async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
+    if (!this.isMuted) {
+      this.log.debug('Track already unmuted', this.logContext);
+      return this;
+    }
     try {
       const deviceHasChanged =
         this._constraints.deviceId &&

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -117,7 +117,6 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-
     try {
       if (this.isMuted) {
         this.log.debug('Track already muted', this.logContext);
@@ -138,7 +137,6 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-
     try {
       if (!this.isMuted) {
         this.log.debug('Track already unmuted', this.logContext);

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -117,6 +117,10 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
+    if (this.isMuted) {
+      this.log.debug('Track already muted', this.logContext);
+      return this;
+    }
     try {
       if (this.source === Track.Source.Camera && !this.isUserProvided) {
         this.log.debug('stopping camera track', this.logContext);
@@ -132,6 +136,10 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
+    if (!this.isMuted) {
+      this.log.debug('Track already unmuted', this.logContext);
+      return this;
+    }
     try {
       if (this.source === Track.Source.Camera && !this.isUserProvided) {
         this.log.debug('reacquiring camera track', this.logContext);

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -117,11 +117,13 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   async mute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-    if (this.isMuted) {
-      this.log.debug('Track already muted', this.logContext);
-      return this;
-    }
+
     try {
+      if (this.isMuted) {
+        this.log.debug('Track already muted', this.logContext);
+        return this;
+      }
+
       if (this.source === Track.Source.Camera && !this.isUserProvided) {
         this.log.debug('stopping camera track', this.logContext);
         // also stop the track, so that camera indicator is turned off
@@ -136,11 +138,13 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   async unmute(): Promise<typeof this> {
     const unlock = await this.muteLock.lock();
-    if (!this.isMuted) {
-      this.log.debug('Track already unmuted', this.logContext);
-      return this;
-    }
+
     try {
+      if (!this.isMuted) {
+        this.log.debug('Track already unmuted', this.logContext);
+        return this;
+      }
+
       if (this.source === Track.Source.Camera && !this.isUserProvided) {
         this.log.debug('reacquiring camera track', this.logContext);
         await this.restartTrack();


### PR DESCRIPTION
restarting tracks seemingly takes a lot longer on new Safari versions (>=17.3.1). 
This tries to minimise that impact by avoiding unnecessary restarts to tracks. 
Previously calling `unmute` repeatedly would have led to multiple track restarts even if the track is unmuted already.