### PR TITLE
Revert "Add option (`KeyProviderOptions`) to allowKeyExtraction."

### DIFF
--- a/.changeset/many-onions-agree.md
+++ b/.changeset/many-onions-agree.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Revert "Add option (`KeyProviderOptions`) to allowKeyExtraction."

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -222,19 +222,11 @@ export class E2EEManager
     keyProvider
       .on(KeyProviderEvent.SetKey, (keyInfo) => this.postKey(keyInfo))
       .on(KeyProviderEvent.RatchetRequest, (participantId, keyIndex) =>
-        this.postRatchetRequest(
-          participantId,
-          keyIndex,
-          keyProvider.getOptions().allowKeyExtraction,
-        ),
+        this.postRatchetRequest(participantId, keyIndex),
       );
   }
 
-  private postRatchetRequest(
-    participantIdentity?: string,
-    keyIndex?: number,
-    extractable?: boolean,
-  ) {
+  private postRatchetRequest(participantIdentity?: string, keyIndex?: number) {
     if (!this.worker) {
       throw Error('could not ratchet key, worker is missing');
     }
@@ -243,7 +235,6 @@ export class E2EEManager
       data: {
         participantIdentity: participantIdentity,
         keyIndex,
-        extractable,
       },
     };
     this.worker.postMessage(msg);

--- a/src/e2ee/constants.ts
+++ b/src/e2ee/constants.ts
@@ -37,7 +37,6 @@ export const KEY_PROVIDER_DEFAULTS: KeyProviderOptions = {
   ratchetWindowSize: 8,
   failureTolerance: DECRYPTION_FAILURE_TOLERANCE,
   keyringSize: 16,
-  allowKeyExtraction: false,
 } as const;
 
 export const MAX_SIF_COUNT = 100;

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -74,7 +74,6 @@ export interface RatchetRequestMessage extends BaseMessage {
   data: {
     participantIdentity?: string;
     keyIndex?: number;
-    extractable?: boolean;
   };
 }
 
@@ -131,7 +130,6 @@ export type KeyProviderOptions = {
   ratchetWindowSize: number;
   failureTolerance: number;
   keyringSize: number;
-  allowKeyExtraction: boolean;
 };
 
 export type KeyInfo = {

--- a/src/e2ee/utils.ts
+++ b/src/e2ee/utils.ts
@@ -27,14 +27,13 @@ export async function importKey(
   keyBytes: Uint8Array | ArrayBuffer,
   algorithm: string | { name: string } = { name: ENCRYPTION_ALGORITHM },
   usage: 'derive' | 'encrypt' = 'encrypt',
-  extractable: boolean = false,
 ) {
   // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey
   return crypto.subtle.importKey(
     'raw',
     keyBytes,
     algorithm,
-    extractable,
+    false,
     usage === 'derive' ? ['deriveBits', 'deriveKey'] : ['encrypt', 'decrypt'],
   );
 }

--- a/src/e2ee/worker/ParticipantKeyHandler.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.ts
@@ -108,10 +108,9 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
    * returns the ratcheted material
    * if `setKey` is true (default), it will also set the ratcheted key directly on the crypto key ring
    * @param keyIndex
-   * @param setKey set the new key. Will emit KeyHandlerEvent.KeyRatcheted after key generation (default: true)
-   * @param extractable allow key extraction (get the key in plaintext) on the ratcheted new key (default: false)
+   * @param setKey
    */
-  ratchetKey(keyIndex?: number, setKey = true, extractable = false): Promise<CryptoKey> {
+  ratchetKey(keyIndex?: number, setKey = true): Promise<CryptoKey> {
     const currentKeyIndex = keyIndex ?? this.getCurrentKeyIndex();
 
     const existingPromise = this.ratchetPromiseMap.get(currentKeyIndex);
@@ -131,7 +130,6 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
           await ratchet(currentMaterial, this.keyProviderOptions.ratchetSalt),
           currentMaterial.algorithm.name,
           'derive',
-          extractable,
         );
 
         if (setKey) {

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -119,11 +119,11 @@ onmessage = (ev) => {
 async function handleRatchetRequest(data: RatchetRequestMessage['data']) {
   if (useSharedKey) {
     const keyHandler = getSharedKeyHandler();
-    await keyHandler.ratchetKey(data.keyIndex, true, data.extractable);
+    await keyHandler.ratchetKey(data.keyIndex);
     keyHandler.resetKeyStatus();
   } else if (data.participantIdentity) {
     const keyHandler = getParticipantKeyHandler(data.participantIdentity);
-    await keyHandler.ratchetKey(data.keyIndex, true, data.extractable);
+    await keyHandler.ratchetKey(data.keyIndex);
     keyHandler.resetKeyStatus();
   } else {
     workerLogger.error(


### PR DESCRIPTION
Reverts livekit/client-sdk-js#1490

This was not helping since the `CryptoKey` which is emitted will never be extractable.
More on that topic can be found here: https://github.com/w3c/webcrypto/issues/76

A proper solution to this would be to not emit the imported Key but the original material for the key.

@BillCarsonFr has a solution how this would look like and plans to create a PR with a working solution for the problem that livekit/client-sdk-js#1490 tried to solve. 