### PR TITLE
RPC updates

### DIFF
--- a/.changeset/silent-garlics-add.md
+++ b/.changeset/silent-garlics-add.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+RPC updates

--- a/README.md
+++ b/README.md
@@ -320,14 +320,14 @@ room.localParticipant?.registerRpcMethod(
   'greet',
   
   // method handler - will be called when the method is invoked by a RemoteParticipant
-  async (requestId: string, callerIdentity: string, payload: string, responseTimeoutMs: number) => {
+  async (requestId: string, callerIdentity: string, payload: string, responseTimeout: number) => {
     console.log(`Received greeting from ${callerIdentity}: ${payload}`);
     return `Hello, ${callerIdentity}!`;
   }
 );
 ```
 
-In addition to the payload, your handler will also receive `responseTimeoutMs`, which informs you the maximum time available to return a response. If you are unable to respond in time, the call will result in an error on the caller's side.
+In addition to the payload, your handler will also receive `responseTimeout`, which informs you the maximum time available to return a response. If you are unable to respond in time, the call will result in an error on the caller's side.
 
 #### Performing an RPC request
 
@@ -346,7 +346,7 @@ try {
 }
 ```
 
-You may find it useful to adjust the `responseTimeoutMs` parameter, which indicates the amount of time you will wait for a response. We recommend keeping this value as low as possible while still satisfying the constraints of your application.
+You may find it useful to adjust the `responseTimeout` parameter, which indicates the amount of time you will wait for a response. We recommend keeping this value as low as possible while still satisfying the constraints of your application.
 
 #### Errors
 

--- a/README.md
+++ b/README.md
@@ -316,9 +316,9 @@ The participant who implements the method and will receive its calls must first 
 
 ```typescript
 room.localParticipant?.registerRpcMethod(
-   // method name - can be any string that makes sense for your application
+  // method name - can be any string that makes sense for your application
   'greet',
-  
+
   // method handler - will be called when the method is invoked by a RemoteParticipant
   async (data: RpcInvocationData) => {
     console.log(`Received greeting from ${data.callerIdentity}: ${data.payload}`);

--- a/README.md
+++ b/README.md
@@ -335,11 +335,11 @@ The caller may then initiate an RPC call like so:
 
 ```typescript
 try {
-  const response = await room.localParticipant!.performRpc(
-    'recipient-identity',
-    'greet',
-    'Hello from RPC!',
-  );
+  const response = await room.localParticipant!.performRpc({
+    destinationIdentity: 'recipient-identity',
+    method: 'greet',
+    payload: 'Hello from RPC!',
+  });
   console.log('RPC response:', response);
 } catch (error) {
   console.error('RPC call failed:', error);

--- a/README.md
+++ b/README.md
@@ -320,9 +320,9 @@ room.localParticipant?.registerRpcMethod(
   'greet',
   
   // method handler - will be called when the method is invoked by a RemoteParticipant
-  async (requestId: string, callerIdentity: string, payload: string, responseTimeout: number) => {
-    console.log(`Received greeting from ${callerIdentity}: ${payload}`);
-    return `Hello, ${callerIdentity}!`;
+  async (data: RpcInvocationData) => {
+    console.log(`Received greeting from ${data.callerIdentity}: ${data.payload}`);
+    return `Hello, ${data.callerIdentity}!`;
   }
 );
 ```
@@ -338,7 +338,7 @@ try {
   const response = await room.localParticipant!.performRpc(
     'recipient-identity',
     'greet',
-    'Hello from RPC!'
+    'Hello from RPC!',
   );
   console.log('RPC response:', response);
 } catch (error) {

--- a/examples/rpc/rpc-demo.ts
+++ b/examples/rpc/rpc-demo.ts
@@ -76,7 +76,7 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
       requestId: string,
       callerIdentity: string,
       payload: string,
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => {
       console.log(`[Greeter] Oh ${callerIdentity} arrived and said "${payload}"`);
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -90,12 +90,13 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
       requestId: string,
       callerIdentity: string,
       payload: string,
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => {
       const jsonData = JSON.parse(payload);
       const number = jsonData.number;
+      
       console.log(
-        `[Math Genius] I guess ${callerIdentity} wants the square root of ${number}. I've only got ${responseTimeoutMs / 1000} seconds to respond but I think I can pull it off.`,
+        `[Math Genius] I guess ${callerIdentity} wants the square root of ${number}. I've only got ${responseTimeout / 1000} seconds to respond but I think I can pull it off.`,
       );
 
       console.log(`[Math Genius] *doing math*…`);
@@ -114,7 +115,7 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
       requestId: string,
       callerIdentity: string,
       payload: string,
-      responseTimeoutMs: number,
+      responseTimeout: number,
     ) => {
       const jsonData = JSON.parse(payload);
       const { numerator, denominator } = jsonData;

--- a/examples/rpc/rpc-demo.ts
+++ b/examples/rpc/rpc-demo.ts
@@ -1,4 +1,10 @@
-import { Room, type RoomConnectOptions, RoomEvent, RpcError, RpcInvocationData } from '../../src/index';
+import {
+  Room,
+  type RoomConnectOptions,
+  RoomEvent,
+  RpcError,
+  RpcInvocationData,
+} from '../../src/index';
 
 let startTime: number;
 
@@ -84,7 +90,7 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
     async (data: RpcInvocationData) => {
       const jsonData = JSON.parse(data.payload);
       const number = jsonData.number;
-      
+
       console.log(
         `[Math Genius] I guess ${data.callerIdentity} wants the square root of ${number}. I've only got ${data.responseTimeout / 1000} seconds to respond but I think I can pull it off.`,
       );

--- a/examples/rpc/rpc-demo.ts
+++ b/examples/rpc/rpc-demo.ts
@@ -1,4 +1,4 @@
-import { Room, type RoomConnectOptions, RoomEvent, RpcError } from '../../src/index';
+import { Room, type RoomConnectOptions, RoomEvent, RpcError, RpcInvocationData } from '../../src/index';
 
 let startTime: number;
 
@@ -72,13 +72,8 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
   await greetersRoom.localParticipant?.registerRpcMethod(
     'arrival',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async (
-      requestId: string,
-      callerIdentity: string,
-      payload: string,
-      responseTimeout: number,
-    ) => {
-      console.log(`[Greeter] Oh ${callerIdentity} arrived and said "${payload}"`);
+    async (data: RpcInvocationData) => {
+      console.log(`[Greeter] Oh ${data.callerIdentity} arrived and said "${data.payload}"`);
       await new Promise((resolve) => setTimeout(resolve, 2000));
       return 'Welcome and have a wonderful day!';
     },
@@ -86,17 +81,12 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
 
   await mathGeniusRoom.localParticipant?.registerRpcMethod(
     'square-root',
-    async (
-      requestId: string,
-      callerIdentity: string,
-      payload: string,
-      responseTimeout: number,
-    ) => {
-      const jsonData = JSON.parse(payload);
+    async (data: RpcInvocationData) => {
+      const jsonData = JSON.parse(data.payload);
       const number = jsonData.number;
       
       console.log(
-        `[Math Genius] I guess ${callerIdentity} wants the square root of ${number}. I've only got ${responseTimeout / 1000} seconds to respond but I think I can pull it off.`,
+        `[Math Genius] I guess ${data.callerIdentity} wants the square root of ${number}. I've only got ${data.responseTimeout / 1000} seconds to respond but I think I can pull it off.`,
       );
 
       console.log(`[Math Genius] *doing math*…`);
@@ -110,18 +100,12 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
 
   await mathGeniusRoom.localParticipant?.registerRpcMethod(
     'divide',
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async (
-      requestId: string,
-      callerIdentity: string,
-      payload: string,
-      responseTimeout: number,
-    ) => {
-      const jsonData = JSON.parse(payload);
+    async (data: RpcInvocationData) => {
+      const jsonData = JSON.parse(data.payload);
       const { numerator, denominator } = jsonData;
 
       console.log(
-        `[Math Genius] ${callerIdentity} wants to divide ${numerator} by ${denominator}. Let me think...`,
+        `[Math Genius] ${data.callerIdentity} wants to divide ${numerator} by ${denominator}. Let me think...`,
       );
 
       await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/examples/rpc/rpc-demo.ts
+++ b/examples/rpc/rpc-demo.ts
@@ -130,7 +130,11 @@ const registerReceiverMethods = async (greetersRoom: Room, mathGeniusRoom: Room)
 const performGreeting = async (room: Room): Promise<void> => {
   console.log("[Caller] Letting the greeter know that I've arrived");
   try {
-    const response = await room.localParticipant!.performRpc('greeter', 'arrival', 'Hello');
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'greeter',
+      method: 'arrival',
+      payload: 'Hello',
+    });
     console.log(`[Caller] That's nice, the greeter said: "${response}"`);
   } catch (error) {
     console.error('[Caller] RPC call failed:', error);
@@ -141,11 +145,11 @@ const performGreeting = async (room: Room): Promise<void> => {
 const performDisconnection = async (room: Room): Promise<void> => {
   console.log('[Caller] Checking back in on the greeter...');
   try {
-    const response = await room.localParticipant!.performRpc(
-      'greeter',
-      'arrival',
-      'You still there?',
-    );
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'greeter',
+      method: 'arrival',
+      payload: 'You still there?',
+    });
     console.log(`[Caller] That's nice, the greeter said: "${response}"`);
   } catch (error) {
     if (error instanceof RpcError && error.code === RpcError.ErrorCode.RECIPIENT_DISCONNECTED) {
@@ -160,11 +164,11 @@ const performDisconnection = async (room: Room): Promise<void> => {
 const performSquareRoot = async (room: Room): Promise<void> => {
   console.log("[Caller] What's the square root of 16?");
   try {
-    const response = await room.localParticipant!.performRpc(
-      'math-genius',
-      'square-root',
-      JSON.stringify({ number: 16 }),
-    );
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'math-genius',
+      method: 'square-root',
+      payload: JSON.stringify({ number: 16 }),
+    });
     const parsedResponse = JSON.parse(response);
     console.log(`[Caller] Nice, the answer was ${parsedResponse.result}`);
   } catch (error) {
@@ -176,11 +180,11 @@ const performSquareRoot = async (room: Room): Promise<void> => {
 const performQuantumHypergeometricSeries = async (room: Room): Promise<void> => {
   console.log("[Caller] What's the quantum hypergeometric series of 42?");
   try {
-    const response = await room.localParticipant!.performRpc(
-      'math-genius',
-      'quantum-hypergeometric-series',
-      JSON.stringify({ number: 42 }),
-    );
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'math-genius',
+      method: 'quantum-hypergeometric-series',
+      payload: JSON.stringify({ number: 42 }),
+    });
     const parsedResponse = JSON.parse(response);
     console.log(`[Caller] genius says ${parsedResponse.result}!`);
   } catch (error) {
@@ -199,11 +203,11 @@ const performQuantumHypergeometricSeries = async (room: Room): Promise<void> => 
 const performDivision = async (room: Room): Promise<void> => {
   console.log("[Caller] Let's try dividing 10 by 0");
   try {
-    const response = await room.localParticipant!.performRpc(
-      'math-genius',
-      'divide',
-      JSON.stringify({ numerator: 10, denominator: 0 }),
-    );
+    const response = await room.localParticipant!.performRpc({
+      destinationIdentity: 'math-genius',
+      method: 'divide',
+      payload: JSON.stringify({ numerator: 10, denominator: 0 }),
+    });
     const parsedResponse = JSON.parse(response);
     console.log(`[Caller] The result is ${parsedResponse.result}`);
   } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import {
 } from './room/utils';
 import { getBrowser } from './utils/browserParser';
 
-export { RpcError } from './room/rpc';
+export { RpcError, RpcInvocationData } from './room/rpc';
 
 export * from './connectionHelper/ConnectionCheck';
 export * from './connectionHelper/checks/Checker';

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import {
 } from './room/utils';
 import { getBrowser } from './utils/browserParser';
 
-export { RpcError, RpcInvocationData } from './room/rpc';
+export { RpcError, type RpcInvocationData } from './room/rpc';
 
 export * from './connectionHelper/ConnectionCheck';
 export * from './connectionHelper/checks/Checker';

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import {
 } from './room/utils';
 import { getBrowser } from './utils/browserParser';
 
-export { RpcError, type RpcInvocationData } from './room/rpc';
+export { RpcError, type RpcInvocationData, type PerformRpcParams } from './room/rpc';
 
 export * from './connectionHelper/ConnectionCheck';
 export * from './connectionHelper/checks/Checker';

--- a/src/room/participant/LocalParticipant.test.ts
+++ b/src/room/participant/LocalParticipant.test.ts
@@ -56,14 +56,15 @@ describe('LocalParticipant', () => {
         methodName,
         'test payload',
         5000,
+        1,
       );
 
-      expect(handler).toHaveBeenCalledWith(
-        'test-request-id',
-        mockCaller.identity,
-        'test payload',
-        5000,
-      );
+      expect(handler).toHaveBeenCalledWith({
+        requestId: 'test-request-id',
+        callerIdentity: mockCaller.identity,
+        payload: 'test payload',
+        responseTimeout: 5000,
+      });
 
       // Check if sendDataPacket was called twice (once for ACK and once for response)
       expect(mockSendDataPacket).toHaveBeenCalledTimes(2);
@@ -100,14 +101,15 @@ describe('LocalParticipant', () => {
         methodName,
         'test payload',
         5000,
+        1,
       );
 
-      expect(handler).toHaveBeenCalledWith(
-        'test-error-request-id',
-        mockCaller.identity,
-        'test payload',
-        5000,
-      );
+      expect(handler).toHaveBeenCalledWith({
+        requestId: 'test-error-request-id',
+        callerIdentity: mockCaller.identity,
+        payload: 'test payload',
+        responseTimeout: 5000,
+      });
 
       // Check if sendDataPacket was called twice (once for ACK and once for error response)
       expect(mockSendDataPacket).toHaveBeenCalledTimes(2);
@@ -141,14 +143,15 @@ describe('LocalParticipant', () => {
         methodName,
         'test payload',
         5000,
+        1,
       );
 
-      expect(handler).toHaveBeenCalledWith(
-        'test-rpc-error-request-id',
-        mockCaller.identity,
-        'test payload',
-        5000,
-      );
+      expect(handler).toHaveBeenCalledWith({
+        requestId: 'test-rpc-error-request-id',
+        callerIdentity: mockCaller.identity,
+        payload: 'test payload',
+        responseTimeout: 5000,
+      });
 
       // Check if sendDataPacket was called twice (once for ACK and once for error response)
       expect(mockSendDataPacket).toHaveBeenCalledTimes(2);
@@ -212,11 +215,11 @@ describe('LocalParticipant', () => {
         }, 10);
       });
 
-      const result = await localParticipant.performRpc(
-        mockRemoteParticipant.identity,
+      const result = await localParticipant.performRpc({
+        destinationIdentity: mockRemoteParticipant.identity,
         method,
         payload,
-      );
+      });
 
       expect(mockSendDataPacket).toHaveBeenCalledTimes(1);
       expect(result).toBe(responsePayload);
@@ -226,18 +229,18 @@ describe('LocalParticipant', () => {
       const method = 'timeoutMethod';
       const payload = 'timeoutPayload';
 
-      const timeoutMs = 50;
+      const timeout = 50;
 
-      const resultPromise = localParticipant.performRpc(
-        mockRemoteParticipant.identity,
+      const resultPromise = localParticipant.performRpc({
+        destinationIdentity: mockRemoteParticipant.identity,
         method,
         payload,
-        timeoutMs,
-      );
+        responseTimeout: timeout,
+      });
 
       mockSendDataPacket.mockImplementationOnce(() => {
         return new Promise((resolve) => {
-          setTimeout(resolve, timeoutMs + 10);
+          setTimeout(resolve, timeout + 10);
         });
       });
 
@@ -246,8 +249,8 @@ describe('LocalParticipant', () => {
       await expect(resultPromise).rejects.toThrow('Response timeout');
 
       const elapsedTime = Date.now() - startTime;
-      expect(elapsedTime).toBeGreaterThanOrEqual(timeoutMs);
-      expect(elapsedTime).toBeLessThan(timeoutMs + 50); // Allow some margin for test execution
+      expect(elapsedTime).toBeGreaterThanOrEqual(timeout);
+      expect(elapsedTime).toBeLessThan(timeout + 50); // Allow some margin for test execution
 
       expect(mockSendDataPacket).toHaveBeenCalledTimes(1);
     });
@@ -271,7 +274,11 @@ describe('LocalParticipant', () => {
       });
 
       await expect(
-        localParticipant.performRpc(mockRemoteParticipant.identity, method, payload),
+        localParticipant.performRpc({
+          destinationIdentity: mockRemoteParticipant.identity,
+          method,
+          payload,
+        }),
       ).rejects.toThrow(errorMessage);
     });
 
@@ -281,11 +288,11 @@ describe('LocalParticipant', () => {
 
       mockSendDataPacket.mockImplementationOnce(() => Promise.resolve());
 
-      const resultPromise = localParticipant.performRpc(
-        mockRemoteParticipant.identity,
+      const resultPromise = localParticipant.performRpc({
+        destinationIdentity: mockRemoteParticipant.identity,
         method,
         payload,
-      );
+      });
 
       // Simulate a small delay before disconnection
       await new Promise((resolve) => setTimeout(resolve, 200));

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -257,6 +257,7 @@ export default class LocalParticipant extends Participant {
           rpcRequest.method,
           rpcRequest.payload,
           rpcRequest.responseTimeoutMs,
+          rpcRequest.version,
         );
         break;
       case 'rpcResponse':
@@ -1662,8 +1663,19 @@ export default class LocalParticipant extends Participant {
     method: string,
     payload: string,
     responseTimeout: number,
+    version: number,
   ) {
     await this.publishRpcAck(callerIdentity, requestId);
+
+    if (version !== 1) {
+      await this.publishRpcResponse(
+        callerIdentity,
+        requestId,
+        null,
+        RpcError.builtIn('UNSUPPORTED_VERSION'),
+      );
+      return;
+    }
 
     const handler = this.rpcHandlers.get(method);
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -32,7 +32,7 @@ import {
   UnexpectedConnectionState,
 } from '../errors';
 import { EngineEvent, ParticipantEvent, TrackEvent } from '../events';
-import { MAX_PAYLOAD_BYTES, RpcError, type RpcInvocationData, byteLength } from '../rpc';
+import { MAX_PAYLOAD_BYTES, RpcError, type RpcInvocationData, byteLength, type PerformRpcParams } from '../rpc';
 import LocalAudioTrack from '../track/LocalAudioTrack';
 import LocalTrack from '../track/LocalTrack';
 import LocalTrackPublication from '../track/LocalTrackPublication';
@@ -77,18 +77,6 @@ import {
   getDefaultDegradationPreference,
   mediaTrackToLocalTrack,
 } from './publishUtils';
-
-/** Parameters for performing an RPC call */
-interface PerformRpcParams {
-  /** The `identity` of the destination participant */
-  destinationIdentity: string;
-  /** The method name to call */
-  method: string;
-  /** The method payload */
-  payload: string;
-  /** Timeout for receiving a response after initial connection (milliseconds). Default: 10000 */
-  responseTimeout?: number;
-}
 
 export default class LocalParticipant extends Participant {
   audioTrackPublications: Map<string, LocalTrackPublication>;

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -32,7 +32,13 @@ import {
   UnexpectedConnectionState,
 } from '../errors';
 import { EngineEvent, ParticipantEvent, TrackEvent } from '../events';
-import { MAX_PAYLOAD_BYTES, RpcError, type RpcInvocationData, byteLength, type PerformRpcParams } from '../rpc';
+import {
+  MAX_PAYLOAD_BYTES,
+  type PerformRpcParams,
+  RpcError,
+  type RpcInvocationData,
+  byteLength,
+} from '../rpc';
 import LocalAudioTrack from '../track/LocalAudioTrack';
 import LocalTrack from '../track/LocalTrack';
 import LocalTrackPublication from '../track/LocalTrackPublication';

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1570,10 +1570,7 @@ export default class LocalParticipant extends Participant {
    * and they will be received on the caller's side with the message intact.
    * Other errors thrown in your handler will not be transmitted as-is, and will instead arrive to the caller as `1500` ("Application Error").
    */
-  registerRpcMethod(
-    method: string,
-    handler: (data: RpcInvocationData) => Promise<string>,
-  ) {
+  registerRpcMethod(method: string, handler: (data: RpcInvocationData) => Promise<string>) {
     this.rpcHandlers.set(method, handler);
   }
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1466,7 +1466,8 @@ export default class LocalParticipant extends Participant {
   }
 
   /**
-   * Initiate an RPC call to a remote participant.
+   * Initiate an RPC call to a remote participant
+   * @param params - Parameters for initiating the RPC call, see {@link PerformRpcParams}
    * @returns A promise that resolves with the response payload or rejects with an error.
    * @throws Error on failure. Details in `message`.
    */

--- a/src/room/rpc.ts
+++ b/src/room/rpc.ts
@@ -3,6 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import { RpcError as RpcError_Proto } from '@livekit/protocol';
 
+/** Parameters for initiating an RPC call */
+export interface PerformRpcParams {
+  /** The `identity` of the destination participant */
+  destinationIdentity: string;
+  /** The method name to call */
+  method: string;
+  /** The method payload */
+  payload: string;
+  /** Timeout for receiving a response after initial connection (milliseconds). Default: 10000 */
+  responseTimeout?: number;
+}
+
 /**
  * Data passed to method handler for incoming RPC invocations
  */

--- a/src/room/rpc.ts
+++ b/src/room/rpc.ts
@@ -4,6 +4,38 @@
 import { RpcError as RpcError_Proto } from '@livekit/protocol';
 
 /**
+ * Data passed to method handler for incoming RPC invocations
+ */
+export class RpcInvocationData {
+  /**
+   * The unique request ID. Will match at both sides of the call, useful for debugging or logging.
+   */
+  requestId: string;
+
+  /**
+   * The unique participant identity of the caller.
+   */
+  callerIdentity: string;
+
+  /**
+   * The payload of the request. User-definable format, typically JSON.
+   */
+  payload: string;
+
+  /**
+   * The maximum time the caller will wait for a response.
+   */
+  responseTimeout: number;
+
+  constructor(requestId: string, callerIdentity: string, payload: string, responseTimeout: number) {
+    this.requestId = requestId;
+    this.callerIdentity = callerIdentity;
+    this.payload = payload;
+    this.responseTimeout = responseTimeout;
+  }
+}
+
+/**
  * Specialized error handling for RPC methods.
  *
  * Instances of this type, when thrown in a method handler, will have their `message`

--- a/src/room/rpc.ts
+++ b/src/room/rpc.ts
@@ -65,6 +65,7 @@ export class RpcError extends Error {
     RECIPIENT_NOT_FOUND: 1401,
     REQUEST_PAYLOAD_TOO_LARGE: 1402,
     UNSUPPORTED_SERVER: 1403,
+    UNSUPPORTED_VERSION: 1404,
   } as const;
 
   /**
@@ -82,6 +83,7 @@ export class RpcError extends Error {
     RECIPIENT_NOT_FOUND: 'Recipient not found',
     REQUEST_PAYLOAD_TOO_LARGE: 'Request payload too large',
     UNSUPPORTED_SERVER: 'RPC not supported by server',
+    UNSUPPORTED_VERSION: 'Unsupported RPC version',
   } as const;
 
   /**

--- a/src/room/rpc.ts
+++ b/src/room/rpc.ts
@@ -6,7 +6,7 @@ import { RpcError as RpcError_Proto } from '@livekit/protocol';
 /**
  * Data passed to method handler for incoming RPC invocations
  */
-export class RpcInvocationData {
+export interface RpcInvocationData {
   /**
    * The unique request ID. Will match at both sides of the call, useful for debugging or logging.
    */
@@ -26,13 +26,6 @@ export class RpcInvocationData {
    * The maximum time the caller will wait for a response.
    */
   responseTimeout: number;
-
-  constructor(requestId: string, callerIdentity: string, payload: string, responseTimeout: number) {
-    this.requestId = requestId;
-    this.callerIdentity = callerIdentity;
-    this.payload = payload;
-    this.responseTimeout = responseTimeout;
-  }
 }
 
 /**


### PR DESCRIPTION
- remove 'ms' modified from response timeout name, since JS uses millisecond times anyways.
- implement the version check, which hopefully we don't have to use but provides future optionality.
- change handlers to receive arguments as a data class instead of params, to allow additional params to be added later without breaking existing implementations
- Change performRpc method to use an interface to make it clearer which args are which