### PR TITLE
[FIX] Update active device immediately for muted video tracks

### DIFF
--- a/.changeset/tough-laws-deny.md
+++ b/.changeset/tough-laws-deny.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Update active device immediately for muted video tracks

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1337,6 +1337,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         this.options.videoCaptureDefaults!.deviceId = prevDeviceId;
         throw e;
       }
+      const isMuted = tracks.some((t) => t.track?.isMuted ?? false);
+      if (success && isMuted) shouldTriggerImmediateDeviceChange = true;
     } else if (kind === 'audiooutput') {
       shouldTriggerImmediateDeviceChange = true;
       if (


### PR DESCRIPTION
Fixes: [components-js/issues/1134 Muted video tracks issue](https://github.com/livekit/components-js/issues/1134#issuecomment-2877490017) 

- When changing video input devices while tracks are muted, the UI didn’t update because muted tracks don’t trigger automatic device restarts.
- Similar fix as done in PR: #1526 