### PR TITLE
Read deviceId from source mediastreamtrack

### DIFF
--- a/.changeset/eleven-ravens-wonder.md
+++ b/.changeset/eleven-ravens-wonder.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Read deviceId from source mediastreamtrack

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -38,7 +38,7 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
   async setDeviceId(deviceId: ConstrainDOMString): Promise<boolean> {
     if (
       this._constraints.deviceId === deviceId &&
-      this._mediaStreamTrack.getSettings().deviceId === deviceId
+      this._mediaStreamTrack.getSettings().deviceId === unwrapConstraint(deviceId)
     ) {
       return true;
     }

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -36,7 +36,10 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
   }
 
   async setDeviceId(deviceId: ConstrainDOMString): Promise<boolean> {
-    if (this._constraints.deviceId === deviceId) {
+    if (
+      this._constraints.deviceId === deviceId &&
+      this._mediaStreamTrack.getSettings().deviceId === deviceId
+    ) {
       return true;
     }
     this._constraints.deviceId = deviceId;
@@ -44,7 +47,7 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
       await this.restartTrack();
     }
     return (
-      this.isMuted || unwrapConstraint(deviceId) === this.mediaStreamTrack.getSettings().deviceId
+      this.isMuted || unwrapConstraint(deviceId) === this._mediaStreamTrack.getSettings().deviceId
     );
   }
 


### PR DESCRIPTION
with LocalAudioTracks supporting the processor API now, we have to make sure to not read the settings from the processedTrack but from the underlying source mediaStreamTrack instead.

This was in place already for `LocalVideoTrack` but I missed to update the same logic for `LocalAudioTrack` when adding the processor support. 

The way this manifested was that `setDeviceId` would return `false` when a processor is set, even though the device had actually changed.