### PR TITLE
Stop MediaStream tracks at the end of the video check

### DIFF
--- a/.changeset/dull-otters-dress.md
+++ b/.changeset/dull-otters-dress.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Stop MediaStream tracks at the end of the video check

--- a/src/connectionHelper/checks/publishVideo.ts
+++ b/src/connectionHelper/checks/publishVideo.ts
@@ -83,6 +83,7 @@ export class PublishVideoCheck extends Checker {
       video.play();
     });
 
+    stream.getTracks().forEach((t) => t.stop());
     video.remove();
   }
 }


### PR DESCRIPTION
Stops MediaStream tracks at the end of the video check to release the camera and prevent it from staying active.