### PR TITLE
Add degradationPreference option for LocalVideoTrack

### DIFF
--- a/.changeset/dull-buckets-chew.md
+++ b/.changeset/dull-buckets-chew.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Add degradationPreference option for LocalVideoTrack

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -858,7 +858,7 @@ export default class LocalParticipant extends Participant {
 
     track.sender = await this.engine.createSender(track, opts, encodings);
 
-    if (track instanceof LocalVideoTrack && opts.degradationPreference) {
+    if (track instanceof LocalVideoTrack) {
       opts.degradationPreference ??= getDefaultDegradationPreference(track);
       track.setDegradationPreference(opts.degradationPreference);
     }

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -19,6 +19,7 @@ import {
   isReactNative,
   isSVCCodec,
   isSafari,
+  unwrapConstraint,
 } from '../utils';
 
 /** @internal */
@@ -438,5 +439,19 @@ export class ScalabilityMode {
 
   toString(): string {
     return `L${this.spatial}T${this.temporal}${this.suffix ?? ''}`;
+  }
+}
+
+export function getDefaultDegradationPreference(track: LocalVideoTrack): RTCDegradationPreference {
+  // a few of reasons we have different default paths:
+  // 1. without this, Chrome seems to aggressively resize the SVC video stating `quality-limitation: bandwidth` even when BW isn't an issue
+  // 2. since we are overriding contentHint to motion (to workaround L1T3 publishing), it overrides the default degradationPreference to `balanced`
+  if (
+    track.source === Track.Source.ScreenShare ||
+    (track.constraints.height && unwrapConstraint(track.constraints.height) >= 1080)
+  ) {
+    return 'maintain-resolution';
+  } else {
+    return 'balanced';
   }
 }

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -15,8 +15,17 @@ const defaultDimensionsTimeout = 1000;
 export default abstract class LocalTrack<
   TrackKind extends Track.Kind = Track.Kind,
 > extends Track<TrackKind> {
+  protected _sender?: RTCRtpSender;
+
   /** @internal */
-  sender?: RTCRtpSender;
+  get sender(): RTCRtpSender | undefined {
+    return this._sender;
+  }
+
+  /** @internal */
+  set sender(sender: RTCRtpSender | undefined) {
+    this._sender = sender;
+  }
 
   /** @internal */
   codec?: VideoCodec;

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -65,6 +65,11 @@ export interface TrackPublishDefaults {
   scalabilityMode?: ScalabilityMode;
 
   /**
+   * degradation preference
+   */
+  degradationPreference?: RTCDegradationPreference;
+
+  /**
    * Up to two additional simulcast layers to publish in addition to the original
    * Track.
    * When left blank, it defaults to h180, h360.

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -491,8 +491,10 @@ export function isVideoCodec(maybeCodec: string): maybeCodec is VideoCodec {
   return videoCodecs.includes(maybeCodec as VideoCodec);
 }
 
-export function unwrapConstraint(constraint: ConstrainDOMString): string {
-  if (typeof constraint === 'string') {
+export function unwrapConstraint(constraint: ConstrainDOMString): string;
+export function unwrapConstraint(constraint: ConstrainULong): number;
+export function unwrapConstraint(constraint: ConstrainDOMString | ConstrainULong): string | number {
+  if (typeof constraint === 'string' || typeof constraint === 'number') {
     return constraint;
   }
 


### PR DESCRIPTION
- adds `localVideoTrack.setDegradationPreference` 
- adds `degradationPreference` to `TrackPublishOptions`
- computes a default `degradationPreference` if none is set explicitly