### PR TITLE
Remove track from pending publishing on device errors

### DIFF
--- a/.changeset/fair-moose-draw.md
+++ b/.changeset/fair-moose-draw.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Remove track from pending publishing on device errors

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -497,6 +497,7 @@ export default class LocalParticipant extends Participant {
           if (e instanceof Error) {
             this.emit(ParticipantEvent.MediaDevicesError, e);
           }
+          this.pendingPublishing.delete(source);
           throw e;
         }
         try {


### PR DESCRIPTION
fixes https://github.com/livekit/components-js/issues/1074

This was a recent regression where we're not properly cleaning up `pendingPublishing` when a media device error is encountered.