### PR TITLE
Move github banners to assets directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "rollup --config --bundleConfigAsCjs && rollup --config rollup.config.worker.js --bundleConfigAsCjs && pnpm downlevel-dts",
     "build:watch": "rollup --watch --config --bundleConfigAsCjs",
     "build:worker:watch": "rollup --watch --config rollup.config.worker.js --bundleConfigAsCjs",
-    "build-docs": "typedoc && mkdir -p docs/assets/github && cp .github/*.png docs/assets/github/ && find docs -name '*.html' -type f -exec sed -i '' 's|/.github/|assets/github/|g' {} +",
+    "build-docs": "typedoc && mkdir -p docs/assets/github && cp .github/*.png docs/assets/github/ && find docs -name '*.html' -type f -exec sed -i.bak 's|=\"/.github/|=\"assets/github/|g' {} + && find docs -name '*.bak' -delete",
     "proto": "protoc --es_out src/proto --es_opt target=ts -I./protocol ./protocol/livekit_rtc.proto ./protocol/livekit_models.proto",
     "examples:demo": "vite examples/demo -c vite.config.mjs",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "rollup --config --bundleConfigAsCjs && rollup --config rollup.config.worker.js --bundleConfigAsCjs && pnpm downlevel-dts",
     "build:watch": "rollup --watch --config --bundleConfigAsCjs",
     "build:worker:watch": "rollup --watch --config rollup.config.worker.js --bundleConfigAsCjs",
-    "build-docs": "typedoc && mkdir docs/.github && cp .github/*.png docs/.github/",
+    "build-docs": "typedoc && mkdir -p docs/assets/github && cp .github/*.png docs/assets/github/ && find docs -name '*.html' -type f -exec sed -i '' 's|/.github/|assets/github/|g' {} +",
     "proto": "protoc --es_out src/proto --es_opt target=ts -I./protocol ./protocol/livekit_rtc.proto ./protocol/livekit_models.proto",
     "examples:demo": "vite examples/demo -c vite.config.mjs",
     "lint": "eslint src",


### PR DESCRIPTION
Unfortunately #1299 didn't work both due to a leading slash in the img tag (which means relative to the host not the current path) and due to the `.github/` folder not being exposed from S3/cloudfront. Instead of making changes in readme manager, I changed the doc gen script to also rewrite the image url and move the images into assets where they belong.