### PR TITLE
Correct track replacement when resuming local track upstream

### DIFF
--- a/.changeset/kind-nails-battle.md
+++ b/.changeset/kind-nails-battle.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix resumeUpstream with local track processors enabled

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -433,7 +433,7 @@ export default abstract class LocalTrack<
       this.emit(TrackEvent.UpstreamResumed, this);
 
       // this operation is noop if mediastreamtrack is already being sent
-      await this.sender.replaceTrack(this._mediaStreamTrack);
+      await this.sender.replaceTrack(this.mediaStreamTrack);
     } finally {
       unlock();
     }


### PR DESCRIPTION
Currently if a track processor is applied to a video track while the track's upstream is paused (ie. `pauseUpstream()` has been called on it), the next call to resume upstream will replace the processed track with the plain, unprocessed track. This should correct that logic and prevent this incorrect replacement.

My app was performing the following steps when I ran into this behavior:

1. Publish a video track to the room with no processors applied
2. Pause the local video track's upstream
3. Apply a Track processor to the local track
4. Resume the local video track's upstream

I am pausing and resuming the track when I am making processor changes to prevent showing any "flashes" of unprocessed frames when changing between virtual background options.