### PR TITLE
Retry decryption when new key index received

### DIFF
--- a/.changeset/witty-bags-relax.md
+++ b/.changeset/witty-bags-relax.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Retry decryption when a frame with a new key index is received

--- a/src/e2ee/worker/FrameCryptor.test.ts
+++ b/src/e2ee/worker/FrameCryptor.test.ts
@@ -1,5 +1,4 @@
-import { afterEach } from 'node:test';
-import { describe, expect, it, vitest } from 'vitest';
+import { describe, expect, it, vitest, afterEach } from 'vitest';
 import { IV_LENGTH, KEY_PROVIDER_DEFAULTS } from '../constants';
 import type { KeyProviderOptions } from '../types';
 import { createKeyMaterialFromString } from '../utils';

--- a/src/e2ee/worker/FrameCryptor.test.ts
+++ b/src/e2ee/worker/FrameCryptor.test.ts
@@ -1,7 +1,66 @@
-import { describe, expect, it } from 'vitest';
-import { isFrameServerInjected } from './FrameCryptor';
+import { afterEach } from 'node:test';
+import { describe, expect, it, vitest } from 'vitest';
+import { IV_LENGTH, KEY_PROVIDER_DEFAULTS } from '../constants';
+import type { KeyProviderOptions } from '../types';
+import { createKeyMaterialFromString } from '../utils';
+import { FrameCryptor, encryptionEnabledMap, isFrameServerInjected } from './FrameCryptor';
+import { ParticipantKeyHandler } from './ParticipantKeyHandler';
+
+function mockRTCEncodedVideoFrame(data: Uint8Array): RTCEncodedVideoFrame {
+  return {
+    data: data.buffer,
+    timestamp: vitest.getMockedSystemTime()?.getTime() ?? 0,
+    type: 'key',
+    getMetadata(): RTCEncodedVideoFrameMetadata {
+      return {};
+    },
+  };
+}
+
+function mockFrameTrailer(keyIndex: number): Uint8Array {
+  const frameTrailer = new Uint8Array(2);
+
+  frameTrailer[0] = IV_LENGTH;
+  frameTrailer[1] = keyIndex;
+
+  return frameTrailer;
+}
+
+function mockController(): TransformStreamDefaultController {
+  return {
+    desiredSize: 0,
+    enqueue: vitest.fn(),
+    error: vitest.fn(),
+    terminate: vitest.fn(),
+  };
+}
+
+function prepareParticipantTest(
+  participantIdentity: string,
+  partialKeyProviderOptions: Partial<KeyProviderOptions>,
+): { keys: ParticipantKeyHandler; cryptor: FrameCryptor } {
+  const keyProviderOptions = { ...KEY_PROVIDER_DEFAULTS, ...partialKeyProviderOptions };
+  const keys = new ParticipantKeyHandler(participantIdentity, keyProviderOptions);
+
+  encryptionEnabledMap.set(participantIdentity, true);
+
+  const cryptor = new FrameCryptor({
+    participantIdentity,
+    keys,
+    keyProviderOptions,
+    sifTrailer: new Uint8Array(),
+  });
+
+  return { keys, cryptor };
+}
 
 describe('FrameCryptor', () => {
+  const participantIdentity = 'testParticipant';
+
+  afterEach(() => {
+    encryptionEnabledMap.clear();
+  });
+
   it('identifies server injected frame correctly', () => {
     const frameTrailer = new TextEncoder().encode('LKROCKS');
     const frameData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, ...frameTrailer]).buffer;
@@ -15,5 +74,82 @@ describe('FrameCryptor', () => {
     expect(isFrameServerInjected(frameData.buffer, frameTrailer)).toBe(false);
     frameData.fill(0);
     expect(isFrameServerInjected(frameData.buffer, frameTrailer)).toBe(false);
+  });
+
+  it('marks key invalid after too many failures', async () => {
+    const { keys, cryptor } = prepareParticipantTest(participantIdentity, { failureTolerance: 1 });
+
+    expect(keys.hasValidKey).toBe(true);
+
+    await keys.setKey(await createKeyMaterialFromString('password'), 0);
+
+    vitest.spyOn(keys, 'getKeySet');
+    vitest.spyOn(keys, 'decryptionFailure');
+
+    const controller = mockController();
+
+    // TODO: use mock streams instead
+    (cryptor as any).decodeFunction(mockRTCEncodedVideoFrame(mockFrameTrailer(1)), controller);
+
+    expect(keys.decryptionFailure).toHaveBeenCalledTimes(1);
+    expect(keys.getKeySet).toHaveBeenCalledTimes(2);
+    expect(keys.getKeySet).toHaveBeenLastCalledWith(1);
+
+    expect(keys.hasValidKey).toBe(true);
+
+    (cryptor as any).decodeFunction(mockRTCEncodedVideoFrame(mockFrameTrailer(1)), controller);
+
+    expect(keys.decryptionFailure).toHaveBeenCalledTimes(2);
+    expect(keys.getKeySet).toHaveBeenCalledTimes(4);
+    expect(keys.getKeySet).toHaveBeenLastCalledWith(1);
+    expect(keys.hasValidKey).toBe(false);
+
+    // this should still fail as keys are all marked as invalid
+    (cryptor as any).decodeFunction(mockRTCEncodedVideoFrame(mockFrameTrailer(0)), controller);
+
+    // decryptionFailure() isn't called in this case
+    expect(keys.decryptionFailure).toHaveBeenCalledTimes(2);
+    expect(keys.getKeySet).toHaveBeenLastCalledWith(0);
+    expect(keys.hasValidKey).toBe(false);
+  });
+
+  it('mark as valid when a new key is set on same index', async () => {
+    const { keys, cryptor } = prepareParticipantTest(participantIdentity, { failureTolerance: 0 });
+
+    const material = await createKeyMaterialFromString('password');
+    await keys.setKey(material, 0);
+
+    expect(keys.hasValidKey).toBe(true);
+
+    const controller = mockController();
+
+    // TODO: use mock streams instead
+    (cryptor as any).decodeFunction(mockRTCEncodedVideoFrame(mockFrameTrailer(1)), controller);
+
+    expect(keys.hasValidKey).toBe(false);
+
+    await keys.setKey(material, 0);
+
+    expect(keys.hasValidKey).toBe(true);
+  });
+
+  it('mark as valid when a new key is set on new index', async () => {
+    const { keys, cryptor } = prepareParticipantTest(participantIdentity, { failureTolerance: 0 });
+
+    const material = await createKeyMaterialFromString('password');
+    await keys.setKey(material, 0);
+
+    expect(keys.hasValidKey).toBe(true);
+
+    const controller = mockController();
+
+    // TODO: use mock streams instead
+    (cryptor as any).decodeFunction(mockRTCEncodedVideoFrame(mockFrameTrailer(1)), controller);
+
+    expect(keys.hasValidKey).toBe(false);
+
+    await keys.setKey(material, 1);
+
+    expect(keys.hasValidKey).toBe(true);
   });
 });

