### PR TITLE
Unorder the lossy data channel

### DIFF
--- a/.changeset/great-pens-yawn.md
+++ b/.changeset/great-pens-yawn.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": minor
+---
+
+Unorder the lossy data channel

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -616,8 +616,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     // create data channels
     this.lossyDC = this.pcManager.createPublisherDataChannel(lossyDataChannel, {
-      // will drop older packets that arrive
-      ordered: true,
+      ordered: false,
       maxRetransmits: 0,
     });
     this.reliableDC = this.pcManager.createPublisherDataChannel(reliableDataChannel, {


### PR DESCRIPTION
We are changing this behavior system-wide to match the documentation. Our best understanding is it can be done across all SDKs and SFU without explicit coordination.

This change ensures the upstream lossy channel is unordered, the SFU will handle the downstream side.