### PR TITLE
Disable simulcast for screenshare backup codec

### DIFF
--- a/.changeset/grumpy-jobs-camp.md
+++ b/.changeset/grumpy-jobs-camp.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Disable simulcast for screenshare backup codec

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -256,6 +256,10 @@ export function computeTrackBackupEncodings(
   const width = settings.width ?? track.dimensions?.width;
   const height = settings.height ?? track.dimensions?.height;
 
+  // disable simulcast for screenshare backup codec since L1Tx is used by primary codec
+  if (track.source === Track.Source.ScreenShare && opts.simulcast) {
+    opts.simulcast = false;
+  }
   const encodings = computeVideoEncodings(
     track.source === Track.Source.ScreenShare,
     width,


### PR DESCRIPTION
Avoid inconsistent layers between primary and
backup codecs (L1tx is used for screenshare svc).