### PR TITLE
Pass connect options to room from connection checkers

### DIFF
--- a/.changeset/chilled-insects-collect.md
+++ b/.changeset/chilled-insects-collect.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Pass connect options to room from connection checkers

--- a/src/connectionHelper/checks/Checker.ts
+++ b/src/connectionHelper/checks/Checker.ts
@@ -105,7 +105,7 @@ export abstract class Checker extends (EventEmitter as new () => TypedEmitter<Ch
     if (this.room.state === ConnectionState.Connected) {
       return this.room;
     }
-    await this.room.connect(this.url, this.token);
+    await this.room.connect(this.url, this.token, this.connectOptions);
     return this.room;
   }
 


### PR DESCRIPTION
The connection options is included in [Checker documentation](https://docs.livekit.io/client-sdk-js/interfaces/CheckerOptions.html)  so one might think that creating a Checker with some connection options like "rtcConfig" that it would be respected when checks are run. Some checkers seems to use parts of this information, but checkers using normal room connect functionality will not. This change should fix so all connection checkers using normal room connect flow will use this information.