### PR TITLE
Support SIP DTMF data messages

### DIFF
--- a/.changeset/fifty-steaks-fly.md
+++ b/.changeset/fifty-steaks-fly.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Support SIP DTMF data messages.

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -198,6 +198,13 @@ export enum RoomEvent {
   DataReceived = 'dataReceived',
 
   /**
+   * SIP DTMF tones received from another participant.
+   *
+   * args: (participant: [[Participant]], dtmf: [[DataPacket_Kind]])
+   */
+  SipDTMFReceived = 'sipDTMFReceived',
+
+  /**
    * Transcription received from a participant's track.
    * @beta
    */
@@ -409,6 +416,13 @@ export enum ParticipantEvent {
   DataReceived = 'dataReceived',
 
   /**
+   * SIP DTMF tones received from this participant as sender.
+   *
+   * args: (dtmf: [[DataPacket_Kind]])
+   */
+  SipDTMFReceived = 'sipDTMFReceived',
+
+  /**
    * Transcription received from this participant as data source.
    * @beta
    */
@@ -491,7 +505,6 @@ export enum EngineEvent {
   MediaTrackAdded = 'mediaTrackAdded',
   ActiveSpeakersUpdate = 'activeSpeakersUpdate',
   DataPacketReceived = 'dataPacketReceived',
-  TranscriptionReceived = 'transcriptionReceived',
   RTPVideoMapUpdate = 'rtpVideoMapUpdate',
   DCBufferStatusChanged = 'dcBufferStatusChanged',
   ParticipantUpdate = 'participantUpdate',

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -3,6 +3,7 @@ import {
   ParticipantInfo,
   ParticipantPermission,
   ConnectionQuality as ProtoQuality,
+  type SipDTMF,
   SubscriptionError,
 } from '@livekit/protocol';
 import { EventEmitter } from 'events';
@@ -329,6 +330,7 @@ export type ParticipantEventCallbacks = {
   participantMetadataChanged: (prevMetadata: string | undefined, participant?: any) => void;
   participantNameChanged: (name: string) => void;
   dataReceived: (payload: Uint8Array, kind: DataPacket_Kind) => void;
+  sipDTMFReceived: (dtmf: SipDTMF) => void;
   transcriptionReceived: (
     transcription: TranscriptionSegment[],
     publication?: TrackPublication,


### PR DESCRIPTION
Added support for SIP DTMF data messages on rooms and participants.

For consistency with other SDKs, the `RTCEngine` data packet handler signature was changed to receive all message types, which is then switched by type in the Room.

Also compatibility code was added to properly select participant from a shared `participant_identity` on the `DataPacket` (see https://github.com/livekit/protocol/pull/706).