### PR TITLE
fix e2ee decryption enabled detection

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1417,7 +1417,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       adaptiveStreamSettings,
     );
 
-    if (publication?.isEncrypted && !this.isE2EEEnabled) {
+    if (publication?.isEncrypted && !this.e2eeManager) {
       this.emit(
         RoomEvent.EncryptionError,
         new Error(


### PR DESCRIPTION
quick follow up for https://github.com/livekit/client-sdk-js/pull/1627. 

For remote tracks (decryption) we'll have to check for the presence of the `e2eeManager`, because `this.isE2EEEnabled` only indicates whether or not sender encryption is active. 