### PR TITLE
fix: set attributes of remote participants earlier

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1733,10 +1733,18 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         loggerName: this.options.loggerName,
       });
     } else {
-      participant = new RemoteParticipant(this.engine.client, '', identity, undefined, undefined, {
-        loggerContextCb: () => this.logContext,
-        loggerName: this.options.loggerName,
-      });
+      participant = new RemoteParticipant(
+        this.engine.client,
+        '',
+        identity,
+        undefined,
+        undefined,
+        undefined,
+        {
+          loggerContextCb: () => this.logContext,
+          loggerName: this.options.loggerName,
+        },
+      );
     }
     if (this.options.webAudioMix) {
       participant.setAudioContext(this.audioContext);

--- a/src/room/participant/LocalParticipant.test.ts
+++ b/src/room/participant/LocalParticipant.test.ts
@@ -47,6 +47,7 @@ describe('LocalParticipant', () => {
         'Remote Participant',
         '',
         undefined,
+        undefined,
         ParticipantKind.STANDARD,
       );
 
@@ -92,6 +93,7 @@ describe('LocalParticipant', () => {
         'Remote Participant',
         '',
         undefined,
+        undefined,
         ParticipantKind.STANDARD,
       );
 
@@ -133,6 +135,7 @@ describe('LocalParticipant', () => {
         'remote-identity',
         'Remote Participant',
         '',
+        undefined,
         undefined,
         ParticipantKind.STANDARD,
       );
@@ -195,6 +198,7 @@ describe('LocalParticipant', () => {
         'remote-identity',
         'Remote Participant',
         '',
+        undefined,
         undefined,
         ParticipantKind.STANDARD,
       );

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -144,7 +144,7 @@ export default class LocalParticipant extends Participant {
 
   /** @internal */
   constructor(sid: string, identity: string, engine: RTCEngine, options: InternalRoomOptions) {
-    super(sid, identity, undefined, undefined, {
+    super(sid, identity, undefined, undefined, undefined, {
       loggerName: options.loggerName,
       loggerContextCb: () => this.engine.logContext,
     });

--- a/src/room/participant/Participant.ts
+++ b/src/room/participant/Participant.ts
@@ -126,6 +126,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     identity: string,
     name?: string,
     metadata?: string,
+    attributes?: Record<string, string>,
     loggerOptions?: LoggerOptions,
     kind: ParticipantKind = ParticipantKind.STANDARD,
   ) {
@@ -143,7 +144,7 @@ export default class Participant extends (EventEmitter as new () => TypedEmitter
     this.videoTrackPublications = new Map();
     this.trackPublications = new Map();
     this._kind = kind;
-    this._attributes = {};
+    this._attributes = attributes ?? {};
   }
 
   getTrackPublications(): TrackPublication[] {

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -44,6 +44,7 @@ export default class RemoteParticipant extends Participant {
       pi.identity,
       pi.name,
       pi.metadata,
+      pi.attributes,
       loggerOptions,
       pi.kind,
     );
@@ -64,10 +65,11 @@ export default class RemoteParticipant extends Participant {
     identity?: string,
     name?: string,
     metadata?: string,
+    attributes?: Record<string, string>,
     loggerOptions?: LoggerOptions,
     kind: ParticipantKind = ParticipantKind.STANDARD,
   ) {
-    super(sid, identity || '', name, metadata, loggerOptions, kind);
+    super(sid, identity || '', name, metadata, attributes, loggerOptions, kind);
     this.signalClient = signalClient;
     this.trackPublications = new Map();
     this.audioTrackPublications = new Map();


### PR DESCRIPTION
Otherwise the attributes are not set during the "ParticipantConnected" event, which makes it difficult to react to this event accordingly.

I didn't test it, but if I understand the code correctly, there is one potentially problematic side effect: "ParticipantAttributesChanged" is not emitted anymore on connect. Which sounds fine to me, as the attributes didn't change from any previous setting, they just started that way. However, it might break workflows