### PR TITLE
Add RTCEngine`SupersededBy` event

### DIFF
--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -34,7 +34,6 @@ import { isE2EESupported, isScriptTransformSupported } from './utils';
 
 export interface BaseE2EEManager {
   setup(room: Room): void;
-  setupEngine(engine: RTCEngine): void;
   setParticipantCryptorEnabled(enabled: boolean, participantIdentity: string): void;
   setSifTrailer(trailer: Uint8Array): void;
   on<E extends keyof E2EEManagerCallbacks>(event: E, listener: E2EEManagerCallbacks[E]): this;
@@ -173,6 +172,9 @@ export class E2EEManager
   public setupEngine(engine: RTCEngine) {
     engine.on(EngineEvent.RTPVideoMapUpdate, (rtpMap) => {
       this.postRTPMap(rtpMap);
+    });
+    engine.on(EngineEvent.SupersededBy, (newEngine) => {
+      this.setupEngine(newEngine);
     });
   }
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -94,8 +94,10 @@ enum PCState {
   Closed,
 }
 
+const EngineEventEmitter = EventEmitter as new () => TypedEventEmitter<EngineEventCallbacks>;
+
 /** @internal */
-export default class RTCEngine extends (EventEmitter as new () => TypedEventEmitter<EngineEventCallbacks>) {
+export default class RTCEngine extends EngineEventEmitter {
   client: SignalClient;
 
   rtcConfig: RTCConfiguration = {};

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1580,6 +1580,7 @@ export type EngineEventCallbacks = {
   offline: () => void;
   signalRequestResponse: (response: RequestResponse) => void;
   signalConnected: (joinResp: JoinResponse) => void;
+  supersededBy: (newEngine: RTCEngine) => void;
 };
 
 function supportOptionalDatachannel(protocol: number | undefined): boolean {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -517,6 +517,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       return;
     }
 
+    const oldEngine = this.engine;
     this.engine = new RTCEngine(this.options);
 
     this.engine
@@ -610,12 +611,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         }
       });
 
-    if (this.localParticipant) {
-      this.localParticipant.setupEngine(this.engine);
-    }
-    if (this.e2eeManager) {
-      this.e2eeManager.setupEngine(this.engine);
-    }
+    oldEngine?.emit(EngineEvent.SupersededBy, this.engine);
   }
 
   /**

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -606,6 +606,7 @@ export enum EngineEvent {
   SignalRequestResponse = 'signalRequestResponse',
   SignalConnected = 'signalConnected',
   RoomMoved = 'roomMoved',
+  SupersededBy = 'supersededBy',
 }
 
 export enum TrackEvent {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -234,7 +234,7 @@ export default class LocalParticipant extends Participant {
   /**
    * @internal
    */
-  setupEngine(engine: RTCEngine) {
+  private setupEngine(engine: RTCEngine) {
     this.engine = engine;
     this.engine.on(EngineEvent.RemoteMute, (trackSid: string, muted: boolean) => {
       const pub = this.trackPublications.get(trackSid);
@@ -263,7 +263,8 @@ export default class LocalParticipant extends Participant {
       .on(EngineEvent.SubscribedQualityUpdate, this.handleSubscribedQualityUpdate)
       .on(EngineEvent.Closing, this.handleClosing)
       .on(EngineEvent.SignalRequestResponse, this.handleSignalRequestResponse)
-      .on(EngineEvent.DataPacketReceived, this.handleDataPacket);
+      .on(EngineEvent.DataPacketReceived, this.handleDataPacket)
+      .on(EngineEvent.SupersededBy, this.handleNewEngine);
   }
 
   private handleReconnecting = () => {
@@ -335,6 +336,10 @@ export default class LocalParticipant extends Participant {
         this.handleIncomingRpcAck(rpcAck.requestId);
         break;
     }
+  };
+
+  private handleNewEngine = (newEngine: RTCEngine) => {
+    this.setupEngine(newEngine);
   };
 
   /**


### PR DESCRIPTION
## Problem / Concern
`RTCEngine` gets fully town down and recreated initially when an initial connection is created and also whenever a reconnection occurs. This means that any class that has a reference to `engine` must be informed of this new change so that it can keep its reference to `engine` current.

The current means this is being done is by calling a `setupEngine` method on all dependents - right now, `LocalParticipant` and `E2EEManager`, plus soon `OutgoingDataStreamManager`. This is relatively coupled though because the room needs to call that method on each of these classes!

## Potential solution
The existing approach _works_, but is inelegant. To attempt to solve this in a slightly more elegant way, I've added a new `SupersededBy` event to the `RTCEngine` which is fired on the old engine whenever a new engine is generated, which allows anybody who has the engine to always have the latest copy. 