### PR TITLE
Add more options to streamText method

### DIFF
--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -22,6 +22,17 @@ export interface SendTextOptions {
   onProgress?: (progress: number) => void;
 }
 
+export interface StreamTextOptions {
+  topic?: string;
+  destinationIdentities?: Array<string>;
+  type?: 'create' | 'update';
+  streamId?: string;
+  version?: number;
+  attachedStreamIds?: Array<string>;
+  replyToStreamId?: string;
+  totalSize?: number;
+}
+
 export type DataPublishOptions = {
   /**
    * whether to send this as reliable or lossy.


### PR DESCRIPTION
This changes internal handling so that `sendText` internally calls `streamText`, similar to how this is handled in node. 

