### PR TITLE
Await pending publications with timeout

### DIFF
--- a/.changeset/tame-news-study.md
+++ b/.changeset/tame-news-study.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Await pending publications with timeout

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -2016,11 +2016,18 @@ export default class LocalParticipant extends Participant {
   }
 
   private async waitForPendingPublicationOfSource(source: Track.Source) {
-    const publishPromiseEntry = Array.from(this.pendingPublishPromises.entries()).find(
-      ([pendingTrack]) => pendingTrack.source === source,
-    );
-    if (publishPromiseEntry) {
-      return publishPromiseEntry[1];
+    const waitForPendingTimeout = 10_000;
+    const startTime = Date.now();
+
+    while (Date.now() < startTime + waitForPendingTimeout) {
+      const publishPromiseEntry = Array.from(this.pendingPublishPromises.entries()).find(
+        ([pendingTrack]) => pendingTrack.source === source,
+      );
+      if (publishPromiseEntry) {
+        return publishPromiseEntry[1];
+      }
+      sleep(20);
     }
+    throw new Error('waiting for pending publication promise timed out');
   }
 }


### PR DESCRIPTION
previously if there was no entry in `pendingPublishPromises` yet, this would have resolved immediately without actually waiting for the pending publication to be published.
