### PR TITLE
Reset `joinAttempts` when closing RTCEngine

### DIFF
--- a/.changeset/chatty-bags-matter.md
+++ b/.changeset/chatty-bags-matter.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Reset `joinAttempts` when closing RTCEngine

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -262,6 +262,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
     try {
       this._isClosed = true;
+      this.joinAttempts = 0;
       this.emit(EngineEvent.Closing);
       this.removeAllListeners();
       this.deregisterOnLineListener();


### PR DESCRIPTION
Hi.
Currently, `joinAttempts` in RTCEngine will not reset after closing. This makes it so that if we fail joining after `maxJoinAttempts` and want to connect to the server **again** (manually), and then the first attempt fails, no more attempts will be made to connect to the server and we will see logs like `Couldn't connect to server, attempt **4** of 3` in the console.
``` typescript
this.log.warn(
  `Couldn't connect to server, attempt ${this.joinAttempts} of ${this.maxJoinAttempts}`,
  this.logContext,
);
if (this.joinAttempts < this.maxJoinAttempts) {
  return this.join(url, token, opts, abortSignal);
}
```