### PR TITLE
feature: E2E Allow sharing ratcheted material out-of-band

### DIFF
--- a/.changeset/nasty-clocks-invent.md
+++ b/.changeset/nasty-clocks-invent.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+feature: E2E Allow sharing ratcheted material out-of-band

--- a/.changeset/nasty-clocks-invent.md
+++ b/.changeset/nasty-clocks-invent.md
@@ -1,5 +1,5 @@
 ---
-"livekit-client": patch
+"livekit-client": minor
 ---
 
 feature: E2E Allow sharing ratcheted material out-of-band

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -154,6 +154,13 @@ export class E2EEManager
       case 'ratchetKey':
         this.keyProvider.emit(KeyProviderEvent.KeyRatcheted, data.material, data.keyIndex);
         break;
+      case 'ratchetRequestCompleted':
+        this.keyProvider.emit(
+          KeyProviderEvent.RatchetRequestCompleted,
+          data.keyBuffer,
+          data.keyIndex,
+        );
+        break;
       default:
         break;
     }

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -152,12 +152,10 @@ export class E2EEManager
         }
         break;
       case 'ratchetKey':
-        this.keyProvider.emit(KeyProviderEvent.KeyRatcheted, data.material, data.keyIndex);
-        break;
-      case 'ratchetRequestCompleted':
         this.keyProvider.emit(
-          KeyProviderEvent.RatchetRequestCompleted,
-          data.keyBuffer,
+          KeyProviderEvent.KeyRatcheted,
+          data.ratchetResult,
+          data.participantIdentity,
           data.keyIndex,
         );
         break;

--- a/src/e2ee/KeyProvider.ts
+++ b/src/e2ee/KeyProvider.ts
@@ -3,7 +3,7 @@ import type TypedEventEmitter from 'typed-emitter';
 import log from '../logger';
 import { KEY_PROVIDER_DEFAULTS } from './constants';
 import { type KeyProviderCallbacks, KeyProviderEvent } from './events';
-import type { KeyInfo, KeyProviderOptions } from './types';
+import type { KeyInfo, KeyProviderOptions, RatchetResult } from './types';
 import { createKeyMaterialFromBuffer, createKeyMaterialFromString } from './utils';
 
 /**
@@ -39,13 +39,20 @@ export class BaseKeyProvider extends (EventEmitter as new () => TypedEventEmitte
   }
 
   /**
-   * callback being invoked after a ratchet request has been performed on a participant
-   * that surfaces the new key material.
-   * @param material
+   * Callback being invoked after a key has been ratcheted.
+   * Can happen when:
+   * - A decryption failure occurs and the key is auto-ratcheted
+   * - A ratchet request is sent (see {@link ratchetKey()})
+   * @param ratchetResult Contains the ratcheted chain key (exportable to other participants) and the derived new key material.
+   * @param participantId
    * @param keyIndex
    */
