### PR TITLE
Convert URL Scheme When Creating WebSocket Object

### DIFF
--- a/.changeset/breezy-cups-laugh.md
+++ b/.changeset/breezy-cups-laugh.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Convert URL Scheme When Creating WebSocket Object

--- a/src/api/utils.test.ts
+++ b/src/api/utils.test.ts
@@ -9,6 +9,13 @@ describe('createRtcUrl', () => {
     expect(result.toString()).toBe('wss://example.com/rtc');
   });
 
+  it('should create a basic RTC URL with http protocol', () => {
+    const url = 'http://example.com';
+    const searchParams = new URLSearchParams();
+    const result = createRtcUrl(url, searchParams);
+    expect(result.toString()).toBe('ws://example.com/rtc');
+  });
+
   it('should handle search parameters', () => {
     const url = 'wss://example.com';
     const searchParams = new URLSearchParams({

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,7 +1,7 @@
-import { toHttpUrl } from '../room/utils';
+import { toHttpUrl, toWebsocketUrl } from '../room/utils';
 
 export function createRtcUrl(url: string, searchParams: URLSearchParams) {
-  const urlObj = new URL(url);
+  const urlObj = new URL(toWebsocketUrl(url));
   searchParams.forEach((value, key) => {
     urlObj.searchParams.set(key, value);
   });


### PR DESCRIPTION
resolve #1491 
Add logic to convert the scheme to `ws://` or `wss://` when creating the rtcUrl to ensure a successful WebSocket connection. Use the toWebsocketUrl function for this purpose.