### PR TITLE
Handle more data stream errors

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -61,7 +61,7 @@ import {
   roomOptionDefaults,
   videoDefaults,
 } from './defaults';
-import { ConnectionError, ConnectionErrorReason, UnsupportedServer } from './errors';
+import { ConnectionError, ConnectionErrorReason, DataStreamError, DataStreamErrorReason, UnsupportedServer } from './errors';
 import { EngineEvent, ParticipantEvent, RoomEvent, TrackEvent } from './events';
 import LocalParticipant from './participant/LocalParticipant';
 import type Participant from './participant/Participant';
@@ -289,7 +289,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   registerTextStreamHandler(topic: string, callback: TextStreamHandler) {
     if (this.textStreamHandlers.has(topic)) {
-      throw new TypeError(`A text stream handler for topic "${topic}" has already been set.`);
+      throw new DataStreamError(
+        `A text stream handler for topic "${topic}" has already been set.`,
+        DataStreamErrorReason.HandlerAlreadyRegistered,
+      );
     }
     this.textStreamHandlers.set(topic, callback);
   }
@@ -300,7 +303,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   registerByteStreamHandler(topic: string, callback: ByteStreamHandler) {
     if (this.byteStreamHandlers.has(topic)) {
-      throw new TypeError(`A byte stream handler for topic "${topic}" has already been set.`);
+      throw new DataStreamError(
+        `A byte stream handler for topic "${topic}" has already been set.`,
+        DataStreamErrorReason.HandlerAlreadyRegistered,
+      );
     }
     this.byteStreamHandlers.set(topic, callback);
   }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1847,6 +1847,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       const stream = new ReadableStream({
         start: (controller) => {
           streamController = controller;
+
+          if (this.textStreamControllers.has(streamHeader.streamId)) {
+            throw new DataStreamError(
+              `A data stream read is already in progress for a stream with id ${streamHeader.streamId}.`,
+              DataStreamErrorReason.AlreadyOpened,
+            );
+          }
+
           this.byteStreamControllers.set(streamHeader.streamId, {
             info,
             controller: streamController,
@@ -1884,6 +1892,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       const stream = new ReadableStream<DataStream_Chunk>({
         start: (controller) => {
           streamController = controller;
+
+          if (this.textStreamControllers.has(streamHeader.streamId)) {
+            throw new DataStreamError(
+              `A data stream read is already in progress for a stream with id ${streamHeader.streamId}.`,
+              DataStreamErrorReason.AlreadyOpened,
+            );
+          }
+
           this.textStreamControllers.set(streamHeader.streamId, {
             info,
             controller: streamController,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -61,7 +61,13 @@ import {
   roomOptionDefaults,
   videoDefaults,
 } from './defaults';
-import { ConnectionError, ConnectionErrorReason, DataStreamError, DataStreamErrorReason, UnsupportedServer } from './errors';
+import {
+  ConnectionError,
+  ConnectionErrorReason,
+  DataStreamError,
+  DataStreamErrorReason,
+  UnsupportedServer,
+} from './errors';
 import { EngineEvent, ParticipantEvent, RoomEvent, TrackEvent } from './events';
 import LocalParticipant from './participant/LocalParticipant';
 import type Participant from './participant/Participant';
@@ -1649,18 +1655,20 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
 
+    // Terminate any in flight data stream receives from the given participant
     const streamsBeingSentByDisconnectingParticipant = [
       ...Array.from(this.textStreamControllers.values()),
       ...Array.from(this.byteStreamControllers.values()),
-    ].filter(controller => controller.sendingParticipantIdentity === identity)
+    ].filter((controller) => controller.sendingParticipantIdentity === identity);
     if (streamsBeingSentByDisconnectingParticipant.length > 0) {
-      const topics = streamsBeingSentByDisconnectingParticipant.map(
-        controller => controller.info.topic
-      );
-      throw new DataStreamError(
-        `Participant ${identity} disconnected in the middle of sending data on these topics: ${topics.join(', ')}`,
-        DataStreamErrorReason.AbnormalEnd,
-      );
+      for (const controller of streamsBeingSentByDisconnectingParticipant) {
+        controller.outOfBandFailureRejectingFuture.reject?.(
+          new DataStreamError(
+            `Participant ${identity} unexpectedly disconnected in the middle of sending data`,
+            DataStreamErrorReason.AbnormalEnd,
+          ),
+        );
+      }
     }
 
     participant.trackPublications.forEach((publication) => {
@@ -1826,7 +1834,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   private async handleStreamHeader(streamHeader: DataStream_Header, participantIdentity: string) {
     if (streamHeader.contentHeader.case === 'byteHeader') {
       const streamHandlerCallback = this.byteStreamHandlers.get(streamHeader.topic);
-
       if (!streamHandlerCallback) {
         this.log.debug(
           'ignoring incoming byte stream due to no handler for topic',
@@ -1834,7 +1841,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         );
         return;
       }
+
       let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
+      const outOfBandFailureRejectingFuture = new Future<never>();
+
       const info: ByteStreamInfo = {
         id: streamHeader.streamId,
         name: streamHeader.contentHeader.value.name ?? 'unknown',
@@ -1860,18 +1870,23 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             controller: streamController,
             startTime: Date.now(),
             sendingParticipantIdentity: participantIdentity,
+            outOfBandFailureRejectingFuture,
           });
         },
       });
       streamHandlerCallback(
-        new ByteStreamReader(info, stream, bigIntToNumber(streamHeader.totalLength)),
+        new ByteStreamReader(
+          info,
+          stream,
+          bigIntToNumber(streamHeader.totalLength),
+          outOfBandFailureRejectingFuture,
+        ),
         {
           identity: participantIdentity,
         },
       );
     } else if (streamHeader.contentHeader.case === 'textHeader') {
       const streamHandlerCallback = this.textStreamHandlers.get(streamHeader.topic);
-
       if (!streamHandlerCallback) {
         this.log.debug(
           'ignoring incoming text stream due to no handler for topic',
@@ -1879,7 +1894,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         );
         return;
       }
+
       let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
+      const outOfBandFailureRejectingFuture = new Future<never>();
       const info: TextStreamInfo = {
         id: streamHeader.streamId,
         mimeType: streamHeader.mimeType,
@@ -1905,11 +1922,17 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             controller: streamController,
             startTime: Date.now(),
             sendingParticipantIdentity: participantIdentity,
+            outOfBandFailureRejectingFuture,
           });
         },
       });
       streamHandlerCallback(
-        new TextStreamReader(info, stream, bigIntToNumber(streamHeader.totalLength)),
+        new TextStreamReader(
+          info,
+          stream,
+          bigIntToNumber(streamHeader.totalLength),
+          outOfBandFailureRejectingFuture,
+        ),
         { identity: participantIdentity },
       );
     }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1649,6 +1649,20 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
 
+    const streamsBeingSentByDisconnectingParticipant = [
+      ...Array.from(this.textStreamControllers.values()),
+      ...Array.from(this.byteStreamControllers.values()),
+    ].filter(controller => controller.sendingParticipantIdentity === identity)
+    if (streamsBeingSentByDisconnectingParticipant.length > 0) {
+      const topics = streamsBeingSentByDisconnectingParticipant.map(
+        controller => controller.info.topic
+      );
+      throw new DataStreamError(
+        `Participant ${identity} disconnected in the middle of sending data on these topics: ${topics.join(', ')}`,
+        DataStreamErrorReason.AbnormalEnd,
+      );
+    }
+
     participant.trackPublications.forEach((publication) => {
       participant.unpublishTrack(publication.trackSid, true);
     });
@@ -1837,6 +1851,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             info,
             controller: streamController,
             startTime: Date.now(),
+            sendingParticipantIdentity: participantIdentity,
           });
         },
       });
