### PR TITLE
Emit MediaDeviceError only when acquiring tracks fails

### DIFF
--- a/.changeset/strong-shrimps-wave.md
+++ b/.changeset/strong-shrimps-wave.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Emit MediaDeviceError only when acquiring tracks fails

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -486,6 +486,16 @@ export default class LocalParticipant extends Participant {
             default:
               throw new TrackInvalidError(source);
           }
+        } catch (e: unknown) {
+          localTracks?.forEach((tr) => {
+            tr.stop();
+          });
+          if (e instanceof Error) {
+            this.emit(ParticipantEvent.MediaDevicesError, e);
+          }
+          throw e;
+        }
+        try {
           const publishPromises: Array<Promise<LocalTrackPublication>> = [];
           for (const localTrack of localTracks) {
             this.log.info('publishing track', {
@@ -502,9 +512,6 @@ export default class LocalParticipant extends Participant {
           localTracks?.forEach((tr) => {
             tr.stop();
           });
-          if (e instanceof Error && !(e instanceof TrackInvalidError)) {
-            this.emit(ParticipantEvent.MediaDevicesError, e);
-          }
           throw e;
         } finally {
           this.pendingPublishing.delete(source);


### PR DESCRIPTION
previously `MediaDeviceError` would also be emitted on (more general) publication failures e.g. due to network connection issues