### PR TITLE
lock all APIs that change underlying track with the same lock

### DIFF
--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -169,7 +169,7 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
   };
 
   async setProcessor(processor: TrackProcessor<Track.Kind.Audio, AudioProcessorOptions>) {
-    const unlock = await this.processorLock.lock();
+    const unlock = await this.restartLock.lock();
     try {
       if (!isReactNative() && !this.audioContext) {
         throw Error(


### PR DESCRIPTION
for local tracks we currently have both a processor lock and a restart lock

We can run into situations where the processor loses track of the actual underlying mediastreamtrack if the track is being restarted while the processor is setting up.

In order to avoid this race, this PR removes the processor lock and instead uses the restart lock also in processor related method calls. 
The biggest risk with this change is that there could be unforeseen situations in which two restartlock acquirations block each other. I did some testing to try to force this, but wasn't able to and also cannot spot anything that would allow this in the code, but asking for reviews to take a close look on whether you can spot anything that might lead to a deadlock with this change.
