### PR TITLE
Use legacy SVC encoding specification for React-Native

### DIFF
--- a/.changeset/chilly-grapes-report.md
+++ b/.changeset/chilly-grapes-report.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Use legacy SVC encoding specification for React-Native

--- a/example/sample.ts
+++ b/example/sample.ts
@@ -96,6 +96,7 @@ const appActions = {
         red: true,
         forceStereo: false,
         screenShareEncoding: ScreenSharePresets.h1080fps30.encoding,
+        scalabilityMode: 'L3T3',
       },
       videoCaptureDefaults: {
         resolution: VideoPresets.h720.resolution,

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -148,8 +148,8 @@ export function computeVideoEncodings(
     const browser = getBrowser();
     if (
       isSafari() ||
-      // Event tho RN runs M114, it does not produce SVC layers when a single encoding
-      // is provided. So we'll use the legacy SVC mode.
+      // Even tho RN runs M114, it does not produce SVC layers when a single encoding
+      // is provided. So we'll use the legacy SVC specification for now.
       // TODO: when we upstream libwebrtc, this will need additional verification
       isReactNative() ||
       (browser?.name === 'Chrome' && compareVersions(browser?.version, '113') < 0)

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -148,6 +148,8 @@ export function computeVideoEncodings(
     const browser = getBrowser();
     if (
       isSafari() ||
+      // TODO: RN requires legacy for now
+      isReactNative() ||
       (browser?.name === 'Chrome' && compareVersions(browser?.version, '113') < 0)
     ) {
       for (let i = 0; i < sm.spatial; i += 1) {

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -148,7 +148,9 @@ export function computeVideoEncodings(
     const browser = getBrowser();
     if (
       isSafari() ||
-      // TODO: RN requires legacy for now
+      // Event tho RN runs M114, it does not produce SVC layers when a single encoding
+      // is provided. So we'll use the legacy SVC mode.
+      // TODO: when we upstream libwebrtc, this will need additional verification
       isReactNative() ||
       (browser?.name === 'Chrome' && compareVersions(browser?.version, '113') < 0)
     ) {


### PR DESCRIPTION
Even tho RN runs M114, it does not produce SVC layers when a single encoding is provided.
So we'll use the legacy SVC specification for now.