### PR TITLE
Default to exact matching and retry on unspecified ideal narrowing

### DIFF
--- a/src/api/utils.test.ts
+++ b/src/api/utils.test.ts
@@ -49,6 +49,18 @@ describe('createRtcUrl', () => {
     const parsedResult = new URL(result);
     expect(parsedResult.pathname).toBe('/sub/path/rtc');
   });
+
+  it('should handle sub paths with url params', () => {
+    const url = 'wss://example.com/sub/path?param=value';
+    const searchParams = new URLSearchParams();
+    searchParams.set('token', 'test-token');
+    const result = createRtcUrl(url, searchParams);
+
+    const parsedResult = new URL(result);
+    expect(parsedResult.pathname).toBe('/sub/path/rtc');
+    expect(parsedResult.searchParams.get('param')).toBe('value');
+    expect(parsedResult.searchParams.get('token')).toBe('test-token');
+  });
 });
 
 describe('createValidateUrl', () => {

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -31,70 +31,110 @@ export async function createLocalTracks(
   options?: CreateLocalTracksOptions,
 ): Promise<Array<LocalTrack>> {
   // set default options to true
-  options ??= {};
-  options.audio ??= { deviceId: 'default' };
-  options.video ??= { deviceId: 'default' };
+  const internalOptions = { ...(options ?? {}) };
+  let attemptExactMatch = false;
+  let retryAudioOptions: AudioCaptureOptions | undefined | boolean = options?.audio;
+  let retryVideoOptions: VideoCaptureOptions | undefined | boolean = options?.video;
+  // if the user passes a device id as a string, we default to exact match
+  if (
+    internalOptions.audio &&
+    typeof internalOptions.audio === 'object' &&
+    typeof internalOptions.audio.deviceId === 'string'
+  ) {
+    const deviceId: string = internalOptions.audio.deviceId;
+    internalOptions.audio.deviceId = { exact: deviceId };
+    attemptExactMatch = true;
+    retryAudioOptions = {
+      ...internalOptions.audio,
+      deviceId: { ideal: deviceId },
+    };
+  }
+  if (
+    internalOptions.video &&
+    typeof internalOptions.video === 'object' &&
+    typeof internalOptions.video.deviceId === 'string'
+  ) {
+    const deviceId: string = internalOptions.video.deviceId;
+    internalOptions.video.deviceId = { exact: deviceId };
+    attemptExactMatch = true;
+    retryVideoOptions = {
+      ...internalOptions.video,
+      deviceId: { ideal: deviceId },
+    };
+  }
+  internalOptions.audio ??= { deviceId: 'default' };
+  internalOptions.video ??= { deviceId: 'default' };
 
-  const { audioProcessor, videoProcessor } = extractProcessorsFromOptions(options);
-  const opts = mergeDefaultOptions(options, audioDefaults, videoDefaults);
+  const { audioProcessor, videoProcessor } = extractProcessorsFromOptions(internalOptions);
+  const opts = mergeDefaultOptions(internalOptions, audioDefaults, videoDefaults);
   const constraints = constraintsForOptions(opts);
 
   // Keep a reference to the promise on DeviceManager and await it in getLocalDevices()
   // works around iOS Safari Bug https://bugs.webkit.org/show_bug.cgi?id=179363
   const mediaPromise = navigator.mediaDevices.getUserMedia(constraints);
 
-  if (options.audio) {
+  if (internalOptions.audio) {
     DeviceManager.userMediaPromiseMap.set('audioinput', mediaPromise);
     mediaPromise.catch(() => DeviceManager.userMediaPromiseMap.delete('audioinput'));
   }
-  if (options.video) {
+  if (internalOptions.video) {
     DeviceManager.userMediaPromiseMap.set('videoinput', mediaPromise);
     mediaPromise.catch(() => DeviceManager.userMediaPromiseMap.delete('videoinput'));
   }
+  try {
+    const stream = await mediaPromise;
+    return await Promise.all(
+      stream.getTracks().map(async (mediaStreamTrack) => {
+        const isAudio = mediaStreamTrack.kind === 'audio';
+        let trackOptions = isAudio ? opts!.audio : opts!.video;
+        if (typeof trackOptions === 'boolean' || !trackOptions) {
+          trackOptions = {};
+        }
+        let trackConstraints: MediaTrackConstraints | undefined;
+        const conOrBool = isAudio ? constraints.audio : constraints.video;
+        if (typeof conOrBool !== 'boolean') {
+          trackConstraints = conOrBool;
+        }
 
-  const stream = await mediaPromise;
-  return Promise.all(
-    stream.getTracks().map(async (mediaStreamTrack) => {
-      const isAudio = mediaStreamTrack.kind === 'audio';
-      let trackOptions = isAudio ? opts!.audio : opts!.video;
-      if (typeof trackOptions === 'boolean' || !trackOptions) {
-        trackOptions = {};
-      }
-      let trackConstraints: MediaTrackConstraints | undefined;
-      const conOrBool = isAudio ? constraints.audio : constraints.video;
-      if (typeof conOrBool !== 'boolean') {
-        trackConstraints = conOrBool;
-      }
+        // update the constraints with the device id the user gave permissions to in the permission prompt
+        // otherwise each track restart (e.g. mute - unmute) will try to initialize the device again -> causing additional permission prompts
+        const newDeviceId = mediaStreamTrack.getSettings().deviceId;
+        if (
+          trackConstraints?.deviceId &&
+          unwrapConstraint(trackConstraints.deviceId) !== newDeviceId
+        ) {
+          trackConstraints.deviceId = newDeviceId;
+        } else if (!trackConstraints) {
+          trackConstraints = { deviceId: newDeviceId };
+        }
 
-      // update the constraints with the device id the user gave permissions to in the permission prompt
-      // otherwise each track restart (e.g. mute - unmute) will try to initialize the device again -> causing additional permission prompts
-      const newDeviceId = mediaStreamTrack.getSettings().deviceId;
-      if (
-        trackConstraints?.deviceId &&
-        unwrapConstraint(trackConstraints.deviceId) !== newDeviceId
-      ) {
-        trackConstraints.deviceId = newDeviceId;
-      } else if (!trackConstraints) {
-        trackConstraints = { deviceId: newDeviceId };
-      }
+        const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints);
+        if (track.kind === Track.Kind.Video) {
+          track.source = Track.Source.Camera;
+        } else if (track.kind === Track.Kind.Audio) {
+          track.source = Track.Source.Microphone;
+        }
+        track.mediaStream = stream;
 
-      const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints);
-      if (track.kind === Track.Kind.Video) {
-        track.source = Track.Source.Camera;
-      } else if (track.kind === Track.Kind.Audio) {
-        track.source = Track.Source.Microphone;
-      }
-      track.mediaStream = stream;
+        if (isAudioTrack(track) && audioProcessor) {
+          await track.setProcessor(audioProcessor);
+        } else if (isVideoTrack(track) && videoProcessor) {
+          await track.setProcessor(videoProcessor);
+        }
 
-      if (isAudioTrack(track) && audioProcessor) {
-        await track.setProcessor(audioProcessor);
-      } else if (isVideoTrack(track) && videoProcessor) {
-        await track.setProcessor(videoProcessor);
-      }
-
-      return track;
-    }),
-  );
+        return track;
+      }),
+    );
+  } catch (e) {
+    if (!attemptExactMatch) {
+      throw e;
+    }
+    return createLocalTracks({
+      ...options,
+      audio: retryAudioOptions,
+      video: retryVideoOptions,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
for `createLocalTracks` this PR changes our stream acquisition handling to default to `exact` matching if neither `ideal` nor `exact` have been explicitly specified by the user


1. user passes in `{ deviceId: "my-device-id" }`: Try with exact match if that throws -> try again with "ideal"
2.  `{ deviceId: { exact: "my-device-id"  } }`:  Same behaviour as before, throws overconstrainederror if it cannot be fulfilled
3. `{ deviceId: { ideal: "my-device-id" }}`: Browser's ideal behaviour is respected
