### PR TITLE
Refine room event argument logs

### DIFF
--- a/.changeset/fifty-garlics-ring.md
+++ b/.changeset/fifty-garlics-ring.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Refine room event argument logs

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -2304,10 +2304,7 @@ function mapArgs(args: unknown[]): any {
       return mapArgs(arg);
     }
     if (typeof arg === 'object') {
-      if (!('logContext' in arg)) {
-        return undefined;
-      }
-      return JSON.stringify(arg.logContext);
+      return 'logContext' in arg ? arg.logContext : undefined;
     }
     return arg;
   });

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -2304,7 +2304,10 @@ function mapArgs(args: unknown[]): any {
       return mapArgs(arg);
     }
     if (typeof arg === 'object') {
-      return 'logContext' in arg && arg.logContext;
+      if (!('logContext' in arg)) {
+        return undefined;
+      }
+      return JSON.stringify(arg.logContext);
     }
     return arg;
   });


### PR DESCRIPTION
prevents room event arguments to show up as `false` if no log context was found in the argument