### PR TITLE
Make sure setting a new processor doesn't remove the processor html element

### DIFF
--- a/.changeset/dirty-mayflies-build.md
+++ b/.changeset/dirty-mayflies-build.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Make sure setting a new processor doesn't remove the processor html element


### PR DESCRIPTION
Previously, when a new processor was being set, we would re-use the processor element if possible. 
However, subsequently, we called `stopProcessor` which in turn then removed that element from the DOM.

This PR keeps the element around as a local variable and assigns it to `this.processorElement` only after the old processor has been stopped.

also closes #1148