### PR TITLE
Override sender getter on LocalVideoTrack

### DIFF
--- a/.changeset/giant-hairs-happen.md
+++ b/.changeset/giant-hairs-happen.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Override sender getter on LocalVideoTrack

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -55,7 +55,11 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   private degradationPreference: RTCDegradationPreference = 'balanced';
 
-  override set sender(sender: RTCRtpSender | undefined) {
+  get sender(): RTCRtpSender | undefined {
+    return this._sender;
+  }
+
+  set sender(sender: RTCRtpSender | undefined) {
     this._sender = sender;
     if (this.degradationPreference) {
       this.setDegradationPreference(this.degradationPreference);


### PR DESCRIPTION
This is a super unfortunate oversight on my part. We also need to override the getter in order on the LocalVideoTrack. Otherwise `.sender` will always return undefined. 