### PR TITLE
Fix trailing slash handling in WebSocket URL pathname

### DIFF
--- a/.changeset/cyan-berries-divide.md
+++ b/.changeset/cyan-berries-divide.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix trailing slash handling in WebSocket URL pathname

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -260,7 +260,7 @@ export class SignalClient {
     this.connectOptions = opts;
     const urlObj = new URL(toWebsocketUrl(url));
     // strip trailing slash
-    const hasTrailingSlash = urlObj.pathname.endsWith('/')
+    const hasTrailingSlash = urlObj.pathname.endsWith('/');
     urlObj.pathname += hasTrailingSlash ? 'rtc' : '/rtc';
 
     const clientInfo = getClientInfo();

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -260,8 +260,8 @@ export class SignalClient {
     this.connectOptions = opts;
     const urlObj = new URL(toWebsocketUrl(url));
     // strip trailing slash
-    urlObj.pathname = urlObj.pathname.replace(/\/$/, '');
-    urlObj.pathname += '/rtc';
+    const hasTrailingSlash = urlObj.pathname.endsWith('/')
+    urlObj.pathname += hasTrailingSlash ? 'rtc' : '/rtc';
 
     const clientInfo = getClientInfo();
     const params = createConnectionParams(token, clientInfo, opts);


### PR DESCRIPTION
resolve #1439 

Previously, the code attempted to remove the trailing slash from urlObj.pathname by setting it to an empty string and then appending "/rtc". However, since URL objects always return "/" for an empty path when a host is present, the existing approach never truly removed the slash. This PR updates the logic to explicitly check if the pathname ends with a slash. If it does, we simply append "rtc". Otherwise, we append "/rtc". This ensures the final path is correctly formed without relying on the pathname being set to an empty string.

## References
- https://url.spec.whatwg.org/#dom-url-pathname
- https://url.spec.whatwg.org/#url-path-serializer
- https://url.spec.whatwg.org/#example-url-components