### PR TITLE
Request audio/video in create helpers

### DIFF
--- a/.changeset/purple-cycles-hear.md
+++ b/.changeset/purple-cycles-hear.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: request audio/video in create local track helpers

--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -161,7 +161,7 @@ export async function createLocalVideoTrack(
 ): Promise<LocalVideoTrack> {
   const tracks = await createLocalTracks({
     audio: false,
-    video: options,
+    video: options ?? true,
   });
   return <LocalVideoTrack>tracks[0];
 }
@@ -170,7 +170,7 @@ export async function createLocalAudioTrack(
   options?: AudioCaptureOptions,
 ): Promise<LocalAudioTrack> {
   const tracks = await createLocalTracks({
-    audio: options,
+    audio: options ?? true,
     video: false,
   });
   return <LocalAudioTrack>tracks[0];


### PR DESCRIPTION
previously those helpers were passing audio and video respectively as `undefined` if no explicit options were set.