### PR TITLE
allow manual controls even when adaptiveStream is enabled

### DIFF
--- a/.changeset/rotten-lemons-itch.md
+++ b/.changeset/rotten-lemons-itch.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+allow manual controls even when adaptiveStream is enabled

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -114,7 +114,7 @@ const appActions = {
       },
       publishDefaults: {
         simulcast,
-        videoSimulcastLayers: [VideoPresets.h90, VideoPresets.h216],
+        videoSimulcastLayers: [VideoPresets.h180, VideoPresets.h360],
         videoCodec: preferredCodec || 'vp8',
         dtx: true,
         red: true,

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -86,6 +86,7 @@ export default class RemoteParticipant extends Participant {
       this.log.debug('send update settings', {
         ...this.logContext,
         ...getLogContextFromTrack(publication),
+        settings,
       });
       this.signalClient.sendUpdateTrackSettings(settings);
     });

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -318,7 +318,7 @@ export default class RemoteTrackPublication extends TrackPublication {
     if (this.kind === Track.Kind.Video) {
       let minDimensions = { ...this.requestedVideoDimensions };
 
-      if (this.videoDimensionsAdaptiveStream) {
+      if (this.videoDimensionsAdaptiveStream !== undefined) {
         if (minDimensions.width && minDimensions.height) {
           // check whether the adaptive stream dimensions are smaller than the requested dimensions and use smaller one
           const smallerAdaptive =
@@ -359,7 +359,7 @@ export default class RemoteTrackPublication extends TrackPublication {
         }
       }
 
-      if (minDimensions.width && minDimensions.height) {
+      if (minDimensions.width !== undefined && minDimensions.height !== undefined) {
         settings.width = Math.ceil(minDimensions.width);
         settings.height = Math.ceil(minDimensions.height);
       } else if (this.requestedMaxQuality !== undefined) {

--- a/src/room/track/RemoteTrackPublication.ts
+++ b/src/room/track/RemoteTrackPublication.ts
@@ -315,29 +315,32 @@ export default class RemoteTrackPublication extends TrackPublication {
 
     if (this.videoDimensionsAdaptiveStream) {
       if (minDimensions.width && minDimensions.height) {
+        // check whether the adaptive stream dimensions are smaller than the requested dimensions and use smaller one
         const smallerAdaptive =
           this.videoDimensionsAdaptiveStream.width * this.videoDimensionsAdaptiveStream.height <
           minDimensions.width * minDimensions.height;
         if (smallerAdaptive) {
           minDimensions = this.videoDimensionsAdaptiveStream;
         }
+      } else if (this.requestedMaxQuality) {
+        // check whether adaptive stream dimensions are smaller than the max quality layer and use smaller one
+        if (this.trackInfo?.layers) {
+          for (const layer of this.trackInfo.layers) {
+            if (layer.quality === this.requestedMaxQuality) {
+              const smallerAdaptive =
+                this.videoDimensionsAdaptiveStream.width *
+                  this.videoDimensionsAdaptiveStream.height <
+                layer.width * layer.height;
+              if (smallerAdaptive) {
+                minDimensions = this.videoDimensionsAdaptiveStream;
+              }
+            }
+          }
+        }
       } else {
         minDimensions = this.videoDimensionsAdaptiveStream;
       }
     }
-
-    this.trackInfo?.layers?.forEach((layer) => {
-      if (layer.quality === this.requestedMaxQuality) {
-        if (this.videoDimensionsAdaptiveStream) {
-          const smallerAdaptive =
-            this.videoDimensionsAdaptiveStream.width * this.videoDimensionsAdaptiveStream.height <
-            layer.width * layer.height;
-          if (smallerAdaptive) {
-            minDimensions = this.videoDimensionsAdaptiveStream;
-          }
-        }
-      }
-    });
 
     if (minDimensions.width && minDimensions.height) {
       settings.width = Math.ceil(minDimensions.width);

--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -1,4 +1,4 @@
-import { TrackPublishedResponse, TrackSource } from '@livekit/protocol';
+import { TrackInfo, TrackPublishedResponse, TrackSource, VideoQuality } from '@livekit/protocol';
 import type { AudioProcessorOptions, TrackProcessor, VideoProcessorOptions } from '../..';
 import { cloneDeep } from '../../utils/cloneDeep';
 import { isSafari, sleep } from '../utils';
@@ -328,4 +328,15 @@ export function getTrackSourceFromProto(source: TrackSource): Track.Source {
     default:
       return Track.Source.Unknown;
   }
+}
+
+export function areDimensionsSmaller(a: Track.Dimensions, b: Track.Dimensions): boolean {
+  return a.width * a.height < b.width * b.height;
+}
+
+export function layerDimensionsFor(
+  trackInfo: TrackInfo,
+  quality: VideoQuality,
+): Track.Dimensions | undefined {
+  return trackInfo.layers?.find((l) => l.quality === quality);
 }


### PR DESCRIPTION
this would allow the user to manipulate video dimensions even when adaptive stream is in use.

it would allow us to override requested dims when running in low-power mode, but still be able to use adaptiveStream normally
