### PR TITLE
Use capturing mediastreamtrack settings for audio feature detection

### DIFF
--- a/.changeset/soft-clouds-nail.md
+++ b/.changeset/soft-clouds-nail.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Use capturing mediastreamtrack settings for audio feature detection

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -120,6 +120,14 @@ export default abstract class LocalTrack<
     return this.processor?.processedTrack ?? this._mediaStreamTrack;
   }
 
+  /**
+   * @internal
+   * returns mediaStreamTrack settings of the capturing mediastreamtrack source - ignoring processors
+   */
+  getSourceTrackSettings() {
+    return this._mediaStreamTrack.getSettings();
+  }
+
   private async setMediaStreamTrack(newTrack: MediaStreamTrack, force?: boolean) {
     if (newTrack === this._mediaStreamTrack && !force) {
       return;

--- a/src/room/track/LocalTrackPublication.ts
+++ b/src/room/track/LocalTrackPublication.ts
@@ -84,7 +84,7 @@ export default class LocalTrackPublication extends TrackPublication {
 
   getTrackFeatures() {
     if (this.track instanceof LocalAudioTrack) {
-      const settings = this.track!.mediaStreamTrack.getSettings();
+      const settings = this.track!.getSourceTrackSettings();
       const features: Set<AudioTrackFeature> = new Set();
       if (settings.autoGainControl) {
         features.add(AudioTrackFeature.TF_AUTO_GAIN_CONTROL);


### PR DESCRIPTION
previously the processed track (if a processor is set) was used to determine active features. This doesn't reflect the actual settings on the capturing device though, so it makes more sense to query the settings directly from the input device's track.