### PR TITLE
Fix error when `unwrapConstraint` receives an empty deviceId when creating local tracks

### DIFF
--- a/.changeset/gorgeous-plants-glow.md
+++ b/.changeset/gorgeous-plants-glow.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix error when `unwrapConstraint` receives an empty deviceId when creating local tracks

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -529,13 +529,13 @@ export function unwrapConstraint(constraint: ConstrainDOMString | ConstrainULong
   if (Array.isArray(constraint)) {
     return constraint[0];
   }
-  if (constraint.exact) {
+  if (constraint.exact !== undefined) {
     if (Array.isArray(constraint.exact)) {
       return constraint.exact[0];
     }
     return constraint.exact;
   }
-  if (constraint.ideal) {
+  if (constraint.ideal !== undefined) {
     if (Array.isArray(constraint.ideal)) {
       return constraint.ideal[0];
     }


### PR DESCRIPTION
Hi.
When `createLocalTracks` is called with an empty string deviceId (```{deviceId: ""}```), the `unwrapConstraint` function throws an error because it incorrectly evaluates empty strings as falsy values. This causes the function to throw `"could not unwrap constraint"` error when creating local tracks (audio or video)

and also it prevents the code properly clean up and stop created media tracks, resulting in browsers continuing to show camera/microphone in-use indicators even after the meet ends or fails.

`create.ts`
``` typescript
const newDeviceId = mediaStreamTrack.getSettings().deviceId;
if (
  trackConstraints?.deviceId &&
  //* this line throws when deviceId is an empty string in constraints
  //* like `{ ideal: "" }` or `{ exact: "" }`
  unwrapConstraint(trackConstraints.deviceId) !== newDeviceId
) {
  trackConstraints.deviceId = newDeviceId;
} else if (!trackConstraints) {
  trackConstraints = { deviceId: newDeviceId };
}
```

