### PR TITLE
Allow processors to be set as part of track publish options

### DIFF
--- a/.changeset/eight-pugs-cough.md
+++ b/.changeset/eight-pugs-cough.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Allow processors to be set as part of track publish options

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -449,7 +449,6 @@ export default class LocalParticipant extends Participant {
           track.setAudioContext(this.audioContext);
         }
         track.mediaStream = stream;
-        console.log('checking for processor', trackOptions.processor);
         if (trackOptions.processor) {
           if (track instanceof LocalAudioTrack) {
             await track.setProcessor(trackOptions.processor as TrackProcessor<Track.Kind.Audio>);

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -276,7 +276,10 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
     }
   }
 
-  async setProcessor(processor: TrackProcessor<Track.Kind>, showProcessedStreamLocally = true) {
+  async setProcessor(
+    processor: TrackProcessor<Track.Kind.Video>,
+    showProcessedStreamLocally = true,
+  ) {
     await super.setProcessor(processor, showProcessedStreamLocally);
 
     if (this.processor?.processedTrack) {

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -1,5 +1,9 @@
 import type { Track } from './Track';
-import type { AudioProcessorOptions, TrackProcessor } from './processor/types';
+import type {
+  AudioProcessorOptions,
+  TrackProcessor,
+  VideoProcessorOptions,
+} from './processor/types';
 
 export interface TrackPublishDefaults {
   /**
@@ -157,7 +161,7 @@ export interface VideoCaptureOptions {
   /**
    * initialize the track with a given processor
    */
-  processor?: TrackProcessor<Track.Kind.Video>;
+  processor?: TrackProcessor<Track.Kind.Video, VideoProcessorOptions>;
 }
 
 export interface ScreenShareCaptureOptions {

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -1,4 +1,5 @@
 import type { Track } from './Track';
+import type { AudioProcessorOptions, TrackProcessor } from './processor/types';
 
 export interface TrackPublishDefaults {
   /**
@@ -152,6 +153,11 @@ export interface VideoCaptureOptions {
   facingMode?: 'user' | 'environment' | 'left' | 'right';
 
   resolution?: VideoResolution;
+
+  /**
+   * initialize the track with a given processor
+   */
+  processor?: TrackProcessor<Track.Kind.Video>;
 }
 
 export interface ScreenShareCaptureOptions {
@@ -245,6 +251,11 @@ export interface AudioCaptureOptions {
    * sample size or range of sample sizes which are acceptable and/or required.
    */
   sampleSize?: ConstrainULong;
+
+  /**
+   * initialize the track with a given processor
+   */
+  processor?: TrackProcessor<Track.Kind.Audio, AudioProcessorOptions>;
 }
 
 export interface AudioOutputOptions {


### PR DESCRIPTION
this allows users to specify processors that should be applied to tracks during publishing. 
This helps to solve use cases where users would like to start the initial publication with processors enabled already.

```ts
      videoCaptureDefaults: {
        resolution: VideoPresets.h720.resolution,
        processor: BackgroundBlur(),
      },
      audioCaptureDefaults: {
        processor: KrispNoiseFilter(),
      },
```