### PR TITLE
Don't treat PC config error as SignalReconnectError

### DIFF
--- a/.changeset/fast-goats-notice.md
+++ b/.changeset/fast-goats-notice.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Don't treat PC config error as SignalReconnectError

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -140,8 +140,6 @@ export class SignalClient {
 
   onLeave?: (leave: LeaveRequest) => void;
 
-  onReconnectResponse?: (response: ReconnectResponse) => void;
-
   connectOptions?: ConnectOpts;
 
   ws?: WebSocket;
@@ -359,8 +357,11 @@ export class SignalClient {
               this.startPingInterval();
               if (resp.message?.case === 'reconnect') {
                 resolve(resp.message.value);
-                this.onReconnectResponse?.(resp.message.value);
               } else {
+                this.log.debug(
+                  'declaring signal reconnected without reconnect response received',
+                  this.logContext,
+                );
                 resolve(undefined);
                 shouldProcessMessage = true;
               }

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -216,7 +216,7 @@ export class SignalClient {
     token: string,
     sid?: string,
     reason?: ReconnectReason,
-  ): Promise<ReconnectResponse | void> {
+  ): Promise<ReconnectResponse | undefined> {
     if (!this.options) {
       this.log.warn(
         'attempted to reconnect without signal options being set, ignoring',
@@ -242,7 +242,7 @@ export class SignalClient {
     token: string,
     opts: ConnectOpts,
     abortSignal?: AbortSignal,
-  ): Promise<JoinResponse | ReconnectResponse | void> {
+  ): Promise<JoinResponse | ReconnectResponse | undefined> {
     this.connectOptions = opts;
     url = toWebsocketUrl(url);
     // strip trailing slash
@@ -252,7 +252,7 @@ export class SignalClient {
     const clientInfo = getClientInfo();
     const params = createConnectionParams(token, clientInfo, opts);
 
-    return new Promise<JoinResponse | ReconnectResponse | void>(async (resolve, reject) => {
+    return new Promise<JoinResponse | ReconnectResponse | undefined>(async (resolve, reject) => {
       const unlock = await this.connectionLock.lock();
       try {
         const abortHandler = async () => {
@@ -358,7 +358,7 @@ export class SignalClient {
               if (resp.message?.case === 'reconnect') {
                 resolve(resp.message?.value);
               } else {
-                resolve();
+                resolve(undefined);
                 shouldProcessMessage = true;
               }
             } else if (this.isEstablishingConnection && resp.message.case === 'leave') {

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -140,6 +140,8 @@ export class SignalClient {
 
   onLeave?: (leave: LeaveRequest) => void;
 
+  onReconnectResponse?: (response: ReconnectResponse) => void;
+
   connectOptions?: ConnectOpts;
 
   ws?: WebSocket;
@@ -356,7 +358,8 @@ export class SignalClient {
               abortSignal?.removeEventListener('abort', abortHandler);
               this.startPingInterval();
               if (resp.message?.case === 'reconnect') {
-                resolve(resp.message?.value);
+                resolve(resp.message.value);
+                this.onReconnectResponse?.(resp.message.value);
               } else {
                 resolve(undefined);
                 shouldProcessMessage = true;

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1005,14 +1005,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     this.log.info(`resuming signal connection, attempt ${this.reconnectAttempts}`, this.logContext);
     this.emit(EngineEvent.Resuming);
-
+    let res: ReconnectResponse | undefined;
     try {
       this.setupSignalClientCallbacks();
-      const res = await this.client.reconnect(this.url, this.token, this.participantSid, reason);
-      if (res) {
-        const rtcConfig = this.makeRTCConfiguration(res);
-        this.pcManager.updateConfiguration(rtcConfig);
-      }
+      res = await this.client.reconnect(this.url, this.token, this.participantSid, reason);
     } catch (error) {
       let message = '';
       if (error instanceof Error) {
@@ -1027,7 +1023,13 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
       throw new SignalReconnectError(message);
     }
+
     this.emit(EngineEvent.SignalResumed);
+
+    if (res) {
+      const rtcConfig = this.makeRTCConfiguration(res);
+      this.pcManager.updateConfiguration(rtcConfig);
+    }
 
     if (this.shouldFailNext) {
       this.shouldFailNext = false;

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1009,12 +1009,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     let res: ReconnectResponse | undefined;
     try {
       this.setupSignalClientCallbacks();
-      this.client.onReconnectResponse = (response) => {
-        res = response;
-      };
-      await this.client.reconnect(this.url, this.token, this.participantSid, reason);
+      res = await this.client.reconnect(this.url, this.token, this.participantSid, reason);
     } catch (error) {
-      this.client.onReconnectResponse = undefined;
       let message = '';
       if (error instanceof Error) {
         message = error.message;
@@ -1038,7 +1034,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         }
         await sleep(50);
       }
-      this.client.onReconnectResponse = undefined;
     }
 
     if (res) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1023,7 +1023,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
       throw new SignalReconnectError(message);
     }
-
     this.emit(EngineEvent.SignalResumed);
 
     if (res) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1040,7 +1040,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       const rtcConfig = this.makeRTCConfiguration(res);
       this.pcManager.updateConfiguration(rtcConfig);
     } else {
-      this.log.warn('Did not receive reconnect response after timeout', this.logContext);
+      this.log.warn('Did not receive reconnect response', this.logContext);
     }
 
     if (this.shouldFailNext) {

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -424,7 +424,11 @@ async function setPublishingLayersForSender(
     }
 
     if (encodings.length !== senderEncodings.length) {
-      log.warn('cannot set publishing layers, encodings mismatch');
+      log.warn('cannot set publishing layers, encodings mismatch', {
+        ...logContext,
+        encodings,
+        senderEncodings,
+      });
       return;
     }
 


### PR DESCRIPTION
closes #1050 

Previously an exception thrown in `pc.setConfiguration` was treated as a `SignalReconnectError` which in turn meant the engine kept trying to resume, while a full reconnect would be the appropriate measure. 
