### PR TITLE
[feature] Allow changing arbitrary options during room lifetime (`disconnectOnPageLeave` implemented)

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -235,9 +235,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       this.setupE2EE();
     }
 
+    /**
+     * Proxy for interception of changes to InternalRoomOptions after Room has been instantiated.
+     */
     this.options = new Proxy(this.options, {
       set: (target: InternalRoomOptions, key: keyof InternalRoomOptions, value) => {
-        console.log("Proxy is intercepting!", key, value)
         if (key == 'disconnectOnPageLeave' && value !== target[key]) {
           value === true ? this.registerUnloadEvents() : this.unregisterUnloadEvents()
         }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -234,6 +234,19 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.options.e2ee) {
       this.setupE2EE();
     }
+
+    const self = this
+    this.options = new Proxy(this.options, {
+      set: function (target: InternalRoomOptions, key: keyof InternalRoomOptions, value) {
+        if (key == 'disconnectOnPageLeave' && value !== target[key]) {
+          value === true 
+            ? window.addEventListener('beforeunload', self.onPageLeave) 
+            : window.removeEventListener('beforeunload', self.onPageLeave) 
+        }
+        
+        return true;
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
This is a proposal (or an RFC if you want) implementing a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) on the `Room.options` property. This enables to switch options on or off that otherwise can only be configured once on instantiation. Potential applications could be to have `adaptiveStream` or `dynacast` switches in the example applications, but basically any option can be made configurable at runtime with it.

As a proof-of-concept and first application, this PR implements updating `disconnectOnPageLeave` after the Room has been created, because that was my [XY-Problem](https://xyproblem.info/) that led to this: I wanted to hook up a `beforeunload` handler so a user confirmation is shown should they navigate away during a LiveKit session that is being recorded. The problem i discovered was that the room was being disconnected anyway after the user chose to stay on the page in the confirm dialog.  Digging into the library i realized i had to initialize the Room with `disconnectOnPageLeave: false` – however i felt i don't want to lose this very sensible default behavior. So i implemented this Proxy, which enables to simply `room.options.disconnectOnPageLeave = false` when recording starts and my custom `beforeunload` handler is registered, and vice versa do `room.options.disconnectOnPageLeave = true` when recording stops.