-  protected onKeyRatcheted = (material: CryptoKey, keyIndex?: number) => {
-    log.debug('key ratcheted event received', { material, keyIndex });
+  protected onKeyRatcheted = (
+    ratchetResult: RatchetResult,
+    participantId?: string,
+    keyIndex?: number,
+  ) => {
+    log.debug('key ratcheted event received', { ratchetResult, participantId, keyIndex });
   };
 
   getKeys() {

--- a/src/e2ee/events.ts
+++ b/src/e2ee/events.ts
@@ -4,23 +4,38 @@ import type { KeyInfo } from './types';
 
 export enum KeyProviderEvent {
   SetKey = 'setKey',
+  /** Event for requesting to ratchet the key used to encrypt the stream */
   RatchetRequest = 'ratchetRequest',
+  /** Emitted following a `RatchetRequest`, will contain the ratcheted key material */
+  RatchetRequestCompleted = 'ratchetRequestCompleted',
   KeyRatcheted = 'keyRatcheted',
 }
 
 export type KeyProviderCallbacks = {
   [KeyProviderEvent.SetKey]: (keyInfo: KeyInfo) => void;
   [KeyProviderEvent.RatchetRequest]: (participantIdentity?: string, keyIndex?: number) => void;
+  [KeyProviderEvent.RatchetRequestCompleted]: (material: ArrayBuffer, keyIndex?: number) => void;
   [KeyProviderEvent.KeyRatcheted]: (material: CryptoKey, keyIndex?: number) => void;
 };
 
 export enum KeyHandlerEvent {
+  /** Emitted when a key has been ratcheted. Is emitted when any key has been ratcheted
+   * i.e. when the FrameCryptor tried to ratchet when decryption is failing  */
   KeyRatcheted = 'keyRatcheted',
+  /** Emitted when a ratchet request has been performed for the current user.
+   * Will contain the ratcheted key material that can be sent out-of-band to new participants.
+   * The ratcheted key material can be used with `createKeyMaterialFromBuffer` then with `KeyProvider#setKey`.*/
+  RatchetRequestCompleted = 'ratchetRequestCompleted',
 }
 
 export type ParticipantKeyHandlerCallbacks = {
   [KeyHandlerEvent.KeyRatcheted]: (
     material: CryptoKey,
+    participantIdentity: string,
+    keyIndex?: number,
+  ) => void;
+  [KeyHandlerEvent.RatchetRequestCompleted]: (
+    material: ArrayBuffer,
     participantIdentity: string,
     keyIndex?: number,
   ) => void;

--- a/src/e2ee/events.ts
+++ b/src/e2ee/events.ts
@@ -1,41 +1,35 @@
 import type Participant from '../room/participant/Participant';
 import type { CryptorError } from './errors';
-import type { KeyInfo } from './types';
+import type { KeyInfo, RatchetResult } from './types';
 
 export enum KeyProviderEvent {
   SetKey = 'setKey',
   /** Event for requesting to ratchet the key used to encrypt the stream */
   RatchetRequest = 'ratchetRequest',
-  /** Emitted following a `RatchetRequest`, will contain the ratcheted key material */
-  RatchetRequestCompleted = 'ratchetRequestCompleted',
+  /** Emitted when a key is ratcheted. Could be after auto-ratcheting on decryption failure or
+   *  following a `RatchetRequest`, will contain the ratcheted key material */
   KeyRatcheted = 'keyRatcheted',
 }
 
 export type KeyProviderCallbacks = {
   [KeyProviderEvent.SetKey]: (keyInfo: KeyInfo) => void;
   [KeyProviderEvent.RatchetRequest]: (participantIdentity?: string, keyIndex?: number) => void;
-  [KeyProviderEvent.RatchetRequestCompleted]: (material: ArrayBuffer, keyIndex?: number) => void;
-  [KeyProviderEvent.KeyRatcheted]: (material: CryptoKey, keyIndex?: number) => void;
+  [KeyProviderEvent.KeyRatcheted]: (
+    ratchetedResult: RatchetResult,
+    participantIdentity?: string,
+    keyIndex?: number,
+  ) => void;
 };
 
 export enum KeyHandlerEvent {
   /** Emitted when a key has been ratcheted. Is emitted when any key has been ratcheted
    * i.e. when the FrameCryptor tried to ratchet when decryption is failing  */
   KeyRatcheted = 'keyRatcheted',
-  /** Emitted when a ratchet request has been performed for the current user.
-   * Will contain the ratcheted key material that can be sent out-of-band to new participants.
-   * The ratcheted key material can be used with `createKeyMaterialFromBuffer` then with `KeyProvider#setKey`.*/
-  RatchetRequestCompleted = 'ratchetRequestCompleted',
 }
 
 export type ParticipantKeyHandlerCallbacks = {
   [KeyHandlerEvent.KeyRatcheted]: (
-    material: CryptoKey,
-    participantIdentity: string,
-    keyIndex?: number,
-  ) => void;
-  [KeyHandlerEvent.RatchetRequestCompleted]: (
-    material: ArrayBuffer,
+    ratchetResult: RatchetResult,
     participantIdentity: string,
     keyIndex?: number,
   ) => void;

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -77,6 +77,15 @@ export interface RatchetRequestMessage extends BaseMessage {
   };
 }
 
+export interface RatchetRequestCompletedMessage extends BaseMessage {
+  kind: 'ratchetRequestCompleted';
+  data: {
+    participantIdentity?: string;
+    keyIndex?: number;
+    keyBuffer: ArrayBuffer;
+  };
+}
+
 export interface RatchetMessage extends BaseMessage {
   kind: 'ratchetKey';
   data: {
@@ -118,6 +127,7 @@ export type E2EEWorkerMessage =
   | RTPVideoMapMessage
   | UpdateCodecMessage
   | RatchetRequestMessage
+  | RatchetRequestCompletedMessage
   | RatchetMessage
   | SifTrailerMessage
   | InitAck;

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -77,21 +77,12 @@ export interface RatchetRequestMessage extends BaseMessage {
   };
 }
 
-export interface RatchetRequestCompletedMessage extends BaseMessage {
-  kind: 'ratchetRequestCompleted';
-  data: {
-    participantIdentity?: string;
-    keyIndex?: number;
-    keyBuffer: ArrayBuffer;
-  };
-}
-
 export interface RatchetMessage extends BaseMessage {
   kind: 'ratchetKey';
   data: {
     participantIdentity: string;
     keyIndex?: number;
-    material: CryptoKey;
+    ratchetResult: RatchetResult;
   };
 }
 
@@ -127,12 +118,18 @@ export type E2EEWorkerMessage =
   | RTPVideoMapMessage
   | UpdateCodecMessage
   | RatchetRequestMessage
-  | RatchetRequestCompletedMessage
   | RatchetMessage
   | SifTrailerMessage
   | InitAck;
 
 export type KeySet = { material: CryptoKey; encryptionKey: CryptoKey };
+
+export type RatchetResult = {
+  // The ratchet chain key, which is used to derive the next key.
+  // Can be shared/exported to other participants.
+  chainKey: ArrayBuffer;
+  cryptoKey: CryptoKey;
+};
 
 export type KeyProviderOptions = {
   sharedKey: boolean;

--- a/src/e2ee/worker/ParticipantKeyHandler.test.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vitest } from 'vitest';
+import { describe, expect, it, test, vitest } from 'vitest';
 import { ENCRYPTION_ALGORITHM, KEY_PROVIDER_DEFAULTS } from '../constants';
 import { KeyHandlerEvent } from '../events';
-import { createKeyMaterialFromString } from '../utils';
+import { createKeyMaterialFromString, importKey } from '../utils';
 import { ParticipantKeyHandler } from './ParticipantKeyHandler';
 
 describe('ParticipantKeyHandler', () => {
@@ -282,5 +282,101 @@ describe('ParticipantKeyHandler', () => {
       );
       expect(ciphertexts).matchSnapshot('ciphertexts');
     });
+  });
+
+  describe(`E2EE Ratcheting`, () => {
+    test('Should be possible to share ratcheted material to remote participant', async () => {
+      const senderKeyHandler = new ParticipantKeyHandler('test-sender', KEY_PROVIDER_DEFAULTS);
+      // Initial key
+      const initialMaterial = new Uint8Array(32);
+      crypto.getRandomValues(initialMaterial);
+      const rootMaterial = await importKey(initialMaterial, 'HKDF', 'derive');
+      await senderKeyHandler.setKeyFromMaterial(rootMaterial, 0);
+
+      const iv = new Uint8Array(12);
+      crypto.getRandomValues(iv);
+
+      const firstMessagePreRatchet = new TextEncoder().encode(
+        'Hello world, this is the first message',
+      );
+      const firstCipherText = await encrypt(senderKeyHandler, 0, iv, firstMessagePreRatchet);
+
+      let ratchetBufferResolve: (key: ArrayBuffer) => void;
+      const expectEmitted = new Promise<ArrayBuffer>(async (resolve) => {
+        ratchetBufferResolve = resolve;
+      });
+
+      senderKeyHandler.on(
+        KeyHandlerEvent.RatchetRequestCompleted,
+        (material, identity, keyIndex) => {
+          expect(identity).toEqual('test-sender');
+          expect(keyIndex).toEqual(0);
+          ratchetBufferResolve(material);
+        },
+      );
+
+      const currentKeyIndex = senderKeyHandler.getCurrentKeyIndex();
+      const ratchetedKeySet = await senderKeyHandler.ratchetKey(currentKeyIndex, true);
+
+      // Notice that ratchetedKeySet is not exportable, so we cannot share it out-of-band.
+      // This is a limitation of webcrypto for KDFs keys, they cannot be exported.
+      expect(ratchetedKeySet.extractable).toBe(false);
+
+      const ratchetedMaterial = await expectEmitted;
+
+      // The ratcheted material can be sent out-of-band to new participants. And they
+      // should be able to generate the same keyMaterial
+
+      const generatedMaterial = await importKey(ratchetedMaterial, 'HKDF', 'derive');
+      const receiverKeyHandler = new ParticipantKeyHandler('test-receiver', KEY_PROVIDER_DEFAULTS);
+      await receiverKeyHandler.setKeyFromMaterial(generatedMaterial, 0);
+
+      // Now sender should be able to encrypt to recipient
+
+      const plainText = new TextEncoder().encode('Hello world, this is a test message');
+
+      const cipherText = await encrypt(senderKeyHandler, 0, iv, plainText);
+
+      const clearTextBuffer = await decrypt(receiverKeyHandler, 0, iv, cipherText);
+
+      const clearText = new Uint8Array(clearTextBuffer);
+      expect(clearText).toEqual(plainText);
+
+      // The receiver should not be able to decrypt the first message
+      const decryptPromise = decrypt(receiverKeyHandler, 0, iv, firstCipherText);
+      await expect(decryptPromise).rejects.toThrowError();
+    });
+
+    async function encrypt(
+      participantKeyHandler: ParticipantKeyHandler,
+      keyIndex: number,
+      iv: Uint8Array,
+      data: Uint8Array,
+    ): Promise<ArrayBuffer> {
+      return crypto.subtle.encrypt(
+        {
+          name: ENCRYPTION_ALGORITHM,
+          iv,
+        },
+        participantKeyHandler.getKeySet(keyIndex)!.encryptionKey,
+        data,
+      );
+    }
+
+    async function decrypt(
+      participantKeyHandler: ParticipantKeyHandler,
+      keyIndex: number,
+      iv: Uint8Array,
+      cipherText: ArrayBuffer,
+    ): Promise<ArrayBuffer> {
+      return crypto.subtle.decrypt(
+        {
+          name: ENCRYPTION_ALGORITHM,
+          iv,
+        },
+        participantKeyHandler.getKeySet(keyIndex)!.encryptionKey,
+        cipherText,
+      );
+    }
   });
 });

--- a/src/e2ee/worker/ParticipantKeyHandler.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.ts
@@ -136,6 +136,12 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
             this.participantIdentity,
             currentKeyIndex,
           );
