### PR TITLE
Account for spatial layers in default video encoding for SVC codecs

### DIFF
--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -118,6 +118,8 @@ export function computeVideoEncodings(
     return [{}];
   }
 
+  let useDefaultVideoEncoding = !videoEncoding;
+
   if (!videoEncoding) {
     // find the right encoding based on width/height
     videoEncoding = determineAppropriateEncoding(isScreenShare, width, height, videoCodec);
@@ -163,8 +165,12 @@ export function computeVideoEncodings(
       /* @ts-ignore */
       encodings[0].scalabilityMode = scalabilityMode;
     } else {
+      const svcBitrate = useDefaultVideoEncoding
+        ? // account for spatial layers if default video encoding computation has been used to determine bitrate
+          original.encoding.maxBitrate * Math.cbrt(sm.spatial)
+        : original.encoding.maxBitrate;
       encodings.push({
-        maxBitrate: videoEncoding.maxBitrate,
+        maxBitrate: svcBitrate,
         maxFramerate: original.encoding.maxFramerate,
         /* @ts-ignore */
         scalabilityMode: scalabilityMode,


### PR DESCRIPTION
I couldn't find any analysis on how much additional bitrate a spatial layer adds for SVC, going with cube root is more of a gut feeling. 
Please advise on what a better factor for this could be.