### PR TITLE
Remove internal calls to setCodecPreferences on sender transceivers

### DIFF
--- a/.changeset/slimy-flowers-travel.md
+++ b/.changeset/slimy-flowers-travel.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Remove internal calls to setCodecPreferences on senders

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -474,8 +474,6 @@ export default class PCTransport extends EventEmitter {
         await this.pc.setLocalDescription(sd);
       }
     } catch (e) {
-      // this error cannot always be caught.
-      // If the local description has a setCodecPreferences error, this error will be uncaught
       let msg = 'unknown error';
       if (e instanceof Error) {
         msg = e.message;

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -827,7 +827,6 @@ export default class LocalParticipant extends Participant {
           ...getLogContextFromTrack(track),
           codec: updatedCodec,
         });
-        /* @ts-ignore */
         opts.videoCodec = updatedCodec;
 
         // recompute encodings since bitrates/etc could have changed

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -1,5 +1,4 @@
 import { ClientInfo, ClientInfo_SDK } from '@livekit/protocol';
-import type { DetectableBrowser } from '../utils/browserParser';
 import { getBrowser } from '../utils/browserParser';
 import { protocolVersion, version } from '../version';
 import CriticalTimers from './timers';
@@ -105,31 +104,6 @@ export function supportsSetSinkId(elm?: HTMLMediaElement): boolean {
     elm = document.createElement('audio');
   }
   return 'setSinkId' in elm;
-}
-
-const setCodecPreferencesVersions: Record<DetectableBrowser, string> = {
-  Chrome: '100',
-  Safari: '15',
-  Firefox: '100',
-};
-
-export function supportsSetCodecPreferences(transceiver: RTCRtpTransceiver): boolean {
-  if (!isWeb()) {
-    return false;
-  }
-  if (!('setCodecPreferences' in transceiver)) {
-    return false;
-  }
-  const browser = getBrowser();
-  if (!browser?.name || !browser.version) {
-    // version is required
-    return false;
-  }
-  const v = setCodecPreferencesVersions[browser.name];
-  if (v) {
-    return compareVersions(browser.version, v) >= 0;
-  }
-  return false;
 }
 
 export function isBrowserSupported() {


### PR DESCRIPTION
As recent issues with Chrome 124 arose, we remove all calls to `setCodecPreferences` on publish transceivers and let the server dictate the selected codec by order hierarchy.
This is in accordance with the spec, as `setCodecPreferences` is meant to be a receiver only setting, see [here](https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiver-setcodecpreferences)