### PR TITLE
Add timestamp to exp timeSyncUpdate

### DIFF
--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -85,10 +85,13 @@ export default abstract class RemoteTrack<
   registerTimeSyncUpdate() {
     const loop = () => {
       this.timeSyncHandle = requestAnimationFrame(() => loop());
-      const newTime = this.receiver?.getSynchronizationSources()[0]?.rtpTimestamp;
-      if (newTime && this.rtpTimestamp !== newTime) {
-        this.emit(TrackEvent.TimeSyncUpdate, newTime);
-        this.rtpTimestamp = newTime;
+      const sources = this.receiver?.getSynchronizationSources()[0];
+      if (sources) {
+        const { timestamp, rtpTimestamp } = sources;
+        if (rtpTimestamp && this.rtpTimestamp !== rtpTimestamp) {
+          this.emit(TrackEvent.TimeSyncUpdate, { timestamp, rtpTimestamp });
+          this.rtpTimestamp = rtpTimestamp;
+        }
       }
     };
     loop();

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -525,5 +525,5 @@ export type TrackEventCallbacks = {
   upstreamResumed: (track: any) => void;
   trackProcessorUpdate: (processor?: TrackProcessor<Track.Kind, any>) => void;
   audioTrackFeatureUpdate: (track: any, feature: AudioTrackFeature, enabled: boolean) => void;
-  timeSyncUpdate: (timestamp: number) => void;
+  timeSyncUpdate: (update: { timestamp: number; rtpTimestamp: number }) => void;
 };


### PR DESCRIPTION
for client processing purposes both the `rtpTimestamp` and the `timestamp` value of synchronizationSources can be useful