### PR TITLE
Allow version range from `@livekit/protocol` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@livekit/mutex": "1.0.0",
-    "@livekit/protocol": "1.29.4",
+    "@livekit/protocol": "^1.29.4",
     "events": "^3.3.0",
     "loglevel": "^1.8.0",
     "sdp-transform": "^2.14.1",


### PR DESCRIPTION
I realized when migrating to v2 that yarn resolved two separate versions of `@livekit/protocol`.

This should ensure when installing it along with other SDKs (such as `livekit-server-sdk`) to always resolve to a common compatible version without having to dedupe the dependencies.

It's just a suggestion, it may be the case that the livekit team has a very specific reason for pinning the version in this js sdk?
