### PR TITLE
chore: expose reconnection types

### DIFF
--- a/.changeset/expose-reconnect-types.md
+++ b/.changeset/expose-reconnect-types.md
@@ -1,5 +1,5 @@
 ---
-'livekit-client': minor
+'livekit-client': patch
 ---
 
 Expose `ReconnectContext` and `ReconnectPolicy`, for use in custom reconnection implementations.

--- a/.changeset/expose-reconnect-types.md
+++ b/.changeset/expose-reconnect-types.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': minor
+---
+
+Expose `ReconnectContext` and `ReconnectPolicy`, for use in custom reconnection implementations.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Mutex } from '@livekit/mutex';
 import { DataPacket_Kind, DisconnectReason, SubscriptionError } from '@livekit/protocol';
 import { LogLevel, LoggerNames, getLogger, setLogExtension, setLogLevel } from './logger';
 import DefaultReconnectPolicy from './room/DefaultReconnectPolicy';
+import type { ReconnectContext, ReconnectPolicy } from './room/ReconnectPolicy';
 import Room, { ConnectionState } from './room/Room';
 import LocalParticipant from './room/participant/LocalParticipant';
 import Participant, { ConnectionQuality, ParticipantKind } from './room/participant/Participant';
@@ -108,4 +109,6 @@ export type {
   AudioSenderStats,
   VideoReceiverStats,
   VideoSenderStats,
+  ReconnectContext,
+  ReconnectPolicy,
 };


### PR DESCRIPTION
I wanted to implement my own `ReconnectPolicy`, but was unable to use the interface, due to the fact that these were not exposed.