### PR TITLE
Handle `RTCPeerConnection` error on `replaceTrack` 

### DIFF
--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -172,7 +172,17 @@ export default abstract class LocalTrack<
       }
     }
     if (this.sender) {
-      await this.sender.replaceTrack(processedTrack ?? newTrack);
+      try {
+        await this.sender.replaceTrack(processedTrack ?? newTrack);
+      } catch (e) {
+        this.log.error('failed to replace track on sender', {
+          ...this.logContext,
+          error: e,
+          newTrack: newTrack,
+          processedTrack: processedTrack,
+          sender: this.sender
+        });
+      }
     }
     // if `newTrack` is different from the existing track, stop the
     // older track just before replacing it


### PR DESCRIPTION

### Changes
 * [x] Catch / log `InvalidStateError: RTCPeerConnection is closed` exception

### Repro
1. In Safari / Firefox (not Chrome / Edge)
2. After a region change / reconnection
3. With _or_ without audio processing (Krisp) on
4. When trying to un-mute with `localParticipant.setMicrophoneEnabled`
5. Before: it would raise the `InvalidStateError: RTCPeerConnection is closed` error and remain muted
6. After: we can catch the error, but it still doesn't un-mute

### Screenshots

#### Uncaught
<img width="1624" alt="Screenshot 2024-11-19 at 1 12 09 PM" src="https://github.com/user-attachments/assets/398a2869-b3bd-42b8-bdd3-71afc6751fcd">

#### Krisp Off
<img width="1624" alt="Screenshot 2024-11-19 at 1 04 56 PM" src="https://github.com/user-attachments/assets/6147aefd-c556-43de-9494-a4797e826230">

#### Krisp On
<img width="1624" alt="Screenshot 2024-11-19 at 1 02 36 PM" src="https://github.com/user-attachments/assets/8017d788-b55f-4b67-8182-79f8826e659e">
