### PR TITLE
Export TrackType enum as value entity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export {
   Room,
   SubscriptionError,
   TrackPublication,
+  TrackType,
   compareVersions,
   createAudioAnalyser,
   getBrowser,
@@ -127,5 +128,4 @@ export type {
   VideoSenderStats,
   ReconnectContext,
   ReconnectPolicy,
-  TrackType,
 };


### PR DESCRIPTION
Just upgraded to v2.8.1 and realized #1370 did not really solve #1369 yet.

As per https://github.com/microsoft/TypeScript/issues/40344, a type import does not suffice to be able to put the enum to any use.

