### PR TITLE
Emit TimesyncUpdates for local tracks

### DIFF
--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -139,6 +139,8 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
     this.monitorInterval = setInterval(() => {
       this.monitorSender();
     }, monitorFrequency);
+
+    this.registerTimeSyncUpdate();
   }
 
   protected monitorSender = async () => {

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -108,6 +108,8 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
     this.monitorInterval = setInterval(() => {
       this.monitorSender();
     }, monitorFrequency);
+
+    this.registerTimeSyncUpdate();
   }
 
   stop() {


### PR DESCRIPTION
Manually computing these for local tracks makes it easier to compute `activeTranscriptions` with the same API that we use for remote tracks. 
Downside is that we register this for every local track independently, but probably not a major concern.