### PR TITLE
Make sure a 401 ConnectionError is thrown on invalid token permissions

### DIFF
--- a/.changeset/violet-lamps-join.md
+++ b/.changeset/violet-lamps-join.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Make sure a 401 ConnectionError is thrown on invalid token permissions

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -283,6 +283,7 @@ export class SignalClient {
 
         this.ws.onerror = async (ev: Event) => {
           if (this.state !== SignalConnectionState.CONNECTED) {
+            this.state = SignalConnectionState.DISCONNECTED;
             clearTimeout(wsTimeout);
             try {
               const resp = await fetch(`http${url.substring(2)}/validate${params}`);


### PR DESCRIPTION
Previously there was a race between a generic ConnectionError being thrown on websocket close and the `/validate` path completing (which is triggered by the ws's onerror callback) to reject the promise with the more detailed ConnectionError. 

This PR sets the signal connection state to `Disconnected` if the WS errors out during a connection attempt. This prevents the `onClose` handler on the ws to reject the connection promise preemptively