### PR TITLE
Defer publishing until signal is connected

### DIFF
--- a/.changeset/eight-horses-raise.md
+++ b/.changeset/eight-horses-raise.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Defer publishing until signal is connected

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -235,11 +235,6 @@ const appActions = {
         appendLog(`signal connection established in ${signalConnectionTime}ms`);
         // speed up publishing by starting to publish before it's fully connected
         // publishing is accepted as soon as signal connection has established
-        if (shouldPublish) {
-          await room.localParticipant.enableCameraAndMicrophone();
-          appendLog(`tracks published in ${Date.now() - startTime}ms`);
-          updateButtonsForPublishState();
-        }
       })
       .on(RoomEvent.ParticipantEncryptionStatusChanged, () => {
         updateButtonsForPublishState();
@@ -353,8 +348,19 @@ const appActions = {
       if ((<HTMLInputElement>$('e2ee')).checked) {
         await room.setE2EEEnabled(true);
       }
-
-      await room.connect(url, token, connectOptions);
+      const publishPromise = new Promise<void>(async (resolve, reject) => {
+        try {
+          if (shouldPublish) {
+            await room.localParticipant.enableCameraAndMicrophone();
+            appendLog(`tracks published in ${Date.now() - startTime}ms`);
+            updateButtonsForPublishState();
+          }
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+      await Promise.all([room.connect(url, token, connectOptions), publishPromise]);
       const elapsed = Date.now() - startTime;
       appendLog(
         `successfully connected to ${room.name} in ${Math.round(elapsed)}ms`,

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -248,6 +248,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
 
       this.clientConfiguration = joinResponse.clientConfiguration;
+      // emit signal connected event after a short delay to allow for join response to be processed on room
+      setTimeout(() => {
+        this.emit(EngineEvent.SignalConnected);
+      }, 10);
       return joinResponse;
     } catch (e) {
       if (e instanceof ConnectionError) {
@@ -1500,6 +1504,7 @@ export type EngineEventCallbacks = {
   remoteMute: (trackSid: string, muted: boolean) => void;
   offline: () => void;
   signalRequestResponse: (response: RequestResponse) => void;
+  signalConnected: () => void;
 };
 
 function supportOptionalDatachannel(protocol: number | undefined): boolean {

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -562,6 +562,7 @@ export enum EngineEvent {
   LocalTrackSubscribed = 'localTrackSubscribed',
   Offline = 'offline',
   SignalRequestResponse = 'signalRequestResponse',
+  SignalConnected = 'signalConnected',
 }
 
 export enum TrackEvent {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -2041,11 +2041,6 @@ export default class LocalParticipant extends Participant {
     return true;
   }
 
-  /**
-   * @internal
-   */
-  onSignalConnectionEstablished() {}
-
   private updateTrackSubscriptionPermissions = () => {
     this.log.debug('updating track subscription permissions', {
       ...this.logContext,


### PR DESCRIPTION
This PR defers publishing attempts until signal is connected. 
There's a 15s timeout between publishing attempt until signal connection is connected.

Previous behaviour was that publishing on a room that's not connected would simply fail. 

This change allows for patterns where device acquisition can happen in parallel to room connection, e.g. 

```ts
await Promise.all([room.connect(...), room.localParticipant.enableMicrophoneAndCamera()]);
```


