### PR TITLE
Add support for participant attributes

### DIFF
--- a/.changeset/heavy-buses-fly.md
+++ b/.changeset/heavy-buses-fly.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Add support for participant attributes

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@livekit/protocol": "1.19.0",
     "events": "^3.3.0",
     "loglevel": "^1.8.0",
-    "microdiff": "^1.4.0",
     "sdp-transform": "^2.14.1",
     "ts-debounce": "^4.0.0",
     "tslib": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
     "size-limit": "size-limit"
   },
   "dependencies": {
-    "@livekit/protocol": "1.16.0",
+    "@livekit/protocol": "1.19.0",
     "events": "^3.3.0",
     "loglevel": "^1.8.0",
+    "microdiff": "^1.4.0",
     "sdp-transform": "^2.14.1",
     "ts-debounce": "^4.0.0",
     "tslib": "2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       loglevel:
         specifier: ^1.8.0
         version: 1.9.1
-      microdiff:
-        specifier: ^1.4.0
-        version: 1.4.0
       sdp-transform:
         specifier: ^2.14.1
         version: 2.14.1
@@ -2640,9 +2637,6 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  microdiff@1.4.0:
-    resolution: {integrity: sha512-OBKBOa1VBznvLPb/3ljeJaENVe0fO0lnWl77lR4vhPlQD71UpjEoRV5P0KdQkcjbFlBu1Oy2mEUBMU3wxcBAGg==}
-
   micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
@@ -3434,8 +3428,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.6.0-dev.20240621:
-    resolution: {integrity: sha512-1JHiBIcEY9qrX/0coAIUIdH0XdDUuwIJ7VZGZ1CbksCWq2bztyvRX7YIcGvTkN/kFGEcrmyFIUEouq+pnLvQPw==}
+  typescript@5.6.0-dev.20240701:
+    resolution: {integrity: sha512-x8jIDJiBfgaT4/vpz3FwNKa2dYQsLZXKWsaCeyQWrXzkbKyirrGdVuOr3nbz0bcvteZNJ2BCZPDlAiwsX/pENw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5670,7 +5664,7 @@ snapshots:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.6.0-dev.20240621
+      typescript: 5.6.0-dev.20240701
 
   electron-to-chromium@1.4.724: {}
 
@@ -6567,8 +6561,6 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  microdiff@1.4.0: {}
-
   micromatch@4.0.5:
     dependencies:
       braces: 3.0.2
@@ -7353,7 +7345,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.6.0-dev.20240621: {}
+  typescript@5.6.0-dev.20240701: {}
 
   ufo@1.5.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,17 @@ importers:
   .:
     dependencies:
       '@livekit/protocol':
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.19.0
+        version: 1.19.0
       events:
         specifier: ^3.3.0
         version: 3.3.0
       loglevel:
         specifier: ^1.8.0
         version: 1.9.1
+      microdiff:
+        specifier: ^1.4.0
+        version: 1.4.0
       sdp-transform:
         specifier: ^2.14.1
         version: 2.14.1
@@ -818,9 +821,6 @@ packages:
   '@bufbuild/protobuf@1.10.0':
     resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
 
-  '@bufbuild/protobuf@1.9.0':
-    resolution: {integrity: sha512-W7gp8Q/v1NlCZLsv8pQ3Y0uCu/SHgXOVFK+eUluUKWXmsb6VHkpNx0apdOWWcDbB9sJoKeP8uPrjmehJz6xETQ==}
-
   '@bufbuild/protoc-gen-es@1.10.0':
     resolution: {integrity: sha512-zBYBsVT/ul4uZb6F+kD7/k4sWNHVVbEPfJwKi0FDr+9VJo8MKIofI6pkr5ksBLr4fi/74r+e/75Xi/0clL5dXg==}
     engines: {node: '>=14'}
@@ -1090,8 +1090,8 @@ packages:
   '@livekit/changesets-changelog-github@0.0.4':
     resolution: {integrity: sha512-MXaiLYwgkYciZb8G2wkVtZ1pJJzZmVx5cM30Q+ClslrIYyAqQhRbPmZDM79/5CGxb1MTemR/tfOM25tgJgAK0g==}
 
-  '@livekit/protocol@1.16.0':
-    resolution: {integrity: sha512-xZZTZVh2FmWmUgNS3n+oGNbA4GcS4XOwhg8CWy75jenYxbgQ89ds7ixfMQ+F+oxktcXfJ1qsph086oRTlg8e5Q==}
+  '@livekit/protocol@1.19.0':
+    resolution: {integrity: sha512-pHcVjEQGNDJFMJjEYyuHmARCFOorA/7duHEYjiVFjymF5GkM8Sfdf6prnTvqxxaWrlKBFsPhgApgaocR2pJEMA==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2640,6 +2640,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  microdiff@1.4.0:
+    resolution: {integrity: sha512-OBKBOa1VBznvLPb/3ljeJaENVe0fO0lnWl77lR4vhPlQD71UpjEoRV5P0KdQkcjbFlBu1Oy2mEUBMU3wxcBAGg==}
+
   micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
@@ -3431,8 +3434,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.6.0-dev.20240604:
-    resolution: {integrity: sha512-uwpkMy5U51ERVvVtQmDZwjYllREGrqP35JcdR5yWIoZ7ZE2I1oDsDs3mtLiiiccyHspCZ54Z741ibuP3NbACtg==}
+  typescript@5.6.0-dev.20240621:
+    resolution: {integrity: sha512-1JHiBIcEY9qrX/0coAIUIdH0XdDUuwIJ7VZGZ1CbksCWq2bztyvRX7YIcGvTkN/kFGEcrmyFIUEouq+pnLvQPw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4522,8 +4525,6 @@ snapshots:
 
   '@bufbuild/protobuf@1.10.0': {}
 
-  '@bufbuild/protobuf@1.9.0': {}
-
   '@bufbuild/protoc-gen-es@1.10.0(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@bufbuild/protoplugin': 1.10.0
@@ -4844,9 +4845,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@livekit/protocol@1.16.0':
+  '@livekit/protocol@1.19.0':
     dependencies:
-      '@bufbuild/protobuf': 1.9.0
+      '@bufbuild/protobuf': 1.10.0
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -5669,7 +5670,7 @@ snapshots:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.6.0-dev.20240604
+      typescript: 5.6.0-dev.20240621
 
   electron-to-chromium@1.4.724: {}
 
@@ -6566,6 +6567,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  microdiff@1.4.0: {}
+
   micromatch@4.0.5:
     dependencies:
       braces: 3.0.2
@@ -7350,7 +7353,7 @@ snapshots:
 
   typescript@5.4.5: {}
 
-  typescript@5.6.0-dev.20240604: {}
+  typescript@5.6.0-dev.20240621: {}
 
   ufo@1.5.3: {}
 

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -511,12 +511,13 @@ export class SignalClient {
     });
   }
 
-  sendUpdateLocalMetadata(metadata: string, name: string) {
+  sendUpdateLocalMetadata(metadata: string, name: string, attributes: Record<string, string> = {}) {
     return this.sendRequest({
       case: 'updateMetadata',
       value: new UpdateParticipantMetadata({
         metadata,
         name,
+        attributes,
       }),
     });
   }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -2128,7 +2128,7 @@ export type RoomEventCallbacks = {
     participant: RemoteParticipant | LocalParticipant,
   ) => void;
   participantAttributesChanged: (
-    attributes: Record<string, string>,
+    changedAttributes: Record<string, string>,
     participant: RemoteParticipant | LocalParticipant,
   ) => void;
   activeSpeakersChanged: (speakers: Array<Participant>) => void;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1519,7 +1519,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   ) => {
     // find the participant
     const participant =
-      transcription.participantIdentity === this.localParticipant.identity
+      transcription.transcribedParticipantIdentity === this.localParticipant.identity
         ? this.localParticipant
         : remoteParticipant;
     const publication = participant?.trackPublications.get(transcription.trackId);
@@ -2125,6 +2125,10 @@ export type RoomEventCallbacks = {
   participantNameChanged: (name: string, participant: RemoteParticipant | LocalParticipant) => void;
   participantPermissionsChanged: (
     prevPermissions: ParticipantPermission | undefined,
+    participant: RemoteParticipant | LocalParticipant,
+  ) => void;
+  participantAttributesChanged: (
+    attributes: Record<string, string>,
     participant: RemoteParticipant | LocalParticipant,
   ) => void;
   activeSpeakersChanged: (speakers: Array<Participant>) => void;

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -185,6 +185,9 @@ export enum RoomEvent {
    */
   ParticipantNameChanged = 'participantNameChanged',
 
+  /**  */
+  ParticipantAttributesChanged = 'participantAttributesChanged',
+
   /**
    * Room metadata is a simple way for app-specific state to be pushed to
    * all users.
@@ -495,6 +498,9 @@ export enum ParticipantEvent {
 
   /** @internal */
   PCTrackAdded = 'pcTrackAdded',
+
+  /** */
+  AttributesChanged = 'attributesChanged',
 }
 
 /** @internal */

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -188,7 +188,7 @@ export enum RoomEvent {
   /**
    * Participant attributes is an app-specific key value state to be pushed to
    * all users.
-   * When a participant's attributes changed, this event will be emitted with the new attributes and the participant
+   * When a participant's attributes changed, this event will be emitted with the changed attributes and the participant
    */
   ParticipantAttributesChanged = 'participantAttributesChanged',
 
@@ -506,7 +506,7 @@ export enum ParticipantEvent {
   /**
    * Participant attributes is an app-specific key value state to be pushed to
    * all users.
-   * When a participant's attributes changed, this event will be emitted with the new attributes
+   * When a participant's attributes changed, this event will be emitted with the changed attributes
    */
   AttributesChanged = 'attributesChanged',
 }

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -185,7 +185,11 @@ export enum RoomEvent {
    */
   ParticipantNameChanged = 'participantNameChanged',
 
-  /**  */
+  /**
+   * Participant attributes is an app-specific key value state to be pushed to
+   * all users.
+   * When a participant's attributes changed, this event will be emitted with the new attributes and the participant
+   */
   ParticipantAttributesChanged = 'participantAttributesChanged',
 
   /**
@@ -499,7 +503,11 @@ export enum ParticipantEvent {
   /** @internal */
   PCTrackAdded = 'pcTrackAdded',
 
-  /** */
+  /**
+   * Participant attributes is an app-specific key value state to be pushed to
+   * all users.
+   * When a participant's attributes changed, this event will be emitted with the new attributes
+   */
   AttributesChanged = 'attributesChanged',
 }
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -203,6 +203,10 @@ export default class LocalParticipant extends Participant {
     this.engine.client.sendUpdateLocalMetadata(this.metadata ?? '', name);
   }
 
+  async setAttributes(attributes: Record<string, string>) {
+    this.engine.client.sendUpdateLocalMetadata(this.metadata ?? '', this.name ?? '', attributes);
+  }
+
   /**
    * Enable or disable a participant's camera track.
    *

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -204,7 +204,11 @@ export default class LocalParticipant extends Participant {
   }
 
   async setAttributes(attributes: Record<string, string>) {
-    this.engine.client.sendUpdateLocalMetadata(this.metadata ?? '', this.name ?? '', attributes);
+    await this.engine.client.sendUpdateLocalMetadata(
+      this.metadata ?? '',
+      this.name ?? '',
+      attributes,
+    );
   }
 
   /**

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -8,7 +8,6 @@ import {
   SubscriptionError,
 } from '@livekit/protocol';
 import { EventEmitter } from 'events';
-import diff from 'microdiff';
 import type TypedEmitter from 'typed-emitter';
 import log, { LoggerNames, StructuredLogger, getLogger } from '../../logger';
 import { ParticipantEvent, TrackEvent } from '../events';
@@ -19,6 +18,7 @@ import type RemoteTrack from '../track/RemoteTrack';
 import type RemoteTrackPublication from '../track/RemoteTrackPublication';
 import { Track } from '../track/Track';
 import type { TrackPublication } from '../track/TrackPublication';
+import { diffAttributes } from '../track/utils';
 import type { LoggerOptions, TranscriptionSegment } from '../types';
 
 export enum ConnectionQuality {
@@ -259,11 +259,11 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
    * Updates metadata from server
    **/
   private _setAttributes(attributes: Record<string, string>) {
-    const metadataDiff = diff(this.attributes, attributes);
+    const diff = diffAttributes(attributes, this.attributes);
     this._attributes = attributes;
 
-    if (metadataDiff.length > 0) {
-      this.emit(ParticipantEvent.AttributesChanged, attributes);
+    if (Object.keys(diff).length > 0) {
+      this.emit(ParticipantEvent.AttributesChanged, diff);
     }
   }
 
@@ -385,5 +385,5 @@ export type ParticipantEventCallbacks = {
     publication: RemoteTrackPublication,
     status: TrackPublication.SubscriptionStatus,
   ) => void;
-  attributesChanged: (attributes: Record<string, string>) => void;
+  attributesChanged: (changedAttributes: Record<string, string>) => void;
 };

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -8,6 +8,7 @@ import {
   SubscriptionError,
 } from '@livekit/protocol';
 import { EventEmitter } from 'events';
+import diff from 'microdiff';
 import type TypedEmitter from 'typed-emitter';
 import log, { LoggerNames, StructuredLogger, getLogger } from '../../logger';
 import { ParticipantEvent, TrackEvent } from '../events';
@@ -77,6 +78,8 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
   /** client metadata, opaque to livekit */
   metadata?: string;
 
+  private _attributes: Record<string, string>;
+
   lastSpokeAt?: Date | undefined;
 
   permissions?: ParticipantPermission;
@@ -112,6 +115,11 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     return this._kind;
   }
 
+  /** participant attributes, similar to metadata, but as a key/value map */
+  get attributes(): Readonly<Record<string, string>> {
+    return Object.freeze({ ...this._attributes });
+  }
+
   /** @internal */
   constructor(
     sid: string,
@@ -135,6 +143,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     this.videoTrackPublications = new Map();
     this.trackPublications = new Map();
     this._kind = kind;
+    this._attributes = {};
   }
 
   getTrackPublications(): TrackPublication[] {
@@ -214,6 +223,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     this.sid = info.sid;
     this._setName(info.name);
     this._setMetadata(info.metadata);
+    this._setAttributes(info.attributes);
     if (info.permission) {
       this.setPermissions(info.permission);
     }
@@ -242,6 +252,18 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
 
     if (changed) {
       this.emit(ParticipantEvent.ParticipantNameChanged, name);
+    }
+  }
+
+  /**
+   * Updates metadata from server
+   **/
+  private _setAttributes(attributes: Record<string, string>) {
+    const metadataDiff = diff(this.attributes, attributes);
+    this._attributes = attributes;
+
+    if (metadataDiff.length > 0) {
+      this.emit(ParticipantEvent.AttributesChanged, attributes);
     }
   }
 
@@ -363,4 +385,5 @@ export type ParticipantEventCallbacks = {
     publication: RemoteTrackPublication,
     status: TrackPublication.SubscriptionStatus,
   ) => void;
+  attributesChanged: (attributes: Record<string, string>) => void;
 };

--- a/src/room/track/utils.test.ts
+++ b/src/room/track/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { AudioCaptureOptions, VideoCaptureOptions, VideoPresets } from './options';
-import { constraintsForOptions, mergeDefaultOptions } from './utils';
+import { constraintsForOptions, diffAttributes, mergeDefaultOptions } from './utils';
 
 describe('mergeDefaultOptions', () => {
   const audioDefaults: AudioCaptureOptions = {
@@ -107,5 +107,32 @@ describe('constraintsForOptions', () => {
     expect(videoOpts.height).toEqual(VideoPresets.h720.resolution.height);
     expect(videoOpts.frameRate).toEqual(VideoPresets.h720.resolution.frameRate);
     expect(videoOpts.aspectRatio).toEqual(VideoPresets.h720.resolution.aspectRatio);
+  });
+});
+
+describe('diffAttributes', () => {
+  it('detects changed values', () => {
+    const oldValues: Record<string, string> = { a: 'value', b: 'initial', c: 'value' };
+    const newValues: Record<string, string> = { a: 'value', b: 'updated', c: 'value' };
+
+    const diff = diffAttributes(oldValues, newValues);
+    expect(Object.keys(diff).length).toBe(1);
+    expect(diff.b).toBe('updated');
+  });
+  it('detects new values', () => {
+    const newValues: Record<string, string> = { a: 'value', b: 'value', c: 'value' };
+    const oldValues: Record<string, string> = { a: 'value', b: 'value' };
+
+    const diff = diffAttributes(oldValues, newValues);
+    expect(Object.keys(diff).length).toBe(1);
+    expect(diff.c).toBe('value');
+  });
+  it('detects deleted values as empty strings', () => {
+    const newValues: Record<string, string> = { a: 'value', b: 'value' };
+    const oldValues: Record<string, string> = { a: 'value', b: 'value', c: 'value' };
+
+    const diff = diffAttributes(oldValues, newValues);
+    expect(Object.keys(diff).length).toBe(1);
+    expect(diff.c).toBe('');
   });
 });

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -243,3 +243,19 @@ export function getLogContextFromTrack(track: Track | TrackPublication): Record<
 export function supportsSynchronizationSources(): boolean {
   return typeof RTCRtpReceiver !== 'undefined' && 'getSynchronizationSources' in RTCRtpReceiver;
 }
+
+export function diffAttributes(
+  oldValues: Record<string, string>,
+  newValues: Record<string, string>,
+) {
+  const allKeys = [...Object.keys(newValues), ...Object.keys(oldValues)];
+  const diff: Record<string, string> = {};
+
+  for (const key of allKeys) {
+    if (oldValues[key] !== newValues[key]) {
+      diff[key] = newValues[key] ?? '';
+    }
+  }
+
+  return diff;
+}


### PR DESCRIPTION
after this gets merged, I'll update #1168 to include request error handling also for the attribute updates. 

Do we want a protocol bump for this so that clients can know whether or not the server supports attributes already?