### PR TITLE
fix: don't try to set audio output on Safari without explicit user interaction

### DIFF
--- a/.changeset/strong-garlics-wink.md
+++ b/.changeset/strong-garlics-wink.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: don't try to set audio output on Safari without explicit user interaction

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -103,7 +103,6 @@ import {
   isLocalParticipant,
   isReactNative,
   isRemotePub,
-  isSafari,
   isSafariBased,
   isWeb,
   numberToBigInt,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1356,6 +1356,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
           // @ts-expect-error setSinkId is not yet in the typescript type of AudioContext
           this.audioContext?.setSinkId(deviceId);
         }
+
         // also set audio output on all audio elements, even if webAudioMix is enabled in order to workaround echo cancellation not working on chrome with non-default output devices
         // see https://issues.chromium.org/issues/40252911#comment7
         await Promise.all(
@@ -2047,7 +2048,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       // switch to first available device if previously active device is not available any more
       if (
         devicesOfKind.length > 0 &&
-        !devicesOfKind.find((deviceInfo) => deviceInfo.deviceId === this.getActiveDevice(kind))
+        !devicesOfKind.find((deviceInfo) => deviceInfo.deviceId === this.getActiveDevice(kind)) &&
+        // avoid switching audio output on safari without explicit user action as it leads to slowed down audio playback
+        (kind !== 'audiooutput' || !isSafari())
       ) {
         await this.switchActiveDevice(kind, devicesOfKind[0].deviceId);
       }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -104,6 +104,7 @@ import {
   isReactNative,
   isRemotePub,
   isSafari,
+  isSafariBased,
   isWeb,
   numberToBigInt,
   sleep,
@@ -2041,7 +2042,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         }
       }
 
-      if ((kind === 'audioinput' && !isSafari()) || kind === 'videoinput') {
+      if ((kind === 'audioinput' && !isSafariBased()) || kind === 'videoinput') {
         // airpods on Safari need special handling for audioinput as the track doesn't end as soon as you take them out
         continue;
       }
@@ -2050,7 +2051,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         devicesOfKind.length > 0 &&
         !devicesOfKind.find((deviceInfo) => deviceInfo.deviceId === this.getActiveDevice(kind)) &&
         // avoid switching audio output on safari without explicit user action as it leads to slowed down audio playback
-        (kind !== 'audiooutput' || !isSafari())
+        (kind !== 'audiooutput' || !isSafariBased())
       ) {
         await this.switchActiveDevice(kind, devicesOfKind[0].deviceId);
       }

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -143,6 +143,11 @@ export function isSafari(): boolean {
   return getBrowser()?.name === 'Safari';
 }
 
+export function isSafariBased(): boolean {
+  const b = getBrowser();
+  return b?.name === 'Safari' || b?.os === 'iOS';
+}
+
 export function isSafari17(): boolean {
   const b = getBrowser();
   return b?.name === 'Safari' && b.version.startsWith('17.');


### PR DESCRIPTION
doing so leads to `setSinkId` being called on recent Safari versions without proper permissions. 

this in turn seems to trigger an implementation bug where the output device does not change (expected), however the audio becomes quieter and slowed/pitched down (unexpected). 