### PR TITLE
Catch failing set sink id promise

### DIFF
--- a/.changeset/poor-cobras-mate.md
+++ b/.changeset/poor-cobras-mate.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Catch failing set sink id promise

--- a/src/room/track/RemoteAudioTrack.ts
+++ b/src/room/track/RemoteAudioTrack.ts
@@ -104,8 +104,9 @@ export default class RemoteAudioTrack extends RemoteTrack<Track.Kind.Audio> {
     }
 
     if (this.sinkId && supportsSetSinkId(element)) {
-      /* @ts-ignore */
-      element.setSinkId(this.sinkId);
+      element.setSinkId(this.sinkId).catch((e) => {
+        this.log.error('Failed to set sink id on remote audio track', e, this.logContext);
+      });
     }
     if (this.audioContext && needsNewWebAudioConnection) {
       this.log.debug('using audio context mapping', this.logContext);


### PR DESCRIPTION
this could have caused an unhandled promise rejection on recent Safari versions that support setSinkId. 
Safari requires an explicit user gesture to enable this. 
Code paths should not have been affected as the promise wasn't awaited in the first place, but it's nicer to error in our SDK logs than raising the unhandled rejection