### PR TITLE
Make Remote Tracks `getSenderStats` method public

### DIFF
--- a/.changeset/popular-swans-greet.md
+++ b/.changeset/popular-swans-greet.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Make Remote Tracks `getSenderStats` method public

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -233,7 +233,7 @@ export default class RemoteAudioTrack extends RemoteTrack<Track.Kind.Audio> {
     this.prevStats = stats;
   };
 
-  protected async getReceiverStats(): Promise<AudioReceiverStats | undefined> {
+  async getReceiverStats(): Promise<AudioReceiverStats | undefined> {
     if (!this.receiver || !this.receiver.getStats) {
       return;
     }

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -163,7 +163,7 @@ export default class RemoteVideoTrack extends RemoteTrack<Track.Kind.Video> {
     this.prevStats = stats;
   };
 
-  private async getReceiverStats(): Promise<VideoReceiverStats | undefined> {
+  async getReceiverStats(): Promise<VideoReceiverStats | undefined> {
     if (!this.receiver || !this.receiver.getStats) {
       return;
     }


### PR DESCRIPTION
Hi.
Currently, `getSenderStats` method in remote tracks (audio & video) are private or protected and unlike local tracks, there is no way to call them from outside the class and this makes us unable to access them if we need to check Stats for remote tracks. (for debugging and metric stuff)