### PR TITLE
Disable webAudioMix by default

### DIFF
--- a/.changeset/moody-apples-speak.md
+++ b/.changeset/moody-apples-speak.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+Disable webAudioMix by default

--- a/src/room/defaults.ts
+++ b/src/room/defaults.ts
@@ -37,7 +37,7 @@ export const roomOptionDefaults: InternalRoomOptions = {
   stopLocalTrackOnUnpublish: true,
   reconnectPolicy: new DefaultReconnectPolicy(),
   disconnectOnPageLeave: true,
-  webAudioMix: true,
+  webAudioMix: false,
 } as const;
 
 export const roomConnectOptionDefaults: InternalRoomConnectOptions = {


### PR DESCRIPTION
Due to various issues around echo cancellation and sound duplication that have popped up recently, we're going to disable `webAudioMix` by default. 
The advantages of dealing with native HTMLAudioElement playback outweigh the benefits of piping everything through webAudio. 
The main remaining downside of `webAudioMix: false` is backgrounded tabs in Safari not playing back newly created audio elements if you're not also publishing yourself. That is an edge case that we'll try to fix separately, but for most users it seems better to have web audio disabled by default.  