### PR TITLE
mimeTypeToVideoCodecString should not throw

### DIFF
--- a/.changeset/heavy-garlics-greet.md
+++ b/.changeset/heavy-garlics-greet.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+fix: mimeTypeToVideoCodecString should not throw

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -9,7 +9,6 @@ import {
   type ScreenShareCaptureOptions,
   type VideoCaptureOptions,
   type VideoCodec,
-  videoCodecs,
 } from './options';
 import type { AudioTrack } from './types';
 
@@ -188,11 +187,7 @@ export function screenCaptureToDisplayMediaStreamOptions(
 }
 
 export function mimeTypeToVideoCodecString(mimeType: string) {
-  const codec = mimeType.split('/')[1].toLowerCase() as VideoCodec;
-  if (!videoCodecs.includes(codec)) {
-    throw Error(`Video codec not supported: ${codec}`);
-  }
-  return codec;
+  return mimeType.split('/')[1].toLowerCase() as VideoCodec;
 }
 
 export function getTrackPublicationInfo<T extends TrackPublication>(


### PR DESCRIPTION
The current implementation is not resilient to codecs changes. If a new codec is introduced, previously working code would start failing.