### PR TITLE
Add option (`KeyProviderOptions`) to allowKeyExtraction.

### DIFF
--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -233,7 +233,7 @@ export class E2EEManager
   private postRatchetRequest(
     participantIdentity?: string,
     keyIndex?: number,
-    extracable?: boolean,
+    extractable?: boolean,
   ) {
     if (!this.worker) {
       throw Error('could not ratchet key, worker is missing');
@@ -243,7 +243,7 @@ export class E2EEManager
       data: {
         participantIdentity: participantIdentity,
         keyIndex,
-        extracable,
+        extractable,
       },
     };
     this.worker.postMessage(msg);

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -222,11 +222,19 @@ export class E2EEManager
     keyProvider
       .on(KeyProviderEvent.SetKey, (keyInfo) => this.postKey(keyInfo))
       .on(KeyProviderEvent.RatchetRequest, (participantId, keyIndex) =>
-        this.postRatchetRequest(participantId, keyIndex),
+        this.postRatchetRequest(
+          participantId,
+          keyIndex,
+          keyProvider.getOptions().allowKeyExtraction,
+        ),
       );
   }
 
-  private postRatchetRequest(participantIdentity?: string, keyIndex?: number) {
+  private postRatchetRequest(
+    participantIdentity?: string,
+    keyIndex?: number,
+    extracable?: boolean,
+  ) {
     if (!this.worker) {
       throw Error('could not ratchet key, worker is missing');
     }
@@ -235,6 +243,7 @@ export class E2EEManager
       data: {
         participantIdentity: participantIdentity,
         keyIndex,
+        extracable,
       },
     };
     this.worker.postMessage(msg);

--- a/src/e2ee/constants.ts
+++ b/src/e2ee/constants.ts
@@ -37,6 +37,7 @@ export const KEY_PROVIDER_DEFAULTS: KeyProviderOptions = {
   ratchetWindowSize: 8,
   failureTolerance: DECRYPTION_FAILURE_TOLERANCE,
   keyringSize: 16,
+  allowKeyExtraction: false,
 } as const;
 
 export const MAX_SIF_COUNT = 100;

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -74,6 +74,7 @@ export interface RatchetRequestMessage extends BaseMessage {
   data: {
     participantIdentity?: string;
     keyIndex?: number;
+    extracable?: boolean;
   };
 }
 
@@ -130,6 +131,7 @@ export type KeyProviderOptions = {
   ratchetWindowSize: number;
   failureTolerance: number;
   keyringSize: number;
+  allowKeyExtraction: boolean;
 };
 
 export type KeyInfo = {

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -74,7 +74,7 @@ export interface RatchetRequestMessage extends BaseMessage {
   data: {
     participantIdentity?: string;
     keyIndex?: number;
-    extracable?: boolean;
+    extractable?: boolean;
   };
 }
 

--- a/src/e2ee/utils.ts
+++ b/src/e2ee/utils.ts
@@ -27,13 +27,14 @@ export async function importKey(
   keyBytes: Uint8Array | ArrayBuffer,
   algorithm: string | { name: string } = { name: ENCRYPTION_ALGORITHM },
   usage: 'derive' | 'encrypt' = 'encrypt',
+  extractable: boolean = false,
 ) {
   // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey
   return crypto.subtle.importKey(
     'raw',
     keyBytes,
     algorithm,
-    false,
+    extractable,
     usage === 'derive' ? ['deriveBits', 'deriveKey'] : ['encrypt', 'decrypt'],
   );
 }

--- a/src/e2ee/worker/ParticipantKeyHandler.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.ts
@@ -108,9 +108,10 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
    * returns the ratcheted material
    * if `setKey` is true (default), it will also set the ratcheted key directly on the crypto key ring
    * @param keyIndex
-   * @param setKey
+   * @param setKey set the new key. Will emit KeyHandlerEvent.KeyRatcheted after key generation (default: true)
+   * @param extractable allow key extraction (get the key in plaintext) on the ratcheted new key (default: false)
    */
-  ratchetKey(keyIndex?: number, setKey = true): Promise<CryptoKey> {
+  ratchetKey(keyIndex?: number, setKey = true, extractable = false): Promise<CryptoKey> {
     const currentKeyIndex = keyIndex ?? this.getCurrentKeyIndex();
 
     const existingPromise = this.ratchetPromiseMap.get(currentKeyIndex);
@@ -130,6 +131,7 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
           await ratchet(currentMaterial, this.keyProviderOptions.ratchetSalt),
           currentMaterial.algorithm.name,
           'derive',
+          extractable,
         );
 
         if (setKey) {

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -119,11 +119,11 @@ onmessage = (ev) => {
 async function handleRatchetRequest(data: RatchetRequestMessage['data']) {
   if (useSharedKey) {
     const keyHandler = getSharedKeyHandler();
-    await keyHandler.ratchetKey(data.keyIndex, undefined, data.extracable);
+    await keyHandler.ratchetKey(data.keyIndex, true, data.extractable);
     keyHandler.resetKeyStatus();
   } else if (data.participantIdentity) {
     const keyHandler = getParticipantKeyHandler(data.participantIdentity);
-    await keyHandler.ratchetKey(data.keyIndex, undefined, data.extracable);
+    await keyHandler.ratchetKey(data.keyIndex, true, data.extractable);
     keyHandler.resetKeyStatus();
   } else {
     workerLogger.error(

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -119,11 +119,11 @@ onmessage = (ev) => {
 async function handleRatchetRequest(data: RatchetRequestMessage['data']) {
   if (useSharedKey) {
     const keyHandler = getSharedKeyHandler();
-    await keyHandler.ratchetKey(data.keyIndex);
+    await keyHandler.ratchetKey(data.keyIndex, undefined, data.extracable);
     keyHandler.resetKeyStatus();
   } else if (data.participantIdentity) {
     const keyHandler = getParticipantKeyHandler(data.participantIdentity);
-    await keyHandler.ratchetKey(data.keyIndex);
+    await keyHandler.ratchetKey(data.keyIndex, undefined, data.extracable);
     keyHandler.resetKeyStatus();
   } else {
     workerLogger.error(


### PR DESCRIPTION
This is helpful for systems where only the ratcheted key should be shared with new participants so that new joiners cannot decrypt historic media from the call. It provides an option so that the emitted ratcheted key can be extracted (read as a js variable) and therfore can be shared (in a secure way) over the network to the newjoiner

This touches a couple of ares:
 - the `importKey` method gets an optional property to import an extractable key
  - The e2ee.worker will use the new importKey property based on the data in the `RatchetRequestMessage`
  - The E2eeManager will read the keyProviderOptions and send use the `allowKeyExtraction` to configure the `RatchetRequestMessage`