### PR TITLE
Set logExtension on all livekit loggers if not specified

### DIFF
--- a/.changeset/afraid-mails-reflect.md
+++ b/.changeset/afraid-mails-reflect.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Set logExtension on all livekit loggers if not specified

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -36,17 +36,11 @@ export type StructuredLogger = log.Logger & {
 };
 
 let livekitLogger = log.getLogger('livekit');
+const livekitLoggers = Object.values(LoggerNames).map((name) => log.getLogger(name));
 
 livekitLogger.setDefaultLevel(LogLevel.info);
 
 export default livekitLogger as StructuredLogger;
-
-function getLiveKitLoggers() {
-  const loggers = Object.entries(log.getLoggers()).filter(
-    ([logrName]) => logrName.startsWith('livekit') || logrName.startsWith('lk-'),
-  );
-  return loggers.map(([, logger]) => logger);
-}
 
 /**
  * @internal
@@ -61,7 +55,7 @@ export function setLogLevel(level: LogLevel | LogLevelString, loggerName?: Logge
   if (loggerName) {
     log.getLogger(loggerName).setLevel(level);
   }
-  for (const logger of getLiveKitLoggers()) {
+  for (const logger of livekitLoggers) {
     logger.setLevel(level);
   }
 }
@@ -73,7 +67,7 @@ export type LogExtension = (level: LogLevel, msg: string, context?: object) => v
  * if set, the browser logs will lose their stacktrace information (see https://github.com/pimterry/loglevel#writing-plugins)
  */
 export function setLogExtension(extension: LogExtension, logger?: StructuredLogger) {
-  const loggers = logger ? [logger] : getLiveKitLoggers();
+  const loggers = logger ? [logger] : livekitLoggers;
 
   loggers.forEach((logR) => {
     const originalFactory = logR.methodFactory;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,7 +24,7 @@ export enum LoggerNames {
 
 type LogLevelString = keyof typeof LogLevel;
 
-export type StructuredLogger = {
+export type StructuredLogger = log.Logger & {
   trace: (msg: string, context?: object) => void;
   debug: (msg: string, context?: object) => void;
   info: (msg: string, context?: object) => void;
@@ -41,6 +41,13 @@ livekitLogger.setDefaultLevel(LogLevel.info);
 
 export default livekitLogger as StructuredLogger;
 
+function getLiveKitLoggers() {
+  const loggers = Object.entries(log.getLoggers()).filter(
+    ([logrName]) => logrName.startsWith('livekit') || logrName.startsWith('lk-'),
+  );
+  return loggers.map(([, logger]) => logger);
+}
+
 /**
  * @internal
  */
@@ -54,9 +61,7 @@ export function setLogLevel(level: LogLevel | LogLevelString, loggerName?: Logge
   if (loggerName) {
     log.getLogger(loggerName).setLevel(level);
   }
-  for (const logger of Object.entries(log.getLoggers())
-    .filter(([logrName]) => logrName.startsWith('livekit'))
-    .map(([, logr]) => logr)) {
+  for (const logger of getLiveKitLoggers()) {
     logger.setLevel(level);
   }
 }
@@ -67,24 +72,28 @@ export type LogExtension = (level: LogLevel, msg: string, context?: object) => v
  * use this to hook into the logging function to allow sending internal livekit logs to third party services
  * if set, the browser logs will lose their stacktrace information (see https://github.com/pimterry/loglevel#writing-plugins)
  */
-export function setLogExtension(extension: LogExtension, logger = livekitLogger) {
-  const originalFactory = logger.methodFactory;
+export function setLogExtension(extension: LogExtension, logger?: StructuredLogger) {
+  const loggers = logger ? [logger] : getLiveKitLoggers();
 
-  logger.methodFactory = (methodName, configLevel, loggerName) => {
-    const rawMethod = originalFactory(methodName, configLevel, loggerName);
+  loggers.forEach((logR) => {
+    const originalFactory = logR.methodFactory;
 
-    const logLevel = LogLevel[methodName as LogLevelString];
-    const needLog = logLevel >= configLevel && logLevel < LogLevel.silent;
+    logR.methodFactory = (methodName, configLevel, loggerName) => {
+      const rawMethod = originalFactory(methodName, configLevel, loggerName);
 
-    return (msg, context?: [msg: string, context: object]) => {
-      if (context) rawMethod(msg, context);
-      else rawMethod(msg);
-      if (needLog) {
-        extension(logLevel, msg, context);
-      }
+      const logLevel = LogLevel[methodName as LogLevelString];
+      const needLog = logLevel >= configLevel && logLevel < LogLevel.silent;
+
+      return (msg, context?: [msg: string, context: object]) => {
+        if (context) rawMethod(msg, context);
+        else rawMethod(msg);
+        if (needLog) {
+          extension(logLevel, msg, context);
+        }
+      };
     };
-  };
-  logger.setLevel(logger.getLevel()); // Be sure to call setLevel method in order to apply plugin
+    logR.setLevel(logR.getLevel());
+  });
 }
 
 export const workerLogger = log.getLogger('lk-e2ee') as StructuredLogger;


### PR DESCRIPTION
We shifted to more granular (class based) loggers.
This PR sets the `LogExtension` on all those class based loggers by default (instead of just on one), unless a specific logger gets passed to `setLogLevel` as a second argument. 