### PR TITLE
Fix quality issues with SVC screenshares.

### DIFF
--- a/.changeset/wet-kids-unite.md
+++ b/.changeset/wet-kids-unite.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix quality issues with SVC screenshares

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -329,7 +329,11 @@ const appActions = {
     const enabled = currentRoom.localParticipant.isScreenShareEnabled;
     appendLog(`${enabled ? 'stopping' : 'starting'} screen share`);
     setButtonDisabled('share-screen-button', true);
-    await currentRoom.localParticipant.setScreenShareEnabled(!enabled, { audio: true });
+    try {
+      await currentRoom.localParticipant.setScreenShareEnabled(!enabled, { audio: true });
+    } catch (e) {
+      appendLog('error sharing screen', e);
+    }
     setButtonDisabled('share-screen-button', false);
     updateButtonsForPublishState();
   },

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -732,8 +732,10 @@ export default class LocalParticipant extends Participant {
       // for svc codecs, disable simulcast and use vp8 for backup codec
       if (track instanceof LocalVideoTrack) {
         if (isSVCCodec(videoCodec)) {
-          // vp9 svc with screenshare has problem to encode, always use L1T3 here
           if (track.source === Track.Source.ScreenShare && videoCodec === 'vp9') {
+            // vp9 svc with screenshare cannot encode multiple spatial layers
+            // doing so reduces publish resolution to minimal resolution
+            opts.scalabilityMode = 'L1T3';
             // Chrome does not allow more than 5 fps with L1T3, and it has encoding bugs with L3T3
             // It has a different path for screenshare handling and it seems to be untested/buggy
             // As a workaround, we are setting contentHint to force it to go through the same
@@ -745,8 +747,6 @@ export default class LocalParticipant extends Participant {
                 ...this.logContext,
                 ...getLogContextFromTrack(track),
               });
-            } else {
-              opts.scalabilityMode = 'L1T3';
             }
           }
           // set scalabilityMode to 'L3T3_KEY' by default

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -125,8 +125,6 @@ export function computeVideoEncodings(
   );
 
   if (scalabilityMode && isSVCCodec(videoCodec)) {
-    log.debug(`using svc with scalabilityMode ${scalabilityMode}`);
-
     const sm = new ScalabilityMode(scalabilityMode);
 
     const encodings: RTCRtpEncodingParameters[] = [];
@@ -134,17 +132,14 @@ export function computeVideoEncodings(
     if (sm.spatial > 3) {
       throw new Error(`unsupported scalabilityMode: ${scalabilityMode}`);
     }
-    for (let i = 0; i < sm.spatial; i += 1) {
-      encodings.push({
-        rid: videoRids[2 - i],
-        maxBitrate: videoEncoding.maxBitrate / 3 ** i,
-        /* @ts-ignore */
-        maxFramerate: original.encoding.maxFramerate,
-      });
-    }
-    /* @ts-ignore */
-    encodings[0].scalabilityMode = scalabilityMode;
-    log.debug('encodings', encodings);
+    encodings.push({
+      maxBitrate: videoEncoding.maxBitrate,
+      /* @ts-ignore */
+      maxFramerate: original.encoding.maxFramerate,
+      /* @ts-ignore */
+      scalabilityMode: scalabilityMode,
+    });
+    log.debug(`using svc encoding`, encodings[0]);
     return encodings;
   }
 


### PR DESCRIPTION
When we munged SDP to set bitrate, it was set on the codec's fmtp line.
The codec and its fmtp is shared across media tracks. So if a user is sharing
a camera and screenshare tracks, both tracks will be published at the
same bitrate (typically the user's camera track). This leads to blurry
screenshares.

Additionally, screenshares cannot be encoded in VP9 with L3T3_KEY. Chrome
degrades quality aggressively whenever L1T3 isn't used.