### PR TITLE
chore: output esm as modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "JavaScript/TypeScript client SDK for LiveKit",
   "main": "./dist/livekit-client.umd.js",
   "unpkg": "./dist/livekit-client.umd.js",
-  "module": "./dist/livekit-client.esm.mjs",
+  "module": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./dist/livekit-client.esm.mjs",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/livekit-client.umd.js"
     },
     "./e2ee-worker": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,10 +38,13 @@ export default {
   input: 'src/index.ts',
   output: [
     {
-      file: `dist/${packageJson.name}.esm.mjs`,
-      format: 'es',
+      dir: `dist/esm`,
+      format: "es",
       strict: true,
       sourcemap: true,
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      entryFileNames: "[name].mjs",
     },
     {
       file: `dist/${packageJson.name}.umd.js`,


### PR DESCRIPTION
We can output ESM as modules instead of one big file. Should help with https://github.com/livekit/client-sdk-js/issues/1273