### PR TITLE
Ensure permission request for listDevices works also in Firefox

### DIFF
--- a/.changeset/witty-melons-clean.md
+++ b/.changeset/witty-melons-clean.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Ensure permission request for listDevices works for audio outputs in Firefox

--- a/src/room/DeviceManager.ts
+++ b/src/room/DeviceManager.ts
@@ -41,7 +41,7 @@ export default class DeviceManager {
       !(isSafari() && this.hasDeviceInUse(kind))
     ) {
       const isDummyDeviceOrEmpty =
-        devices.length === 0 ||
+        devices.filter((d) => d.kind === kind).length === 0 ||
         devices.some((device) => {
           const noLabel = device.label === '';
           const isRelevant = kind ? device.kind === kind : true;


### PR DESCRIPTION
When calling `enumerateDevices` in Firefox it would return a list of inputs correctly populated, but omits the `audiooutput` mediakind. By filtering for the desired kind on the returned list we can make sure to request permissions if the desired kind is missing. 
This will make it possible to list and select audio output devices in Firefox.