### PR TITLE
fix: #1346 bugfix, change device show on selection

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -835,7 +835,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    * @internal for testing
    */
   async simulateScenario(scenario: SimulationScenario, arg?: any) {
-    let postAction = () => {};
+    let postAction = () => { };
     let req: SimulateScenario | undefined;
     switch (scenario) {
       case 'signal-reconnect':
@@ -1160,7 +1160,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         throw e;
       }
     }
-    if (deviceHasChanged && success) {
+    if (deviceHasChanged) {
       this.localParticipant.activeDeviceMap.set(kind, deviceId);
       this.emit(RoomEvent.ActiveDeviceChanged, kind, deviceId);
     }
@@ -2104,14 +2104,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         new LocalVideoTrack(
           publishOptions.useRealTracks
             ? (
-                await window.navigator.mediaDevices.getUserMedia({ video: true })
-              ).getVideoTracks()[0]
+              await window.navigator.mediaDevices.getUserMedia({ video: true })
+            ).getVideoTracks()[0]
             : createDummyVideoStreamTrack(
-                160 * (participantOptions.aspectRatios[0] ?? 1),
-                160,
-                true,
-                true,
-              ),
+              160 * (participantOptions.aspectRatios[0] ?? 1),
+              160,
+              true,
+              true,
+            ),
           undefined,
           false,
           { loggerName: this.options.loggerName, loggerContextCb: () => this.logContext },


### PR DESCRIPTION
```
success = (
          await Promise.all(tracks.map((t) => t.audioTrack?.setDeviceId(deviceConstraint)))
        ).every((val) => val === true);
```

```
async setDeviceId(deviceId: ConstrainDOMString): Promise<boolean> {
    if (
      this._constraints.deviceId === deviceId &&
      this._mediaStreamTrack.getSettings().deviceId === unwrapConstraint(deviceId)
    ) {
      return true;
    }
    this._constraints.deviceId = deviceId;
    if (!this.isMuted) {
      await this.restartTrack();
    }
    return (
      this.isMuted || unwrapConstraint(deviceId) === this._mediaStreamTrack.getSettings().deviceId
    );
  }
```

Select device not affect on the device selection, and setDeviceId()'s success is not the real selected result.