+          this.emit(
+            KeyHandlerEvent.KeyRatcheted,
+            newMaterial,
+            this.participantIdentity,
+            currentKeyIndex,
+          );
         }
         resolve(newMaterial);
       } catch (e) {

--- a/src/e2ee/worker/ParticipantKeyHandler.ts
+++ b/src/e2ee/worker/ParticipantKeyHandler.ts
@@ -126,17 +126,13 @@ export class ParticipantKeyHandler extends (EventEmitter as new () => TypedEvent
           );
         }
         const currentMaterial = keySet.material;
-        const newMaterial = await importKey(
-          await ratchet(currentMaterial, this.keyProviderOptions.ratchetSalt),
-          currentMaterial.algorithm.name,
-          'derive',
-        );
-
+        const chainKey = await ratchet(currentMaterial, this.keyProviderOptions.ratchetSalt);
+        const newMaterial = await importKey(chainKey, currentMaterial.algorithm.name, 'derive');
         if (setKey) {
           await this.setKeyFromMaterial(newMaterial, currentKeyIndex, true);
           this.emit(
-            KeyHandlerEvent.KeyRatcheted,
-            newMaterial,
+            KeyHandlerEvent.RatchetRequestCompleted,
+            chainKey,
             this.participantIdentity,
             currentKeyIndex,
           );

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -10,6 +10,7 @@ import type {
   InitAck,
   KeyProviderOptions,
   RatchetMessage,
+  RatchetRequestCompletedMessage,
   RatchetRequestMessage,
 } from '../types';
 import { FrameCryptor, encryptionEnabledMap } from './FrameCryptor';
@@ -176,6 +177,7 @@ function getParticipantKeyHandler(participantIdentity: string) {
   if (!keys) {
     keys = new ParticipantKeyHandler(participantIdentity, keyProviderOptions);
     keys.on(KeyHandlerEvent.KeyRatcheted, emitRatchetedKeys);
+    keys.on(KeyHandlerEvent.RatchetRequestCompleted, emitRatchetRequestCompleted);
     participantKeys.set(participantIdentity, keys);
   }
   return keys;
@@ -236,6 +238,22 @@ function emitRatchetedKeys(material: CryptoKey, participantIdentity: string, key
       participantIdentity,
       keyIndex,
       material,
+    },
+  };
+  postMessage(msg);
+}
+
+function emitRatchetRequestCompleted(
+  keyBuffer: ArrayBuffer,
+  participantIdentity: string,
+  keyIndex?: number,
+) {
+  const msg: RatchetRequestCompletedMessage = {
+    kind: `ratchetRequestCompleted`,
+    data: {
+      participantIdentity,
+      keyIndex,
+      keyBuffer,
     },
   };
   postMessage(msg);

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -10,8 +10,8 @@ import type {
   InitAck,
   KeyProviderOptions,
   RatchetMessage,
-  RatchetRequestCompletedMessage,
   RatchetRequestMessage,
+  RatchetResult,
 } from '../types';
 import { FrameCryptor, encryptionEnabledMap } from './FrameCryptor';
 import { ParticipantKeyHandler } from './ParticipantKeyHandler';
@@ -177,7 +177,6 @@ function getParticipantKeyHandler(participantIdentity: string) {
   if (!keys) {
     keys = new ParticipantKeyHandler(participantIdentity, keyProviderOptions);
     keys.on(KeyHandlerEvent.KeyRatcheted, emitRatchetedKeys);
-    keys.on(KeyHandlerEvent.RatchetRequestCompleted, emitRatchetRequestCompleted);
     participantKeys.set(participantIdentity, keys);
   }
   return keys;
@@ -231,29 +230,17 @@ function setupCryptorErrorEvents(cryptor: FrameCryptor) {
   });
 }
 
