### PR TITLE
Honor calls to track.stop() during an ongoing restart attempt

### DIFF
--- a/.changeset/clean-gifts-applaud.md
+++ b/.changeset/clean-gifts-applaud.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Don't create data channel of publisher until sending data message

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -299,6 +299,7 @@ export default abstract class LocalTrack<
 
       await this.setMediaStreamTrack(newTrack);
       this._constraints = constraints;
+      this.emit(TrackEvent.Restarted, this);
       if (this.manuallyStopped) {
         this.log.warn(
           'track was stopped during a restart, stopping restarted track',
@@ -306,7 +307,6 @@ export default abstract class LocalTrack<
         );
         this.stop();
       }
-      this.emit(TrackEvent.Restarted, this);
       return this;
     } finally {
       unlock();


### PR DESCRIPTION
closes https://github.com/livekit/components-js/issues/851

When calling `track.stop()` while a `track.restart()` is already ongoing, we'd end up with a dangling active mediastreamtrack. 

This change makes sure that if `stop` is called during a `restart` we immediately stop the track again after the restart. 

Alternatives considered:
An arguably cleaner solution would be to make the `stop` function async and await `restartLock.lock`, but that would potentially be a breaking change.