### PR TITLE
Fix applying default processors from captureDefaults

### DIFF
--- a/.changeset/sharp-avocados-hang.md
+++ b/.changeset/sharp-avocados-hang.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix applying default processors from captureDefaults

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -602,16 +602,17 @@ export default class LocalParticipant extends Participant {
    */
   async createTracks(options?: CreateLocalTracksOptions): Promise<LocalTrack[]> {
     options ??= {};
-    const { audioProcessor, videoProcessor, optionsWithoutProcessor } =
-      extractProcessorsFromOptions(options);
 
-    const mergedOptions = mergeDefaultOptions(
-      optionsWithoutProcessor,
+    const mergedOptionsWithProcessors = mergeDefaultOptions(
+      options,
       this.roomOptions?.audioCaptureDefaults,
       this.roomOptions?.videoCaptureDefaults,
     );
 
-    const constraints = constraintsForOptions(mergedOptions);
+    const { audioProcessor, videoProcessor, optionsWithoutProcessor } =
+      extractProcessorsFromOptions(mergedOptionsWithProcessors);
+
+    const constraints = constraintsForOptions(optionsWithoutProcessor);
     let stream: MediaStream | undefined;
     try {
       stream = await navigator.mediaDevices.getUserMedia(constraints);
@@ -639,10 +640,6 @@ export default class LocalParticipant extends Participant {
     return Promise.all(
       stream.getTracks().map(async (mediaStreamTrack) => {
         const isAudio = mediaStreamTrack.kind === 'audio';
-        let trackOptions = isAudio ? mergedOptions!.audio : mergedOptions!.video;
-        if (typeof trackOptions === 'boolean' || !trackOptions) {
-          trackOptions = {};
-        }
         let trackConstraints: MediaTrackConstraints | undefined;
         const conOrBool = isAudio ? constraints.audio : constraints.video;
         if (typeof conOrBool !== 'boolean') {

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -21,6 +21,8 @@ export function mergeDefaultOptions(
   const { optionsWithoutProcessor, audioProcessor, videoProcessor } = extractProcessorsFromOptions(
     options ?? {},
   );
+  const defaultAudioProcessor = audioDefaults?.processor;
+  const defaultVideoProcessor = videoDefaults?.processor;
   const clonedOptions: CreateLocalTracksOptions = cloneDeep(optionsWithoutProcessor) ?? {};
   if (clonedOptions.audio === true) clonedOptions.audio = {};
   if (clonedOptions.video === true) clonedOptions.video = {};
@@ -32,8 +34,8 @@ export function mergeDefaultOptions(
       audioDefaults as Record<string, unknown>,
     );
     clonedOptions.audio.deviceId ??= 'default';
-    if (audioProcessor) {
-      clonedOptions.audio.processor = audioProcessor;
+    if (audioProcessor || defaultAudioProcessor) {
+      clonedOptions.audio.processor = audioProcessor ?? defaultAudioProcessor;
     }
   }
   if (clonedOptions.video) {
@@ -42,8 +44,8 @@ export function mergeDefaultOptions(
       videoDefaults as Record<string, unknown>,
     );
     clonedOptions.video.deviceId ??= 'default';
-    if (videoProcessor) {
-      clonedOptions.video.processor = videoProcessor;
+    if (videoProcessor || defaultVideoProcessor) {
+      clonedOptions.video.processor = videoProcessor ?? defaultVideoProcessor;
     }
   }
   return clonedOptions;


### PR DESCRIPTION
https://github.com/livekit/client-sdk-js/pull/1247 introduced a change where processors set as defaults on the room options would get ignored. This PR fixes that