### PR TITLE
Use ReturnTypes of built-in functions for critical timers

### DIFF
--- a/.changeset/chilled-chefs-warn.md
+++ b/.changeset/chilled-chefs-warn.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Use ReturnTypes of built-in functions for critical timers

--- a/src/room/timers.ts
+++ b/src/room/timers.ts
@@ -4,13 +4,22 @@
  * that the timer fires on time.
  */
 export default class CriticalTimers {
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  static setTimeout = (...args: Parameters<typeof setTimeout>) => setTimeout(...args);
+  static setTimeout: (...args: Parameters<typeof setTimeout>) => ReturnType<typeof setTimeout> = (
+    ...args: Parameters<typeof setTimeout>
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  ) => setTimeout(...args);
 
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  static setInterval = (...args: Parameters<typeof setInterval>) => setInterval(...args);
+  static setInterval: (...args: Parameters<typeof setInterval>) => ReturnType<typeof setInterval> =
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    (...args: Parameters<typeof setInterval>) => setInterval(...args);
 
-  static clearTimeout = (...args: Parameters<typeof clearTimeout>) => clearTimeout(...args);
+  static clearTimeout: (
+    ...args: Parameters<typeof clearTimeout>
+  ) => ReturnType<typeof clearTimeout> = (...args: Parameters<typeof clearTimeout>) =>
+    clearTimeout(...args);
 
-  static clearInterval = (...args: Parameters<typeof clearInterval>) => clearInterval(...args);
+  static clearInterval: (
+    ...args: Parameters<typeof clearInterval>
+  ) => ReturnType<typeof clearInterval> = (...args: Parameters<typeof clearInterval>) =>
+    clearInterval(...args);
 }


### PR DESCRIPTION
A user reported an issue where they were running into a typescript compile error due to `NodeJS.Timer` being declared in `timers.d.ts`. 

This is due to the fact that some of the client-sdk-js dependencies rely on `@types/node` which leads to the `setTimeout` and `setInterval` return types to be interpreted for NodeJS at build time. 
In order to avoid this, we manually declare the types as `ReturnType` of said functions which will prevent references to `NodeJS` types in the build output.