### PR TITLE
Disable simulcast for all iOS browsers when E2EE is enabled

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -11,6 +11,7 @@ import {
   UserPacket,
 } from '@livekit/protocol';
 import type { InternalRoomOptions } from '../../options';
+import { getBrowser } from '../../utils/browserParser';
 import { PCTransportState } from '../PCTransportManager';
 import type RTCEngine from '../RTCEngine';
 import { defaultVideoCodec } from '../defaults';
@@ -622,9 +623,9 @@ export default class LocalParticipant extends Participant {
     };
 
     // disable simulcast if e2ee is set on safari
-    if (isSafari() && this.roomOptions.e2ee) {
+    if ((isSafari() || getBrowser()?.os === 'iOS') && this.roomOptions.e2ee) {
       this.log.info(
-        `End-to-end encryption is set up, simulcast publishing will be disabled on Safari`,
+        `End-to-end encryption is set up, simulcast publishing will be disabled on Safari and iOS browsers running WebKit`,
         {
           ...this.logContext,
         },


### PR DESCRIPTION
Additionally to this fix, it makes sense to re-evaluate whether the restriction (simulcast + E2EE) is still not working in recent Safari versions. 
For iOS it will be tricky to differentiate that based on browser version though as we'll need to get insight on the actual Safari version rather than the Firefox/Chrome version.