### PR TITLE
[BUG] Remove duplicate media devices

### DIFF
--- a/src/room/DeviceManager.ts
+++ b/src/room/DeviceManager.ts
@@ -36,7 +36,7 @@ export default class DeviceManager {
           await Promise.all(DeviceManager.userMediaPromiseMap.values());
         }
       } catch (e: any) {
-        log.warn('error waiting for media permissons');
+        log.warn('error waiting for media permissions');
       }
     }
     let devices = await navigator.mediaDevices.enumerateDevices();
@@ -71,7 +71,18 @@ export default class DeviceManager {
     if (kind) {
       devices = devices.filter((device) => device.kind === kind);
     }
-    return devices;
+    const uniqueDevices: MediaDeviceInfo[] = [];
+    const deviceMap = new Map<string, MediaDeviceInfo>();
+
+    devices.forEach((device) => {
+      const compositeKey = `${device.kind}|${device.groupId}`;
+      if (!deviceMap.has(compositeKey)) {
+        uniqueDevices.push(device);
+        deviceMap.set(compositeKey, device);
+      }
+    });
+
+    return uniqueDevices;
   }
 
   async normalizeDeviceId(


### PR DESCRIPTION
Fixes: [components-js/issues/1139](https://github.com/livekit/components-js/issues/1139) 

- Currently in chrome/firefox we see multiple instances of same device.
- Fixed it by removing duplicates based on groupId and kind.