-function emitRatchetedKeys(material: CryptoKey, participantIdentity: string, keyIndex?: number) {
+function emitRatchetedKeys(
+  ratchetResult: RatchetResult,
+  participantIdentity: string,
+  keyIndex?: number,
+) {
   const msg: RatchetMessage = {
     kind: `ratchetKey`,
     data: {
       participantIdentity,
       keyIndex,
-      material,
-    },
-  };
-  postMessage(msg);
-}
-
-function emitRatchetRequestCompleted(
-  keyBuffer: ArrayBuffer,
-  participantIdentity: string,
-  keyIndex?: number,
-) {
-  const msg: RatchetRequestCompletedMessage = {
-    kind: `ratchetRequestCompleted`,
-    data: {
-      participantIdentity,
-      keyIndex,
-      keyBuffer,
+      ratchetResult,
     },
   };
   postMessage(msg);


### PR DESCRIPTION
One of the interesting thing with ratcheting is that when there is a new member joining a call, it would be possible to only share with him the ratcheted key instead of rotating the existing key and reshare to everyone.

Unfortunatly with the exisiting code it is not possible to share the ratcheted key material out-of-band because it is not exportable (as per [webcrypto limitiation](https://github.com/w3c/webcrypto/pull/113))

This PR introduce a new event `RatchetRequestCompleted` that will be emitted after a `RatchetRequest` has been completed.
This event contains a ArrayBuffer, that can be transmitted out-of-band and used by a new joiner.