### PR TITLE
Fix issues in PublishVideoCheck and PublishAudioCheck helpers

### DIFF
--- a/.changeset/warm-shirts-notice.md
+++ b/.changeset/warm-shirts-notice.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Use kind instead of mediaType for outbound-rtp stats in PublishVideoCheck and PublishAudioCheck helpers

--- a/src/connectionHelper/checks/publishAudio.ts
+++ b/src/connectionHelper/checks/publishAudio.ts
@@ -21,7 +21,10 @@ export class PublishAudioCheck extends Checker {
     }
     let numPackets = 0;
     stats.forEach((stat) => {
-      if (stat.type === 'outbound-rtp' && stat.kind === 'audio') {
+      if (
+        stat.type === 'outbound-rtp' &&
+        (stat.kind === 'audio' || (!stat.kind && stat.mediaType === 'audio'))
+      ) {
         numPackets = stat.packetsSent;
       }
     });

--- a/src/connectionHelper/checks/publishAudio.ts
+++ b/src/connectionHelper/checks/publishAudio.ts
@@ -21,7 +21,7 @@ export class PublishAudioCheck extends Checker {
     }
     let numPackets = 0;
     stats.forEach((stat) => {
-      if (stat.type === 'outbound-rtp' && stat.mediaType === 'audio') {
+      if (stat.type === 'outbound-rtp' && stat.kind === 'audio') {
         numPackets = stat.packetsSent;
       }
     });

--- a/src/connectionHelper/checks/publishVideo.ts
+++ b/src/connectionHelper/checks/publishVideo.ts
@@ -25,7 +25,7 @@ export class PublishVideoCheck extends Checker {
         stat.type === 'outbound-rtp' &&
         (stat.kind === 'video' || (!stat.kind && stat.mediaType === 'video'))
       ) {
-        numPackets = stat.packetsSent;
+        numPackets += stat.packetsSent;
       }
     });
     if (numPackets === 0) {

--- a/src/connectionHelper/checks/publishVideo.ts
+++ b/src/connectionHelper/checks/publishVideo.ts
@@ -21,7 +21,7 @@ export class PublishVideoCheck extends Checker {
     }
     let numPackets = 0;
     stats.forEach((stat) => {
-      if (stat.type === 'outbound-rtp' && stat.mediaType === 'video') {
+      if (stat.type === 'outbound-rtp' && stat.kind === 'video') {
         numPackets = stat.packetsSent;
       }
     });

--- a/src/connectionHelper/checks/publishVideo.ts
+++ b/src/connectionHelper/checks/publishVideo.ts
@@ -12,7 +12,7 @@ export class PublishVideoCheck extends Checker {
     const track = await createLocalVideoTrack();
     room.localParticipant.publishTrack(track);
     // wait for a few seconds to publish
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     // verify RTC stats that it's publishing
     const stats = await track.sender?.getStats();

--- a/src/connectionHelper/checks/publishVideo.ts
+++ b/src/connectionHelper/checks/publishVideo.ts
@@ -21,7 +21,10 @@ export class PublishVideoCheck extends Checker {
     }
     let numPackets = 0;
     stats.forEach((stat) => {
-      if (stat.type === 'outbound-rtp' && stat.kind === 'video') {
+      if (
+        stat.type === 'outbound-rtp' &&
+        (stat.kind === 'video' || (!stat.kind && stat.mediaType === 'video'))
+      ) {
         numPackets = stat.packetsSent;
       }
     });


### PR DESCRIPTION
- It seems like `mediaType` is not working on Safari, so it was changed to `kind` with a fallback to `mediaType`.
- Timeout for video publish was increased `3000 -> 5000`
- All video outbound-rtp packetsSent are now added to the total value, only the last value was used before.

<img width="802" alt="image" src="https://github.com/user-attachments/assets/19d0bb9c-7928-461f-bd23-333223ca6a1a">

https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpStreamStats/kind
https://developer.mozilla.org/en-US/docs/Web/API/RTCOutboundRtpStreamStats#browser_compatibility