### PR TITLE
[FIX] Update active device immediately for muted audio tracks

### DIFF
--- a/.changeset/ninety-baboons-act.md
+++ b/.changeset/ninety-baboons-act.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Update active device immediately for muted audio tracks


### PR DESCRIPTION
Fixes: [components-js/issues/1134](https://github.com/livekit/components-js/issues/1134) 

- When changing audio devices while tracks are muted, the UI didn’t update because muted tracks don’t trigger automatic device restarts.
- Users expected device changes to reflect immediately in the UI, even when muted.
- Fix: Added `shouldTriggerImmediateDeviceChange` flag to detect muted tracks and trigger update if true.