### PR TITLE
fix: correct handling of signal connect future

### DIFF
--- a/.changeset/mighty-dolls-behave.md
+++ b/.changeset/mighty-dolls-behave.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: correct handling of signal connect future

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3439,8 +3439,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.0-dev.20250702:
-    resolution: {integrity: sha512-Qi2JC1TaAuDW62spVXK/hQoqdVQ6VEFgoJYgDwICyWS0Itvas4Sub8rbacMVbXrHveKQ4bWZ9/XlY+2JNkVj5A==}
+  typescript@5.9.0-dev.20250716:
+    resolution: {integrity: sha512-wBOPAX99Y5n6c4JF9ZIPy4xrnUDfFmrzOaFoVWGeDAu8cfV3773xfvNMColH3EnaWf8JytB3rgbcLYDE2nhCQw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5657,7 +5657,7 @@ snapshots:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 5.9.0-dev.20250702
+      typescript: 5.9.0-dev.20250716
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7496,7 +7496,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@5.9.0-dev.20250702: {}
+  typescript@5.9.0-dev.20250716: {}
 
   uc.micro@2.1.0: {}
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -248,6 +248,10 @@ export default class LocalParticipant extends Participant {
       }
     });
 
+    if (this.signalConnectedFuture?.isResolved) {
+      this.signalConnectedFuture = undefined;
+    }
+
     this.engine
       .on(EngineEvent.Connected, this.handleReconnected)
       .on(EngineEvent.SignalConnected, this.handleSignalConnected)

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -418,6 +418,12 @@ export class Future<T> {
 
   onFinally?: () => void;
 
+  get isResolved(): boolean {
+    return this._isResolved;
+  }
+
+  private _isResolved: boolean = false;
+
   constructor(
     futureBase?: (resolve: (arg: T) => void, reject: (e: any) => void) => void,
     onFinally?: () => void,
@@ -429,7 +435,10 @@ export class Future<T> {
       if (futureBase) {
         await futureBase(resolve, reject);
       }
-    }).finally(() => this.onFinally?.());
+    }).finally(() => {
+      this._isResolved = true;
+      this.onFinally?.();
+    });
   }
 }
 


### PR DESCRIPTION
follow up for https://github.com/livekit/client-sdk-js/pull/1587 as the previous PR causes issues with preconnect buffer when reusing the same room instance