### PR TITLE
Don't add dd extension for safari

### DIFF
--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -6,7 +6,7 @@ import { debounce } from 'ts-debounce';
 import log, { LoggerNames, getLogger } from '../logger';
 import { NegotiationError, UnexpectedConnectionState } from './errors';
 import type { LoggerOptions } from './types';
-import { ddExtensionURI, isSafari, isSVCCodec } from './utils';
+import { ddExtensionURI, isSVCCodec, isSafari } from './utils';
 
 /** @internal */
 interface TrackBitrateInfo {


### PR DESCRIPTION
When pubishing both camera and screenshare in
Safari 18.5, the browser could generate sdp with
dd extension in camera and without it in screenshare, munge sdp to add it could cause inconsistent ext id in two media sections and a warning in sfu side.