### PR TITLE
Only retry other regions if connection attempt has not been cancelled

### DIFF
--- a/.changeset/tame-crabs-repeat.md
+++ b/.changeset/tame-crabs-repeat.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Only retry other regions if connection attempt has not been cancelled

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -520,7 +520,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
               return;
             }
           }
-          if (nextUrl) {
+          if (nextUrl && !this.abortController?.signal.aborted) {
             this.log.info(
               `Initial connection failed with ConnectionError: ${e.message}. Retrying with another region: ${nextUrl}`,
               this.logContext,


### PR DESCRIPTION
With https://github.com/livekit/client-sdk-js/pull/1201 the initial population of the region settings got sped up. 
This surfaced an issue where, when given enough time for the region settings to be populated, cancelling a room connection would still trigger the region url provider internally to attempt a connection with a different region. 

We were missing a check before to see whether or not the connection had been cancelled by the user before. 