### PR TITLE
Fix FPS and latency bugs with VP9 screenshare.

### DIFF
--- a/.changeset/smooth-glasses-jam.md
+++ b/.changeset/smooth-glasses-jam.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix FPS and latency issues with VP9 screenshare

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -736,7 +736,16 @@ export default class LocalParticipant extends Participant {
         if (isSVCCodec(videoCodec)) {
           // vp9 svc with screenshare has problem to encode, always use L1T3 here
           if (track.source === Track.Source.ScreenShare && videoCodec === 'vp9') {
-            opts.scalabilityMode = 'L1T3';
+            // Chrome does not allow more than 5 fps with L1T3, and it has encoding bugs with L3T3
+            // It has a different path for screenshare handling and it seems to be untested/buggy
+            // As a workaround, we are setting contentHint to force it to go through the same
+            // path as regular camera video. While this is not optimal, it delivers the performance
+            // that we need
+            if ('contentHint' in track.mediaStreamTrack) {
+              track.mediaStreamTrack.contentHint = 'motion';
+            } else {
+              opts.scalabilityMode = 'L1T3';
+            }
           }
           // set scalabilityMode to 'L3T3_KEY' by default
           opts.scalabilityMode = opts.scalabilityMode ?? 'L3T3_KEY';

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -743,6 +743,10 @@ export default class LocalParticipant extends Participant {
             // that we need
             if ('contentHint' in track.mediaStreamTrack) {
               track.mediaStreamTrack.contentHint = 'motion';
+              this.log.info('forcing contentHint to motion for screenshare with VP9', {
+                ...this.logContext,
+                ...getLogContextFromTrack(track),
+              });
             } else {
               opts.scalabilityMode = 'L1T3';
             }

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -1,6 +1,6 @@
 import { TrackEvent } from '../events';
-import { computeBitrate } from '../stats';
 import type { AudioReceiverStats } from '../stats';
+import { computeBitrate } from '../stats';
 import type { LoggerOptions } from '../types';
 import { isReactNative, supportsSetSinkId } from '../utils';
 import RemoteTrack from './RemoteTrack';


### PR DESCRIPTION
Also restored L3T3_KEY publishing for screen share. It was disabled previously.

Chrome does not allow more than 5 fps with L1T3, and it has encoding bugs with L3T3 It has a different path for screenshare handling and it seems to be untested/buggy As a workaround, we are setting contentHint to force it to go through the same path as regular camera video. While this is not optimal, it delivers the performance that we need.

The problem is [here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/video_coding/codecs/vp9/svc_config.cc;drc=b8a4daa31c86ef61f7a78ea73711b86ab732db32;l=31). where layer 0 always gets capped at 5fps, and it doesn't get reset to 30 even if there's [only a single layer](https://source.chromium.org/chromium/chromium/src/+/main:third_party/webrtc/modules/video_coding/codecs/vp9/svc_config.cc;l=207;drc=b8a4daa31c86ef61f7a78ea73711b86ab732db32) published.