### PR TITLE
Keep dd extension id in the session

### DIFF
--- a/.changeset/young-steaks-switch.md
+++ b/.changeset/young-steaks-switch.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Keep dd extension id in the session

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -587,7 +587,6 @@ function ensureAudioNackAndStereo(
   }
 }
 
-
 function extractStereoAndNackAudioFromOffer(offer: RTCSessionDescriptionInit): {
   stereoMids: string[];
   nackMids: string[];


### PR DESCRIPTION
Safari could generate different rtp extensions
for video tracks(camera and screenshare), need
to use same extension id for dependency descriptor in the offer.