### PR TITLE
Allow semver range for @livekit/protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@livekit/mutex": "1.1.1",
-    "@livekit/protocol": "1.33.0",
+    "@livekit/protocol": "^1.33.0",
     "events": "^3.3.0",
     "loglevel": "^1.8.0",
     "sdp-transform": "^2.14.1",


### PR DESCRIPTION
Harmonizing it with livekit-server-sdk, allowing for a semver range so package managers can resolve to a single compatible version instead of two (which is currently the case). 

Hence i'd like to re-raise this, to save consumers from having to manually dedupe their dependencies each time.

For further information, see https://github.com/livekit/client-sdk-js/pull/1356#issuecomment-2573005093 and https://github.com/livekit/client-sdk-js/pull/1356#issuecomment-2573011526