### PR TITLE
await element to be attached before calling .play on it

### DIFF
--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -486,7 +486,7 @@ export default abstract class LocalTrack<
         throw TypeError('cannot set processor on track of unknown kind');
       }
 
-      attachToElement(this._mediaStreamTrack, processorElement);
+      await attachToElement(this._mediaStreamTrack, processorElement);
       processorElement.muted = true;
 
       processorElement

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -338,7 +338,7 @@ export abstract class Track<
   }
 }
 
-export function attachToElement(track: MediaStreamTrack, element: HTMLMediaElement) {
+export async function attachToElement(track: MediaStreamTrack, element: HTMLMediaElement) {
   let mediaStream: MediaStream;
   if (element.srcObject instanceof MediaStream) {
     mediaStream = element.srcObject;
@@ -382,15 +382,21 @@ export function attachToElement(track: MediaStreamTrack, element: HTMLMediaEleme
       // black until the page is resized or other changes take place.
       // Resetting the src triggers it to render.
       // https://developer.apple.com/forums/thread/690523
-      setTimeout(() => {
-        element.srcObject = mediaStream;
-        // Safari 15 sometimes fails to start a video
-        // when the window is backgrounded before the first frame is drawn
-        // manually calling play here seems to fix that
-        element.play().catch(() => {
-          /** do nothing */
-        });
-      }, 0);
+      await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          element.srcObject = mediaStream;
+          // Safari 15 sometimes fails to start a video
+          // when the window is backgrounded before the first frame is drawn
+          // manually calling play here seems to fix that
+          element
+            .play()
+            .then(resolve)
+            .catch(() => {
+              /** do nothing */
+              reject();
+            });
+        }, 0);
+      });
     }
   }
 }


### PR DESCRIPTION
otherwise Firefox 128 throws this error when 'setProcessor' is called on track: 
```
failed to play processor element
Object { room: undefined, roomID: undefined, participant: undefined, pID: undefined, trackID: undefined, source: "camera", muted: false, enabled: true, kind: "video", streamID: "{bbe7a482-313d-49e6-8d55-5dbe42d2c24f}", … } enabled: true
error: DOMException: The fetching process for the media resource was aborted by the user agent at the user's request. kind: "video"
muted: false
pID: undefined
participant: undefined
room: undefined
roomID: undefined
source: "camera"
streamID: "{bbe7a482-313d-49e6-8d55-5dbe42d2c24f}" streamTrackID: "{ae53ec2f-9257-4f7e-9525-d7b2aa0ad809}" trackID: undefined
<prototype>: Object { … }
```

Unfortunately I'm not able to share code to reproduce this error. :/