### PR TITLE
Handle SVC compatibility with Safari and Chrome prior to M113

### DIFF
--- a/.changeset/neat-cars-sparkle.md
+++ b/.changeset/neat-cars-sparkle.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Handle SVC compatibility with Safari and Chrome prior to M113


### PR DESCRIPTION
Before M113 in Chrome, defining multiple encodings with an SVC codec indicated that SVC mode should be used. Safari still works this way. This is a bit confusing but is due to how libwebrtc interpreted the encodings field before M113.

Announced here: https://groups.google.com/g/discuss-webrtc/c/-QQ3pxrl-fw?pli=1