### PR TITLE
Demote facingMode logs to trace

### DIFF
--- a/.changeset/swift-peaches-compare.md
+++ b/.changeset/swift-peaches-compare.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Demote facingMode logs to trace

--- a/src/room/track/facingMode.ts
+++ b/src/room/track/facingMode.ts
@@ -47,7 +47,7 @@ export function facingModeFromLocalTrack(
   // 1. Try to get facingMode from track settings.
   if ('facingMode' in trackSettings) {
     const rawFacingMode = trackSettings.facingMode;
-    log.debug('rawFacingMode', { rawFacingMode });
+    log.trace('rawFacingMode', { rawFacingMode });
     if (rawFacingMode && typeof rawFacingMode === 'string' && isFacingModeValue(rawFacingMode)) {
       result = { facingMode: rawFacingMode, confidence: 'high' };
     }
@@ -55,7 +55,7 @@ export function facingModeFromLocalTrack(
 
   // 2. If we don't have a high confidence we try to get the facing mode from the device label.
   if (['low', 'medium'].includes(result.confidence)) {
-    log.debug(`Try to get facing mode from device label: (${track.label})`);
+    log.trace(`Try to get facing mode from device label: (${track.label})`);
     const labelAnalysisResult = facingModeFromDeviceLabel(track.label);
     if (labelAnalysisResult !== undefined) {
       result = labelAnalysisResult;


### PR DESCRIPTION
Within components these logs are spamming the console too much so that extracted logs are cut off due to too many instances of this log. 