### PR TITLE
Check for encrypted track if room unencrypted, and if so, emit an event

### DIFF
--- a/.changeset/tiny-birds-enter.md
+++ b/.changeset/tiny-birds-enter.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Check for encrypted track if room unencrypted, and if so, emit an event

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -258,6 +258,9 @@ const appActions = {
             participant.identity
           }) to ${streamState.toString()}`,
         );
+      })
+      .on(RoomEvent.EncryptionError, (error) => {
+        appendLog(`Error encrypting track data: ${error.message}`);
       });
 
     room.registerTextStreamHandler('lk.chat', async (reader, participant) => {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1409,13 +1409,17 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       }
     }
 
-    participant.addSubscribedMediaTrack(
+    const publication = participant.addSubscribedMediaTrack(
       mediaTrack,
       trackId,
       stream,
       receiver,
       adaptiveStreamSettings,
     );
+
+    if (this.isE2EEEnabled && !publication?.isEncrypted) {
+      throw new Error('Encrypted track received, but room does not have encryption enabled!');
+    }
   }
 
   private handleRestarting = () => {

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1420,7 +1420,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (publication?.isEncrypted && !this.isE2EEEnabled) {
       this.emit(
         RoomEvent.EncryptionError,
-        new Error('Encrypted track received, but room does not have encryption enabled!'),
+        new Error(
+          `Encrypted ${publication.source} track received from participant ${participant.sid}, but room does not have encryption enabled!`,
+        ),
       );
     }
   }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1417,8 +1417,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       adaptiveStreamSettings,
     );
 
-    if (this.isE2EEEnabled && !publication?.isEncrypted) {
-      throw new Error('Encrypted track received, but room does not have encryption enabled!');
+    if (publication?.isEncrypted && !this.isE2EEEnabled) {
+      this.emit(
+        RoomEvent.EncryptionError,
+        new Error('Encrypted track received, but room does not have encryption enabled!'),
+      );
     }
   }
 


### PR DESCRIPTION
If a remote participant joins a room and sends an encrypted track, but the local participant / room is not configured to support encryption, throw an error.

<img width="981" height="531" alt="Screenshot 2025-08-14 at 5 02 57 PM" src="https://github.com/user-attachments/assets/113cd30c-a458-41c3-90db-2ba8e66c2e30" />
