### PR TITLE
Fix iOS local track recorder mimetype for preconnect buffer

### DIFF
--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -617,8 +617,13 @@ export default abstract class LocalTrack<
     }
 
     if (!this.localTrackRecorder) {
+      let mimeType = 'audio/webm;codecs=opus';
+      if (!MediaRecorder.isTypeSupported(mimeType)) {
+        // iOS currently only supports video/mp4 as a mime type - even for audio.
+        mimeType = 'video/mp4';
+      }
       this.localTrackRecorder = new LocalTrackRecorder(this, {
-        mimeType: 'audio/webm;codecs=opus',
+        mimeType,
       });
     } else {
       this.log.warn('preconnect buffer already started');


### PR DESCRIPTION
see more info [here](https://stackoverflow.com/questions/67874713/mediarecorder-ios-14-6-mimetype-not-supported)