### PR TITLE
Split out typescript updates in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
       "rangeStrategy": "replace",
       "groupName": "LiveKit dependencies",
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor", "major"],
+      "groupName": "typescript (breaking)"
     }
   ]
 }


### PR DESCRIPTION
minor versions for typescript can include breaking changes, so we wouldn't want to bundle the update with other non-breaking dev dependency updates in the same PR