### PR TITLE
Fix svc encoding for safari 18.4

### DIFF
--- a/.changeset/ten-weeks-throw.md
+++ b/.changeset/ten-weeks-throw.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix svc encoding for safari 18.4

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -216,7 +216,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       room: this.latestJoinResponse?.room?.name,
       roomID: this.latestJoinResponse?.room?.sid,
       participant: this.latestJoinResponse?.participant?.identity,
-      pID: this.latestJoinResponse?.participant?.sid,
+      pID: this.participantSid,
     };
   }
 
@@ -532,6 +532,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     this.client.onRoomMoved = (res: RoomMovedResponse) => {
       this.participantSid = res.participant?.sid;
+      if (this.latestJoinResponse) {
+        this.latestJoinResponse.room = res.room;
+      }
       this.emit(EngineEvent.RoomMoved, res);
     };
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -2153,22 +2153,18 @@ export default class LocalParticipant extends Participant {
       });
       return;
     }
-    if (update.subscribedCodecs.length > 0) {
-      if (!pub.videoTrack) {
-        return;
+    if (!pub.videoTrack) {
+      return;
+    }
+    const newCodecs = await pub.videoTrack.setPublishingCodecs(update.subscribedCodecs);
+    for await (const codec of newCodecs) {
+      if (isBackupCodec(codec)) {
+        this.log.debug(`publish ${codec} for ${pub.videoTrack.sid}`, {
+          ...this.logContext,
+          ...getLogContextFromTrack(pub),
+        });
+        await this.publishAdditionalCodecForTrack(pub.videoTrack, codec, pub.options);
       }
-      const newCodecs = await pub.videoTrack.setPublishingCodecs(update.subscribedCodecs);
-      for await (const codec of newCodecs) {
-        if (isBackupCodec(codec)) {
-          this.log.debug(`publish ${codec} for ${pub.videoTrack.sid}`, {
-            ...this.logContext,
-            ...getLogContextFromTrack(pub),
-          });
-          await this.publishAdditionalCodecForTrack(pub.videoTrack, codec, pub.options);
-        }
-      }
-    } else if (update.subscribedQualities.length > 0) {
-      await pub.videoTrack?.setPublishingLayers(update.subscribedQualities);
     }
   };
 

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -19,6 +19,7 @@ import {
   isReactNative,
   isSVCCodec,
   isSafari,
+  isSafariSvcApi,
   unwrapConstraint,
 } from '../utils';
 
@@ -158,12 +159,15 @@ export function computeVideoEncodings(
       (browser?.name === 'Chrome' && compareVersions(browser?.version, '113') < 0)
     ) {
       const bitratesRatio = sm.suffix == 'h' ? 2 : 3;
+      // safari 18.4 uses a different svc API that requires scaleResolutionDownBy to be set.
+      const requireScale = isSafariSvcApi(browser);
       for (let i = 0; i < sm.spatial; i += 1) {
         // in legacy SVC, scaleResolutionDownBy cannot be set
         encodings.push({
           rid: videoRids[2 - i],
           maxBitrate: videoEncoding.maxBitrate / bitratesRatio ** i,
           maxFramerate: original.encoding.maxFramerate,
+          scaleResolutionDownBy: requireScale ? 2 ** i : undefined,
         });
       }
       // legacy SVC, scalabilityMode is set only on the first encoding

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -378,7 +378,7 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
    * @internal
    * Sets layers that should be publishing
    */
-  async setPublishingLayers(isSvc: boolean,qualities: SubscribedQuality[]) {
+  async setPublishingLayers(isSvc: boolean, qualities: SubscribedQuality[]) {
     this.log.debug('setting publishing layers', { ...this.logContext, qualities });
     if (!this.sender || !this.encodings) {
       return;
@@ -504,7 +504,7 @@ async function setPublishingLayersForSender(
       if (isSVC) {
         const hasEnabledEncoding = qualities.some((q) => q.enabled);
         if (hasEnabledEncoding) {
-          qualities.forEach((q) => q.enabled = true);
+          qualities.forEach((q) => (q.enabled = true));
         }
       }
       // simulcast dynacast encodings

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -5,7 +5,7 @@ import {
   DisconnectReason,
   Transcription as TranscriptionModel,
 } from '@livekit/protocol';
-import { getBrowser, type BrowserDetails } from '../utils/browserParser';
+import { type BrowserDetails, getBrowser } from '../utils/browserParser';
 import { protocolVersion, version } from '../version';
 import { type ConnectionError, ConnectionErrorReason } from './errors';
 import type LocalParticipant from './participant/LocalParticipant';
@@ -152,8 +152,8 @@ export function isSafariSvcApi(browser?: BrowserDetails): boolean {
   if (!browser) {
     browser = getBrowser();
   }
-  // Safari 18.4 requires legacy svc api and scaleResolutionDown to be set 
-  return (browser?.name === 'Safari' && compareVersions(browser.version, '18.3') > 0);
+  // Safari 18.4 requires legacy svc api and scaleResolutionDown to be set
+  return browser?.name === 'Safari' && compareVersions(browser.version, '18.3') > 0;
 }
 
 export function isMobile(): boolean {

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -5,7 +5,7 @@ import {
   DisconnectReason,
   Transcription as TranscriptionModel,
 } from '@livekit/protocol';
-import { getBrowser } from '../utils/browserParser';
+import { getBrowser, type BrowserDetails } from '../utils/browserParser';
 import { protocolVersion, version } from '../version';
 import { type ConnectionError, ConnectionErrorReason } from './errors';
 import type LocalParticipant from './participant/LocalParticipant';
@@ -146,6 +146,14 @@ export function isSafari(): boolean {
 export function isSafari17(): boolean {
   const b = getBrowser();
   return b?.name === 'Safari' && b.version.startsWith('17.');
+}
+
+export function isSafariSvcApi(browser?: BrowserDetails): boolean {
+  if (!browser) {
+    browser = getBrowser();
+  }
+  // Safari 18.4 requires legacy svc api and scaleResolutionDown to be set 
+  return (browser?.name === 'Safari' && compareVersions(browser.version, '18.3') > 0);
 }
 
 export function isMobile(): boolean {


### PR DESCRIPTION
Safari18.4 requires scaleResolutionDown to be set
with legacy svc api.