### PR TITLE
Fix attribute deletion

### DIFF
--- a/.changeset/silver-owls-brush.md
+++ b/.changeset/silver-owls-brush.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix attribute deletion

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -282,7 +282,10 @@ export default class LocalParticipant extends Participant {
             (!name || this.name === name) &&
             (!metadata || this.metadata === metadata) &&
             (!attributes ||
-              Object.entries(attributes).every(([key, value]) => this.attributes[key] === value))
+              Object.entries(attributes).every(
+                ([key, value]) =>
+                  this.attributes[key] === value || (value === '' && !this.attributes[key]),
+              ))
           ) {
             this.pendingSignalRequests.delete(requestId);
             resolve();


### PR DESCRIPTION
setting an attribute to an empty string results in the attribute being deleted. 
This case was missing in resolving the pending update request.