### PR TITLE
Await data publisher connection without multiple negotiations

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -169,6 +169,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
   private loggerOptions: LoggerOptions;
 
+  private publisherConnectionPromise: Promise<void> | undefined;
+
   constructor(private options: InternalRoomOptions) {
     super();
     this.log = getLogger(options.loggerName ?? LoggerNames.Engine);
@@ -1179,7 +1181,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   }
 
   private async ensurePublisherConnected(kind: DataPacket_Kind) {
-    await this.ensureDataTransportConnected(kind, false);
+    if (!this.publisherConnectionPromise) {
+      this.publisherConnectionPromise = this.ensureDataTransportConnected(kind, false);
+    }
+    await this.publisherConnectionPromise;
   }
 
   /* @internal */


### PR DESCRIPTION
We had user reports of `maxListeners exceeded` when they were using e.g. user input events to trigger data publishing. 

This was due to the fact that in those handlers users would typically do something like

```ts
document.addEventListener('mousemove', async (ev) => { await room.localParticipant.publishData(...); }
```

This could trigger multiple negotiation requests while the publisher data connection is establishing as the calls to publishData could be happening in parallel. 

To make this easier for users to handle we keep an internal reference to the publisher connection promise and await that.