@@ -1873,6 +1888,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             info,
             controller: streamController,
             startTime: Date.now(),
+            sendingParticipantIdentity: participantIdentity,
           });
         },
       });

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -88,6 +88,12 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
             rejectingSignalFuture.promise,
           ]);
           if (done) {
+            if (typeof this.totalByteSize === 'number' && this.bytesReceived < this.totalByteSize) {
+              throw new DataStreamError(
+                `Not enough chunk(s) received - expected ${this.totalByteSize} bytes of data total, only received ${this.bytesReceived} bytes`,
+                DataStreamErrorReason.LengthIncomplete,
+              );
+            }
             return { done: true, value: undefined as any };
           } else {
             this.handleChunkReceived(value);
@@ -218,6 +224,12 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
             rejectingSignalFuture.promise,
           ]);
           if (done) {
+            if (typeof this.totalByteSize === 'number' && this.bytesReceived < this.totalByteSize) {
+              throw new DataStreamError(
+                `Not enough chunk(s) received - expected ${this.totalByteSize} bytes of data total, only received ${this.bytesReceived} bytes`,
+                DataStreamErrorReason.LengthIncomplete,
+              );
+            }
             return { done: true, value: undefined };
           } else {
             this.handleChunkReceived(value);

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -38,6 +38,13 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
 export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
   protected handleChunkReceived(chunk: DataStream_Chunk) {
     this.bytesReceived += chunk.content.byteLength;
+    if (typeof this.totalByteSize === 'number' && this.bytesReceived > this.totalByteSize) {
+      throw new DataStreamError(
+        `Extra chunk(s) received - expected ${this.totalByteSize} bytes of data total, received ${this.bytesReceived} bytes`,
+        DataStreamErrorReason.LengthExceeded,
+      );
+    }
+
     const currentProgress = this.totalByteSize
       ? this.bytesReceived / this.totalByteSize
       : undefined;
@@ -152,7 +159,15 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
       return;
     }
     this.receivedChunks.set(index, chunk);
+
     this.bytesReceived += chunk.content.byteLength;
+    if (typeof this.totalByteSize === 'number' && this.bytesReceived > this.totalByteSize) {
+      throw new DataStreamError(
+        `Extra chunk(s) received - expected ${this.totalByteSize} bytes of data total, received ${this.bytesReceived} bytes`,
+        DataStreamErrorReason.LengthExceeded,
+      );
+    }
+
     const currentProgress = this.totalByteSize
       ? this.bytesReceived / this.totalByteSize
       : undefined;

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -1,7 +1,7 @@
 import type { DataStream_Chunk } from '@livekit/protocol';
+import { DataStreamError, DataStreamErrorReason } from './errors';
 import type { BaseStreamInfo, ByteStreamInfo, TextStreamInfo } from './types';
 import { Future, bigIntToNumber } from './utils';
-import { DataStreamError, DataStreamErrorReason } from './errors';
 
 export type BaseStreamReaderReadAllOpts = {
   /** An AbortSignal can be used to terminate reads early. */
@@ -16,6 +16,8 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
   protected _info: T;
 
   protected bytesReceived: number;
+
+  protected outOfBandFailureRejectingFuture?: Future<never>;
 
   get info() {
     return this._info;
@@ -40,11 +42,17 @@ abstract class BaseStreamReader<T extends BaseStreamInfo> {
     }
   }
 
-  constructor(info: T, stream: ReadableStream<DataStream_Chunk>, totalByteSize?: number) {
+  constructor(
+    info: T,
+    stream: ReadableStream<DataStream_Chunk>,
+    totalByteSize?: number,
+    outOfBandFailureRejectingFuture?: Future<never>,
+  ) {
     this.reader = stream;
     this.totalByteSize = totalByteSize;
     this._info = info;
     this.bytesReceived = 0;
+    this.outOfBandFailureRejectingFuture = outOfBandFailureRejectingFuture;
   }
 
   protected abstract handleChunkReceived(chunk: DataStream_Chunk): void;
@@ -99,7 +107,13 @@ export class ByteStreamReader extends BaseStreamReader<ByteStreamInfo> {
         try {
           const { done, value } = await Promise.race([
             reader.read(),
+            // Rejects if this.signal is aborted
             rejectingSignalFuture.promise,
+            // Rejects if something external says it should, like a participant disconnecting, etc
+            this.outOfBandFailureRejectingFuture?.promise ??
+              new Promise<never>(() => {
+                /* never resolves */
+              }),
           ]);
           if (done) {
             this.validateBytesReceived(true);
@@ -161,8 +175,9 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
     info: TextStreamInfo,
     stream: ReadableStream<DataStream_Chunk>,
     totalChunkCount?: number,
+    outOfBandFailureRejectingFuture?: Future<never>,
   ) {
-    super(info, stream, totalChunkCount);
+    super(info, stream, totalChunkCount, outOfBandFailureRejectingFuture);
     this.receivedChunks = new Map();
   }
 
@@ -225,7 +240,13 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
         try {
           const { done, value } = await Promise.race([
             reader.read(),
+            // Rejects if this.signal is aborted
             rejectingSignalFuture.promise,
+            // Rejects if something external says it should, like a participant disconnecting, etc
+            this.outOfBandFailureRejectingFuture?.promise ??
+              new Promise<never>(() => {
+                /* never resolves */
+              }),
           ]);
           if (done) {
             this.validateBytesReceived(true);

--- a/src/room/StreamReader.ts
+++ b/src/room/StreamReader.ts
@@ -1,6 +1,7 @@
 import type { DataStream_Chunk } from '@livekit/protocol';
 import type { BaseStreamInfo, ByteStreamInfo, TextStreamInfo } from './types';
 import { Future, bigIntToNumber } from './utils';
+import { DataStreamError, DataStreamErrorReason } from './errors';
 
 export type BaseStreamReaderReadAllOpts = {
   /** An AbortSignal can be used to terminate reads early. */
@@ -206,9 +207,19 @@ export class TextStreamReader extends BaseStreamReader<TextStreamInfo> {
           } else {
             this.handleChunkReceived(value);
 
+            let decodedResult;
+            try {
+              decodedResult = decoder.decode(value.content);
+            } catch (err) {
+              throw new DataStreamError(
+                `Cannot decode datastream chunk ${value.chunkIndex} as text: ${err}`,
+                DataStreamErrorReason.DecodeFailed,
+              );
+            }
+
             return {
               done: false,
-              value: decoder.decode(value.content),
+              value: decodedResult,
             };
           }
         } catch (err) {

--- a/src/room/errors.ts
+++ b/src/room/errors.ts
@@ -111,6 +111,51 @@ export class SignalRequestError extends LivekitError {
   }
 }
 
+export enum DataStreamErrorReason {
+  // // Unable to open a stream with the same ID more than once.
+  // AlreadyOpened,
+
+  // Stream closed abnormally by remote participant.
+  AbnormalEnd,
+
+  // Incoming chunk data could not be decoded.
+  DecodeFailed, // DONE
+
+  // Read length exceeded total length specified in stream header.
+  LengthExceeded,
+
+  // Read length less than total length specified in stream header.
+  Incomplete,
+
+  // Stream terminated before completion.
+  Terminated,
+
+  // Cannot perform operations on an unknown stream.
+  UnknownStream,
+
+  // Unable to register a stream handler more than once.
+  HandlerAlreadyRegistered, // DONE
+
+  // // Given destination URL is not a directory.
+  // NotDirectory,
+
+  // // Unable to read information about the file to send.
+  // FileInfoUnavailable,
+}
+
+export class DataStreamError extends LivekitError {
+  reason: DataStreamErrorReason;
+
+  reasonName: string;
+
+  constructor(message: string, reason: DataStreamErrorReason) {
+    super(16, message);
+    this.name = 'DataStreamError';
+    this.reason = reason;
+    this.reasonName = DataStreamErrorReason[reason];
+  }
+}
+
 export enum MediaDeviceFailure {
   // user rejected permissions
   PermissionDenied = 'PermissionDenied',

--- a/src/room/errors.ts
+++ b/src/room/errors.ts
@@ -119,7 +119,7 @@ export enum DataStreamErrorReason {
   AbnormalEnd,
 
   // Incoming chunk data could not be decoded.
-  DecodeFailed, // DONE
+  DecodeFailed,
 
   // Read length exceeded total length specified in stream header.
   LengthExceeded,
@@ -134,7 +134,7 @@ export enum DataStreamErrorReason {
   UnknownStream,
 
   // Unable to register a stream handler more than once.
-  HandlerAlreadyRegistered, // DONE
+  HandlerAlreadyRegistered,
 
   // // Given destination URL is not a directory.
   // NotDirectory,

--- a/src/room/errors.ts
+++ b/src/room/errors.ts
@@ -125,7 +125,7 @@ export enum DataStreamErrorReason {
   LengthExceeded,
 
   // Read length less than total length specified in stream header.
-  Incomplete,
+  LengthIncomplete,
 
   // Stream terminated before completion.
   Terminated,

--- a/src/room/errors.ts
+++ b/src/room/errors.ts
@@ -112,8 +112,8 @@ export class SignalRequestError extends LivekitError {
 }
 
 export enum DataStreamErrorReason {
-  // // Unable to open a stream with the same ID more than once.
-  // AlreadyOpened,
+  // Unable to open a stream with the same ID more than once.
+  AlreadyOpened,
 
   // Stream closed abnormally by remote participant.
   AbnormalEnd,

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -1,4 +1,5 @@
 import type { DataStream_Chunk } from '@livekit/protocol';
+import type { Future } from './utils';
 
 export type SimulationOptions = {
   publish?: {
@@ -106,6 +107,7 @@ export interface StreamController<T extends DataStream_Chunk> {
   startTime: number;
   endTime?: number;
   sendingParticipantIdentity?: string;
+  outOfBandFailureRejectingFuture: Future<never>;
 }
 
 export interface BaseStreamInfo {

--- a/src/room/types.ts
+++ b/src/room/types.ts
@@ -105,6 +105,7 @@ export interface StreamController<T extends DataStream_Chunk> {
   controller: ReadableStreamDefaultController<T>;
   startTime: number;
   endTime?: number;
+  sendingParticipantIdentity?: string;
 }
 
 export interface BaseStreamInfo {


### PR DESCRIPTION
After looking at a few other sdks worked, especially the swift sdk, I noticed [there were some data stream-related error cases](https://github.com/livekit/client-sdk-swift/blob/f37bbd260d61e165084962db822c79f995f1a113/Sources/LiveKit/DataStream/StreamError.swift) that this sdk didn't properly handle. Most of these are invariants that shouldn't ever be true in practice and largely only will happen when packets are malformed on the sender end.

So, try to handle these error cases and throw errors to make invalid data fail in a predictable way. A list of error cases:
- If the remote participant disconnects halfway through sending a data stream message, make any currently active `DataStreamReader.readAll` / `DataStreamReader` async iteration operations reject with `new DataStreamError("...", DataStreamErrorReason.AbnormalEnd)`.
- If a client sends text chunks containing data which can not be decoded as a valid utf-8 string, throw a `new  DataStreamError("...", DataStreamError.DecodeFailed)`
- If a client sends a text/byte header containing a `totalSize` parameter and after reading all chunks, the byte lengths all summed up don't equal the expected `totalSize`, then either throw `new DataStreamError("...", DataStreamErrorReason.LengthIncomplete)` if too small, or throw `new DataStreamError("...", DataStreamErrorReason.LengthExceeded)` if too large.
- If `room.registerTextStreamHandler(...)` / `room.registerByteStreamHandler(...)` is called for a topic which already has a handler registered, throw `new DataStreamError("...", DataStreamErrorReason.HandlerAlreadyRegistered)`