### PR TITLE
fix: retry processor playback on abort error

### DIFF
--- a/.changeset/flat-suns-melt.md
+++ b/.changeset/flat-suns-melt.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: retry processor playback on abort error

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -543,11 +543,22 @@ export default abstract class LocalTrack<
       attachToElement(this._mediaStreamTrack, processorElement);
       processorElement.muted = true;
 
-      processorElement
-        .play()
-        .catch((error) =>
-          this.log.error('failed to play processor element', { ...this.logContext, error }),
-        );
+      processorElement.play().catch((error) => {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          // This happens on Safari when the processor is restarted, try again after a delay
+          this.log.warn('failed to play processor element, retrying', {
+            ...this.logContext,
+            error,
+          });
+          setTimeout(() => {
+            processorElement.play().catch((err) => {
+              this.log.error('failed to play processor element', { ...this.logContext, err });
+            });
+          }, 100);
+        } else {
+          this.log.error('failed to play processor element', { ...this.logContext, error });
+        }
+      });
 
       this.processor = processor;
       this.processorElement = processorElement;


### PR DESCRIPTION
workaround for Safari abort error being raised when restarting processors