--- a/src/e2ee/worker/FrameCryptor.test.ts
+++ b/src/e2ee/worker/FrameCryptor.test.ts
@@ -80,7 +80,12 @@ function prepareParticipantTestDecoder(
 
   const input = new TestUnderlyingSource<RTCEncodedVideoFrame>();
   const output = new TestUnderlyingSink<RTCEncodedVideoFrame>();
-  cryptor.setupTransform('decode', new ReadableStream(input), new WritableStream(output), 'testTrack');
+  cryptor.setupTransform(
+    'decode',
+    new ReadableStream(input),
+    new WritableStream(output),
+    'testTrack',
+  );
 
   return { keys, cryptor, input, output };
 }
@@ -147,7 +152,9 @@ describe('FrameCryptor', () => {
   it('drops frames when invalid key', async () => {
     vitest.useFakeTimers();
     try {
-      const { keys, input, output } = prepareParticipantTestDecoder(participantIdentity, { failureTolerance: 0});
+      const { keys, input, output } = prepareParticipantTestDecoder(participantIdentity, {
+        failureTolerance: 0,
+      });
 
       expect(keys.hasValidKey).toBe(true);
 

--- a/src/e2ee/worker/FrameCryptor.test.ts
+++ b/src/e2ee/worker/FrameCryptor.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vitest, afterEach } from 'vitest';
+import { afterEach, describe, expect, it, vitest } from 'vitest';
 import { IV_LENGTH, KEY_PROVIDER_DEFAULTS } from '../constants';
 import type { KeyProviderOptions } from '../types';
 import { createKeyMaterialFromString } from '../utils';
@@ -66,6 +66,7 @@ describe('FrameCryptor', () => {
 
     expect(isFrameServerInjected(frameData, frameTrailer)).toBe(true);
   });
+
   it('identifies server non server injected frame correctly', () => {
     const frameTrailer = new TextEncoder().encode('LKROCKS');
     const frameData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, ...frameTrailer, 10]);

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -360,7 +360,10 @@ export class FrameCryptor extends BaseFrameCryptor {
     const keyIndex = data[encodedFrame.data.byteLength - 1];
 
     if (keyIndex !== this.lastKeyIndexReceived) {
-      workerLogger.debug(`received frame with new key index ${keyIndex}. resetting key status`, this.logContext);
+      workerLogger.debug(
+        `received frame with new key index ${keyIndex}. resetting key status`,
+        this.logContext,
+      );
       this.lastKeyIndexReceived = keyIndex;
       this.keys.resetKeyStatus();
     }

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -54,6 +54,8 @@ export class FrameCryptor extends BaseFrameCryptor {
 
   private keys: ParticipantKeyHandler;
 
+  private lastKeyIndexReceived: number | undefined;
+
   private videoCodec?: VideoCodec;
 
   private rtpMap: Map<number, VideoCodec>;
@@ -357,9 +359,10 @@ export class FrameCryptor extends BaseFrameCryptor {
     const data = new Uint8Array(encodedFrame.data);
     const keyIndex = data[encodedFrame.data.byteLength - 1];
 
-    if (keyIndex !== this.keys.getCurrentKeyIndex()) {
-      workerLogger.debug(`received frame with new key index ${keyIndex}`, this.logContext);
-      this.keys.setCurrentKeyIndex(keyIndex);
+    if (keyIndex !== this.lastKeyIndexReceived) {
+      workerLogger.debug(`received frame with new key index ${keyIndex}. resetting key status`, this.logContext);
+      this.lastKeyIndexReceived = keyIndex;
+      this.keys.resetKeyStatus();
     }
 
     if (!this.keys.hasValidKey) {

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -156,8 +156,8 @@ export class FrameCryptor extends BaseFrameCryptor {
 
   setupTransform(
     operation: 'encode' | 'decode',
-    readable: ReadableStream,
-    writable: WritableStream,
+    readable: ReadableStream<RTCEncodedVideoFrame | RTCEncodedAudioFrame>,
+    writable: WritableStream<RTCEncodedVideoFrame | RTCEncodedAudioFrame>,
     trackId: string,
     codec?: VideoCodec,
   ) {

--- a/src/e2ee/worker/ParticipantKeyHandler.test.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.test.ts
@@ -34,4 +34,88 @@ describe('ParticipantKeyHandler', () => {
     await keyHandler.setKey(materialB, 0);
     expect(keyHandler.getKeySet(0)?.material).toEqual(materialB);
   });
+
+  it('marks invalid if more than failureTolerance failures', async () => {
+    const keyHandler = new ParticipantKeyHandler(participantIdentity, {
+      ...KEY_PROVIDER_DEFAULTS,
+      failureTolerance: 2,
+    });
+    expect(keyHandler.hasValidKey).toBe(true);
+
+    // 1
+    keyHandler.decryptionFailure();
+    expect(keyHandler.hasValidKey).toBe(true);
+
+    // 2
+    keyHandler.decryptionFailure();
+    expect(keyHandler.hasValidKey).toBe(true);
+
+    // 3
+    keyHandler.decryptionFailure();
+    expect(keyHandler.hasValidKey).toBe(false);
+  });
+
+  it('marks valid on encryption success', async () => {
+    const keyHandler = new ParticipantKeyHandler(participantIdentity, {
+      ...KEY_PROVIDER_DEFAULTS,
+      failureTolerance: 0,
+    });
+
+    expect(keyHandler.hasValidKey).toBe(true);
+
+    keyHandler.decryptionFailure();
+
+    expect(keyHandler.hasValidKey).toBe(false);
+
+    keyHandler.decryptionSuccess();
+
+    expect(keyHandler.hasValidKey).toBe(true);
+  });
+
+  it('marks valid on new key', async () => {
+    const keyHandler = new ParticipantKeyHandler(participantIdentity, {
+      ...KEY_PROVIDER_DEFAULTS,
+      failureTolerance: 0,
+    });
+
+    expect(keyHandler.hasValidKey).toBe(true);
+
+    keyHandler.decryptionFailure();
+
+    expect(keyHandler.hasValidKey).toBe(false);
+
+    await keyHandler.setKey(await createKeyMaterialFromString('passwordA'));
+
+    expect(keyHandler.hasValidKey).toBe(true);
+  });
+
+  it('updates currentKeyIndex on new key', async () => {
+    const keyHandler = new ParticipantKeyHandler(participantIdentity, KEY_PROVIDER_DEFAULTS);
+    const material = await createKeyMaterialFromString('password');
+
+    expect(keyHandler.getCurrentKeyIndex()).toBe(0);
+
+    // default is zero
+    await keyHandler.setKey(material);
+    expect(keyHandler.getCurrentKeyIndex()).toBe(0);
+
+    // should go to next index
+    await keyHandler.setKey(material, 1);
+    expect(keyHandler.getCurrentKeyIndex()).toBe(1);
+
+    // should be able to jump ahead
+    await keyHandler.setKey(material, 10);
+    expect(keyHandler.getCurrentKeyIndex()).toBe(10);
+  });
+  it('allows many failures if failureTolerance is -1', async () => {
+    const keyHandler = new ParticipantKeyHandler(participantIdentity, {
+      ...KEY_PROVIDER_DEFAULTS,
+      failureTolerance: -1,
+    });
+    expect(keyHandler.hasValidKey).toBe(true);
+    for (let i = 0; i < 100; i++) {
+      keyHandler.decryptionFailure();
+      expect(keyHandler.hasValidKey).toBe(true);
+    }
+  });
 });

--- a/src/e2ee/worker/ParticipantKeyHandler.test.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.test.ts
@@ -107,6 +107,7 @@ describe('ParticipantKeyHandler', () => {
     await keyHandler.setKey(material, 10);
     expect(keyHandler.getCurrentKeyIndex()).toBe(10);
   });
+
   it('allows many failures if failureTolerance is -1', async () => {
     const keyHandler = new ParticipantKeyHandler(participantIdentity, {
       ...KEY_PROVIDER_DEFAULTS,


### PR DESCRIPTION
This is to be applied on top of https://github.com/livekit/client-sdk-js/pull/1271

i.e. the change can be previewed at https://github.com/hughns/client-sdk-js/compare/unit-test-key-handling...hughns:client-sdk-js:retry-decryption-on-new-key-index

Currently a receiving `FrameCryptor` will never retry decryption once the `failureTolerance` is hit and no new key are received.

This change tracks the last received key index and causes the key status to be reset when a different index is received that on the last frame.