### PR TITLE
Set names of errors and reasonName for enums

### DIFF
--- a/.changeset/smart-mayflies-pay.md
+++ b/.changeset/smart-mayflies-pay.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Populate name property of LiveKit errors and add reasonName for enums

--- a/src/room/errors.ts
+++ b/src/room/errors.ts
@@ -5,11 +5,12 @@ export class LivekitError extends Error {
 
   constructor(code: number, message?: string) {
     super(message || 'an error has occured');
+    this.name = 'LiveKitError';
     this.code = code;
   }
 }
 
-export const enum ConnectionErrorReason {
+export enum ConnectionErrorReason {
   NotAllowed,
   ServerUnreachable,
   InternalError,
@@ -24,6 +25,8 @@ export class ConnectionError extends LivekitError {
 
   reason: ConnectionErrorReason;
 
+  reasonName: string;
+
   constructor(
     message: string,
     reason: ConnectionErrorReason,
@@ -31,45 +34,53 @@ export class ConnectionError extends LivekitError {
     context?: unknown | DisconnectReason,
   ) {
     super(1, message);
+    this.name = 'ConnectionError';
     this.status = status;
     this.reason = reason;
     this.context = context;
+    this.reasonName = ConnectionErrorReason[reason];
   }
 }
 
 export class DeviceUnsupportedError extends LivekitError {
   constructor(message?: string) {
     super(21, message ?? 'device is unsupported');
+    this.name = 'DeviceUnsupportedError';
   }
 }
 
 export class TrackInvalidError extends LivekitError {
   constructor(message?: string) {
     super(20, message ?? 'track is invalid');
+    this.name = 'TrackInvalidError';
   }
 }
 
 export class UnsupportedServer extends LivekitError {
   constructor(message?: string) {
     super(10, message ?? 'unsupported server');
+    this.name = 'UnsupportedServer';
   }
 }
 
 export class UnexpectedConnectionState extends LivekitError {
   constructor(message?: string) {
     super(12, message ?? 'unexpected connection state');
+    this.name = 'UnexpectedConnectionState';
   }
 }
 
 export class NegotiationError extends LivekitError {
   constructor(message?: string) {
     super(13, message ?? 'unable to negotiate');
+    this.name = 'NegotiationError';
   }
 }
 
 export class PublishDataError extends LivekitError {
   constructor(message?: string) {
     super(14, message ?? 'unable to publish data');
+    this.name = 'PublishDataError';
   }
 }
 
@@ -80,9 +91,12 @@ export type RequestErrorReason =
 export class SignalRequestError extends LivekitError {
   reason: RequestErrorReason;
 
+  reasonName: string;
+
   constructor(message: string, reason: RequestErrorReason) {
     super(15, message);
     this.reason = reason;
+    this.reasonName = typeof reason === 'string' ? reason : RequestResponse_Reason[reason];
   }
 }
 


### PR DESCRIPTION
inspired by https://github.com/livekit/client-sdk-js/pull/1384

improve default readability of custom LiveKit errors