### PR TITLE
Use string instead of passing url object to WebSocket constructor

### DIFF
--- a/.changeset/empty-crews-remember.md
+++ b/.changeset/empty-crews-remember.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Use string instead of passing url object to WebSocket constructor

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -310,7 +310,7 @@ export class SignalClient {
         if (this.ws) {
           await this.close(false);
         }
-        this.ws = new WebSocket(urlObj);
+        this.ws = new WebSocket(urlObj.toString());
         this.ws.binaryType = 'arraybuffer';
 
         this.ws.onopen = () => {


### PR DESCRIPTION
React-Native (and WebSockets JS spec) can only take a string in the WebSocket constructor.

Details here: https://github.com/facebook/react-native/issues/49382