### PR TITLE
Datastream - `TextStreamReader`/`ByteStreamReader` read timeouts and abort signals

### DIFF
--- a/.changeset/famous-suns-count.md
+++ b/.changeset/famous-suns-count.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+feat: add ability to include an AbortSignal when reading from a datastream

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -289,6 +289,15 @@
                 </button>
               </div>
             </div>
+            <button
+              id="cancel-chat-receive-button"
+              class="btn btn-outline-secondary btn-sm"
+              type="button"
+              onclick="appActions.cancelChatReceive()"
+              style="display: none;"
+            >
+              Cancel current receive
+            </button>
           </div>
         </div>
       </div>

--- a/examples/demo/styles.css
+++ b/examples/demo/styles.css
@@ -33,6 +33,7 @@
 
 #chat-input-area {
   margin-top: 1.2rem;
+  margin-bottom: 0.5rem;
   display: grid;
   grid-template-columns: auto min-content;
   gap: 1.25rem;

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -227,7 +227,7 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
   }
 
   /**
-   * Injects an AborrSignal, which if aborted, will terminate the currently active
+   * Injects an AbortSignal, which if aborted, will terminate the currently active
    * stream iteration operation.
    *
    * Note that when using AbortSignal.timeout(...), the timeout applies across

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -3,6 +3,7 @@ import type { BaseStreamInfo, ByteStreamInfo, TextStreamInfo } from './types';
 import { Future, bigIntToNumber } from './utils';
 
 export type BaseStreamReaderReadAllOpts = {
+  /** An AbortSignal can be used to terminate reads early. */
   signal?: AbortSignal;
 };
 

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -107,7 +107,7 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
    * Note that when using AbortSignal.timeout(...), the timeout applies across
    * the whole iteration operation, not just one individual chunk read.
    */
-  withAbortSignal(signal?: AbortSignal) {
+  withAbortSignal(signal: AbortSignal) {
     this.signal = signal;
     return this;
   }

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -101,7 +101,7 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
   }
 
   /**
-   * Injects an AborrSignal, which if aborted, will terminate the currently active
+   * Injects an AbortSignal, which if aborted, will terminate the currently active
    * stream iteration operation.
    *
    * Note that when using AbortSignal.timeout(...), the timeout applies across


### PR DESCRIPTION
Adds the ability to include an `AbortSignal` as a parameter when reading byte or text data from a datastream. This permits both manual cancellation (seems useful) but also importantly timeouts using `AbortSignal.timeout(...)`:

## Code overview
```typescript
room.registerTextStreamHandler('lk.chat', async (reader /* TextStreamReader */, participant) => {
  // Async iterator example
  for await (const chunk of reader.withAbortSignal(AbortSignal.timeout(5000))) {
    console.log('Received chunk:', chunk);
  }

  // OR:

  // `.readAll()` example
  const message = await reader.readAll({ signal: AbortSignal.timeout(5000) });
});
```

## VIdeo demo
Note that both of these are using a button-press to cancel the in flight read operation, but with `AbortSignal.timeout(...)` it could just as easily be driven by a timeout instead:

#### Aborting a chat message (uses `TextStreamReader`)
https://github.com/user-attachments/assets/47081155-971c-47a6-a0da-92119b0b9c9a

#### Aborting a file upload (uses `ByteStreamReader`)
https://github.com/user-attachments/assets/10bf79fc-4df2-4f42-ab7d-02d884fe7a1d
