### PR TITLE
 Fix transceiver reuse in chrome when using e2ee

### DIFF
--- a/.changeset/brown-laws-visit.md
+++ b/.changeset/brown-laws-visit.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix transceiver reuse causing destination stream closed errors

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -25,6 +25,7 @@ import type {
   RTPVideoMapMessage,
   RatchetRequestMessage,
   RemoveTransformMessage,
+  ScriptTransfromOptions,
   SetKeyMessage,
   SifTrailerMessage,
   UpdateCodecMessage,
@@ -345,7 +346,7 @@ export class E2EEManager
     }
 
     if (isScriptTransformSupported()) {
-      const options = {
+      const options: ScriptTransfromOptions = {
         kind: 'decode',
         participantIdentity,
         trackId,

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -25,7 +25,7 @@ import type {
   RTPVideoMapMessage,
   RatchetRequestMessage,
   RemoveTransformMessage,
-  ScriptTransfromOptions,
+  ScriptTransformOptions,
   SetKeyMessage,
   SifTrailerMessage,
   UpdateCodecMessage,
@@ -346,7 +346,7 @@ export class E2EEManager
     }
 
     if (isScriptTransformSupported()) {
-      const options: ScriptTransfromOptions = {
+      const options: ScriptTransformOptions = {
         kind: 'decode',
         participantIdentity,
         trackId,

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -371,6 +371,7 @@ export class E2EEManager
       let writable: WritableStream = receiver.writableStream;
       // @ts-ignore
       let readable: ReadableStream = receiver.readableStream;
+
       if (!writable || !readable) {
         // @ts-ignore
         const receiverStreams = receiver.createEncodedStreams();
@@ -390,6 +391,7 @@ export class E2EEManager
           trackId: trackId,
           codec,
           participantIdentity: participantIdentity,
+          isReuse: E2EE_FLAG in receiver,
         },
       };
       this.worker.postMessage(msg, [readable, writable]);
@@ -435,6 +437,7 @@ export class E2EEManager
           codec,
           trackId,
           participantIdentity: this.room.localParticipant.identity,
+          isReuse: false,
         },
       };
       this.worker.postMessage(msg, [senderStreams.readable, senderStreams.writable]);

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -164,7 +164,7 @@ export type DecodeRatchetOptions = {
   encryptionKey?: CryptoKey;
 };
 
-export type ScriptTransfromOptions = {
+export type ScriptTransformOptions = {
   kind: 'decode' | 'encode';
   participantIdentity: string;
   trackId: string;

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -49,6 +49,7 @@ export interface EncodeMessage extends BaseMessage {
     writableStream: WritableStream;
     trackId: string;
     codec?: VideoCodec;
+    isReuse: boolean;
   };
 }
 

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -163,3 +163,10 @@ export type DecodeRatchetOptions = {
   /** ratcheted key to try */
   encryptionKey?: CryptoKey;
 };
+
+export type ScriptTransfromOptions = {
+  kind: 'decode' | 'encode';
+  participantIdentity: string;
+  trackId: string;
+  codec?: VideoCodec;
+};

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -69,6 +69,8 @@ export class FrameCryptor extends BaseFrameCryptor {
 
   private detectedCodec?: VideoCodec;
 
+  private isTransformActive: boolean = false;
+
   constructor(opts: {
     keys: ParticipantKeyHandler;
     participantIdentity: string;
@@ -159,6 +161,7 @@ export class FrameCryptor extends BaseFrameCryptor {
     readable: ReadableStream<RTCEncodedVideoFrame | RTCEncodedAudioFrame>,
     writable: WritableStream<RTCEncodedVideoFrame | RTCEncodedAudioFrame>,
     trackId: string,
+    isReuse: boolean,
     codec?: VideoCodec,
   ) {
     if (codec) {
@@ -173,10 +176,19 @@ export class FrameCryptor extends BaseFrameCryptor {
       ...this.logContext,
     });
 
+    if (isReuse && this.isTransformActive) {
+      workerLogger.debug('reuse transform', {
+        ...this.logContext,
+      });
+      return;
+    }
+
     const transformFn = operation === 'encode' ? this.encodeFunction : this.decodeFunction;
     const transformStream = new TransformStream({
       transform: transformFn.bind(this),
     });
+
+    this.isTransformActive = true;
 
     readable
       .pipeThrough(transformStream)
@@ -189,6 +201,9 @@ export class FrameCryptor extends BaseFrameCryptor {
             ? e
             : new CryptorError(e.message, undefined, this.participantIdentity),
         );
+      })
+      .finally(() => {
+        this.isTransformActive = false;
       });
     this.trackId = trackId;
   }

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -257,10 +257,12 @@ function handleSifTrailer(trailer: Uint8Array) {
 }
 
 // Operations using RTCRtpScriptTransform.
+// @ts-ignore
 if (self.RTCTransformEvent) {
   workerLogger.debug('setup transform event');
   // @ts-ignore
   self.onrtctransform = (event: RTCTransformEvent) => {
+    // @ts-ignore
     const transformer = event.transformer;
     workerLogger.debug('transformer', transformer);
 

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -12,6 +12,7 @@ import type {
   RatchetMessage,
   RatchetRequestMessage,
   RatchetResult,
+  ScriptTransfromOptions,
 } from '../types';
 import { FrameCryptor, encryptionEnabledMap } from './FrameCryptor';
 import { ParticipantKeyHandler } from './ParticipantKeyHandler';
@@ -256,19 +257,17 @@ function handleSifTrailer(trailer: Uint8Array) {
 }
 
 // Operations using RTCRtpScriptTransform.
-// @ts-ignore
 if (self.RTCTransformEvent) {
   workerLogger.debug('setup transform event');
   // @ts-ignore
   self.onrtctransform = (event: RTCTransformEvent) => {
-    // @ts-ignore .transformer property is part of RTCTransformEvent
     const transformer = event.transformer;
     workerLogger.debug('transformer', transformer);
-    // @ts-ignore monkey patching non standard flag
-    transformer.handled = true;
-    const { kind, participantIdentity, trackId, codec } = transformer.options;
+
+    const { kind, participantIdentity, trackId, codec } =
+      transformer.options as ScriptTransfromOptions;
     const cryptor = getTrackCryptor(participantIdentity, trackId);
     workerLogger.debug('transform', { codec });
-    cryptor.setupTransform(kind, transformer.readable, transformer.writable, trackId, codec);
+    cryptor.setupTransform(kind, transformer.readable, transformer.writable, trackId, false, codec);
   };
 }

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -65,6 +65,7 @@ onmessage = (ev) => {
           data.readableStream,
           data.writableStream,
           data.trackId,
+          data.isReuse,
           data.codec,
         );
         break;
@@ -75,6 +76,7 @@ onmessage = (ev) => {
           data.readableStream,
           data.writableStream,
           data.trackId,
+          data.isReuse,
           data.codec,
         );
         break;

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -12,7 +12,7 @@ import type {
   RatchetMessage,
   RatchetRequestMessage,
   RatchetResult,
-  ScriptTransfromOptions,
+  ScriptTransformOptions,
 } from '../types';
 import { FrameCryptor, encryptionEnabledMap } from './FrameCryptor';
 import { ParticipantKeyHandler } from './ParticipantKeyHandler';
@@ -267,7 +267,7 @@ if (self.RTCTransformEvent) {
     workerLogger.debug('transformer', transformer);
 
     const { kind, participantIdentity, trackId, codec } =
-      transformer.options as ScriptTransfromOptions;
+      transformer.options as ScriptTransformOptions;
     const cryptor = getTrackCryptor(participantIdentity, trackId);
     workerLogger.debug('transform', { codec });
     cryptor.setupTransform(kind, transformer.readable, transformer.writable, trackId, false, codec);


### PR DESCRIPTION
the reason #1554 didn't work for Safari was an uncaught type error in the script transform path. 

this PR re-applies the previous fix and adds types for the options passed to the transform event in order to prevent similar issues from happening again.