### PR TITLE
Skip track publish if the room is signalling client is disconnected

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -891,31 +891,43 @@ export default class LocalParticipant extends Participant {
     }
     const publishPromise = new Promise<LocalTrackPublication>(async (resolve, reject) => {
       try {
-        if (this.engine.client.currentState !== SignalConnectionState.CONNECTED) {
-          this.log.debug('deferring track publication until signal is connected', {
-            ...this.logContext,
-            track: getLogContextFromTrack(track),
-          });
+        switch (this.engine.client.currentState) {
+          case SignalConnectionState.CONNECTING:
+          case SignalConnectionState.RECONNECTING:
+            this.log.debug('deferring track publication until signal is connected', {
+              ...this.logContext,
+              track: getLogContextFromTrack(track),
+            });
 
-          const timeout = setTimeout(() => {
-            reject(
-              new PublishTrackError(
-                'publishing rejected as engine not connected within timeout',
-                408,
-              ),
-            );
-          }, 15_000);
-          await this.waitUntilEngineConnected();
-          clearTimeout(timeout);
-          const publication = await this.publish(track, opts, isStereo);
-          resolve(publication);
-        } else {
-          try {
+            const timeout = setTimeout(() => {
+              reject(
+                new PublishTrackError(
+                  'publishing rejected as engine not connected within timeout',
+                  408,
+                ),
+              );
+            }, 15_000);
+            await this.waitUntilEngineConnected();
+            clearTimeout(timeout);
             const publication = await this.publish(track, opts, isStereo);
             resolve(publication);
-          } catch (e) {
-            reject(e);
-          }
+            break;
+
+          case SignalConnectionState.CONNECTED:
+            try {
+              const publication = await this.publish(track, opts, isStereo);
+              resolve(publication);
+            } catch (e) {
+              reject(e);
+            }
+            break;
+
+          case SignalConnectionState.DISCONNECTING:
+          case SignalConnectionState.DISCONNECTED:
+            this.log.debug(
+              `Skipping track publish, engine.client.currentState = ${this.engine.client.currentState}`,
+            );
+            break;
         }
       } catch (e) {
         reject(e);


### PR DESCRIPTION
Previously, `setMicrophoneEnabled` would attempt to publish a given track, and would fail if `this.engine` wasn't properly initialized. When this occurred, a "cannot publish track when not connected" error toast would be shown in the application. 

This could happen via a scenario like the below:
1. `setMicrophoneEnabled` called
2. (a few ms go by)
3. `room.disconnect()` called, which starts tearing down the engine
4. [These lines](https://github.com/livekit/client-sdk-js/blob/b3ac2ace6a693ea04818406835feab195f551d91/src/room/participant/LocalParticipant.ts#L1164-L1166) are hit, the condition passes, and an error is thrown

So, explicitly check now that before calling `this.publish(...)` that the signalling client is connected and healthy, otherwise drop the message.