### PR TITLE
Force playback after app visibility changes back to visible

### DIFF
--- a/.changeset/lemon-horses-cover.md
+++ b/.changeset/lemon-horses-cover.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Force playback after app visibility changes back to visible

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -301,6 +301,20 @@ export abstract class Track<
 
   protected async handleAppVisibilityChanged() {
     this.isInBackground = document.visibilityState === 'hidden';
+    if (!this.isInBackground && this.kind === Track.Kind.Video) {
+      setTimeout(
+        () =>
+          this.attachedElements.forEach((el) =>
+            el
+              .play()
+              .then(() => this.log.debug('resumed video playback'))
+              .catch(() => {
+                /** catch clause necessary for Safari */
+              }),
+          ),
+        0,
+      );
+    }
   }
 
   protected addAppVisibilityListener() {

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -305,12 +305,9 @@ export abstract class Track<
       setTimeout(
         () =>
           this.attachedElements.forEach((el) =>
-            el
-              .play()
-              .then(() => this.log.debug('resumed video playback'))
-              .catch(() => {
-                /** catch clause necessary for Safari */
-              }),
+            el.play().catch(() => {
+              /** catch clause necessary for Safari */
+            }),
           ),
         0,
       );


### PR DESCRIPTION
On Safari sometimes the video element failed to auto play again after the browser came back from being in the background. 
In order to work around this, we force `play` to be called on all attached elements once the app comes back into the foreground.