### PR TITLE
fix: device handling follow ups

### DIFF
--- a/.changeset/swift-lizards-exercise.md
+++ b/.changeset/swift-lizards-exercise.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: device handling follow up

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -66,7 +66,6 @@ import type {
 } from '../track/options';
 import { ScreenSharePresets, VideoPresets, isBackupCodec } from '../track/options';
 import {
-  constraintsForOptions,
   getLogContextFromTrack,
   getTrackSourceFromProto,
   mergeDefaultOptions,
@@ -616,8 +615,6 @@ export default class LocalParticipant extends Participant {
       this.roomOptions?.videoCaptureDefaults,
     );
 
-    const constraints = constraintsForOptions(mergedOptionsWithProcessors);
-
     try {
       const tracks = await createLocalTracks(mergedOptionsWithProcessors, {
         loggerName: this.roomOptions.loggerName,
@@ -639,10 +636,10 @@ export default class LocalParticipant extends Participant {
       return localTracks;
     } catch (err) {
       if (err instanceof Error) {
-        if (constraints.audio) {
+        if (options.audio) {
           this.microphoneError = err;
         }
-        if (constraints.video) {
+        if (options.video) {
           this.cameraError = err;
         }
       }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -55,6 +55,7 @@ import LocalTrack from '../track/LocalTrack';
 import LocalTrackPublication from '../track/LocalTrackPublication';
 import LocalVideoTrack, { videoLayersFromEncodings } from '../track/LocalVideoTrack';
 import { Track } from '../track/Track';
+import { createLocalTracks } from '../track/create';
 import type {
   AudioCaptureOptions,
   BackupVideoCodec,
@@ -65,8 +66,6 @@ import type {
 } from '../track/options';
 import { ScreenSharePresets, VideoPresets, isBackupCodec } from '../track/options';
 import {
-  constraintsForOptions,
-  extractProcessorsFromOptions,
   getLogContextFromTrack,
   getTrackSourceFromProto,
   mergeDefaultOptions,
@@ -107,7 +106,6 @@ import {
   computeTrackBackupEncodings,
   computeVideoEncodings,
   getDefaultDegradationPreference,
-  mediaTrackToLocalTrack,
 } from './publishUtils';
 
 const STREAM_CHUNK_SIZE = 15_000;
@@ -617,61 +615,36 @@ export default class LocalParticipant extends Participant {
       this.roomOptions?.videoCaptureDefaults,
     );
 
-    const { audioProcessor, videoProcessor, optionsWithoutProcessor } =
-      extractProcessorsFromOptions(mergedOptionsWithProcessors);
-
-    const constraints = constraintsForOptions(optionsWithoutProcessor);
-    let stream: MediaStream | undefined;
     try {
-      stream = await navigator.mediaDevices.getUserMedia(constraints);
+      const tracks = await createLocalTracks(mergedOptionsWithProcessors, {
+        loggerName: this.roomOptions.loggerName,
+        loggerContextCb: () => this.logContext,
+      });
+      tracks.map((track) => {
+        if (isAudioTrack(track)) {
+          this.microphoneError = undefined;
+          track.setAudioContext(this.audioContext);
+          track.source = Track.Source.Microphone;
+          this.emit(ParticipantEvent.AudioStreamAcquired);
+        }
+        if (isVideoTrack(track)) {
+          this.cameraError = undefined;
+          track.source = Track.Source.Camera;
+        }
+      });
+      return tracks;
     } catch (err) {
       if (err instanceof Error) {
-        if (constraints.audio) {
+        if (options.audio) {
           this.microphoneError = err;
         }
-        if (constraints.video) {
+        if (options.video) {
           this.cameraError = err;
         }
       }
 
       throw err;
     }
-
-    if (constraints.audio) {
-      this.microphoneError = undefined;
-      this.emit(ParticipantEvent.AudioStreamAcquired);
-    }
-    if (constraints.video) {
-      this.cameraError = undefined;
-    }
-
-    return Promise.all(
-      stream.getTracks().map(async (mediaStreamTrack) => {
-        const isAudio = mediaStreamTrack.kind === 'audio';
-        let trackConstraints: MediaTrackConstraints | undefined;
-        const conOrBool = isAudio ? constraints.audio : constraints.video;
-        if (typeof conOrBool !== 'boolean') {
-          trackConstraints = conOrBool;
-        }
-        const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints, {
-          loggerName: this.roomOptions.loggerName,
-          loggerContextCb: () => this.logContext,
-        });
-        if (track.kind === Track.Kind.Video) {
-          track.source = Track.Source.Camera;
-        } else if (track.kind === Track.Kind.Audio) {
-          track.source = Track.Source.Microphone;
-          track.setAudioContext(this.audioContext);
-        }
-        track.mediaStream = stream;
-        if (isAudioTrack(track) && audioProcessor) {
-          await track.setProcessor(audioProcessor);
-        } else if (isVideoTrack(track) && videoProcessor) {
-          await track.setProcessor(videoProcessor);
-        }
-        return track;
-      }),
-    );
   }
 
   /**

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -64,9 +64,19 @@ export async function createLocalTracks(
       deviceId: { ideal: deviceId },
     };
   }
-  internalOptions.audio ??= { deviceId: 'default' };
-  internalOptions.video ??= { deviceId: 'default' };
-
+  // TODO if internal options don't have device Id specified, set it to 'default'
+  if (
+    internalOptions.audio === true ||
+    (typeof internalOptions.audio === 'object' && !internalOptions.audio.deviceId)
+  ) {
+    internalOptions.audio = { deviceId: 'default' };
+  }
+  if (
+    internalOptions.video === true ||
+    (typeof internalOptions.video === 'object' && !internalOptions.video.deviceId)
+  ) {
+    internalOptions.video = { deviceId: 'default' };
+  }
   const { audioProcessor, videoProcessor } = extractProcessorsFromOptions(internalOptions);
   const opts = mergeDefaultOptions(internalOptions, audioDefaults, videoDefaults);
   const constraints = constraintsForOptions(opts);

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -2,6 +2,7 @@ import DeviceManager from '../DeviceManager';
 import { audioDefaults, videoDefaults } from '../defaults';
 import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
 import { mediaTrackToLocalTrack } from '../participant/publishUtils';
+import type { LoggerOptions } from '../types';
 import { isAudioTrack, isSafari17, isVideoTrack, unwrapConstraint } from '../utils';
 import LocalAudioTrack from './LocalAudioTrack';
 import type LocalTrack from './LocalTrack';
@@ -29,6 +30,7 @@ import {
  */
 export async function createLocalTracks(
   options?: CreateLocalTracksOptions,
+  loggerOptions?: LoggerOptions,
 ): Promise<Array<LocalTrack>> {
   // set default options to true
   const internalOptions = { ...(options ?? {}) };
@@ -108,7 +110,7 @@ export async function createLocalTracks(
           trackConstraints = { deviceId: newDeviceId };
         }
 
-        const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints);
+        const track = mediaTrackToLocalTrack(mediaStreamTrack, trackConstraints, loggerOptions);
         if (track.kind === Track.Kind.Video) {
           track.source = Track.Source.Camera;
         } else if (track.kind === Track.Kind.Audio) {
@@ -129,11 +131,14 @@ export async function createLocalTracks(
     if (!attemptExactMatch) {
       throw e;
     }
-    return createLocalTracks({
-      ...options,
-      audio: retryAudioOptions,
-      video: retryVideoOptions,
-    });
+    return createLocalTracks(
+      {
+        ...options,
+        audio: retryAudioOptions,
+        video: retryVideoOptions,
+      },
+      loggerOptions,
+    );
   }
 }
 


### PR DESCRIPTION
unifies track creation and makes sure localParticipant.createTracks also get's the fix for device acquisition