### PR TITLE
fix(e2ee): h264 publishing with e2ee enabled

### DIFF
--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -11,7 +11,7 @@ import type RemoteTrack from '../room/track/RemoteTrack';
 import type { Track } from '../room/track/Track';
 import type { VideoCodec } from '../room/track/options';
 import { mimeTypeToVideoCodecString } from '../room/track/utils';
-import { isLocalTrack, isVideoTrack } from '../room/utils';
+import { isLocalTrack, isSafariBased, isVideoTrack } from '../room/utils';
 import type { BaseKeyProvider } from './KeyProvider';
 import { E2EE_FLAG } from './constants';
 import { type E2EEManagerCallbacks, EncryptionEvent, KeyProviderEvent } from './events';
@@ -227,7 +227,8 @@ export class E2EEManager
     });
 
     room.localParticipant.on(ParticipantEvent.LocalTrackPublished, (publication) => {
-      if (!isVideoTrack(publication.track)) {
+      // Safari doesn't support retrieving payload information on RTCEncodedVideoFrame, so we need to update the codec manually once we have the trackInfo from the server
+      if (!isVideoTrack(publication.track) || !isSafariBased()) {
         return;
       }
       const msg: UpdateCodecMessage = {
@@ -238,7 +239,6 @@ export class E2EEManager
           participantIdentity: this.room!.localParticipant.identity,
         },
       };
-      console.info('updating local track codec', msg);
 
       this.worker.postMessage(msg);
     });

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -142,7 +142,6 @@ export class FrameCryptor extends BaseFrameCryptor {
    * @param codec
    */
   setVideoCodec(codec: VideoCodec) {
-    workerLogger.info('updating codec on cryptor to', { codec, ...this.logContext });
     this.videoCodec = codec;
   }
 
@@ -267,16 +266,6 @@ export class FrameCryptor extends BaseFrameCryptor {
         encodedFrame.timestamp,
       );
       let frameInfo = this.getUnencryptedBytes(encodedFrame);
-
-      if (encodedFrame instanceof RTCEncodedVideoFrame) {
-        workerLogger.debug('encodedFrame', {
-          manuallySetCodec: this.videoCodec,
-          detectedCodec: this.detectedCodec,
-          encodedFrame,
-          frameInfo,
-          obj: this,
-        });
-      }
 
       // Thіs is not encrypted and contains the VP8 payload descriptor or the Opus TOC byte.
       const frameHeader = new Uint8Array(encodedFrame.data, 0, frameInfo.unencryptedBytes);

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -142,6 +142,7 @@ export class FrameCryptor extends BaseFrameCryptor {
    * @param codec
    */
   setVideoCodec(codec: VideoCodec) {
+    workerLogger.info('updating codec on cryptor to', { codec, ...this.logContext });
     this.videoCodec = codec;
   }
 
@@ -266,6 +267,16 @@ export class FrameCryptor extends BaseFrameCryptor {
         encodedFrame.timestamp,
       );
       let frameInfo = this.getUnencryptedBytes(encodedFrame);
+
+      if (encodedFrame instanceof RTCEncodedVideoFrame) {
+        workerLogger.debug('encodedFrame', {
+          manuallySetCodec: this.videoCodec,
+          detectedCodec: this.detectedCodec,
+          encodedFrame,
+          frameInfo,
+          obj: this,
+        });
+      }
 
       // Thіs is not encrypted and contains the VP8 payload descriptor or the Opus TOC byte.
       const frameHeader = new Uint8Array(encodedFrame.data, 0, frameInfo.unencryptedBytes);

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -98,6 +98,11 @@ onmessage = (ev) => {
         break;
       case 'updateCodec':
         getTrackCryptor(data.participantIdentity, data.trackId).setVideoCodec(data.codec);
+        workerLogger.info('updated codec', {
+          participantIdentity: data.participantIdentity,
+          trackId: data.trackId,
+          codec: data.codec,
+        });
         break;
       case 'setRTPMap':
         // this is only used for the local participant
@@ -151,7 +156,7 @@ function getTrackCryptor(participantIdentity: string, trackId: string) {
   }
   let cryptor = cryptors[0];
   if (!cryptor) {
-    workerLogger.info('creating new cryptor for', { participantIdentity });
+    workerLogger.info('creating new cryptor for', { participantIdentity, trackId });
     if (!keyProviderOptions) {
       throw Error('Missing keyProvider options');
     }

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -215,12 +215,12 @@ export function isE2EESimulcastSupported() {
     } else if (
       browser.os === 'iOS' &&
       browser.osVersion &&
-      compareVersions(supportedSafariVersion, browser.osVersion) >= 0
+      compareVersions(browser.osVersion, supportedSafariVersion) >= 0
     ) {
       return true;
     } else if (
       browser.name === 'Safari' &&
-      compareVersions(supportedSafariVersion, browser.version) >= 0
+      compareVersions(browser.version, supportedSafariVersion) >= 0
     ) {
       return true;
     } else {
@@ -283,6 +283,14 @@ export function getDevicePixelRatio(): number {
   return 1;
 }
 
+/**
+ * @param v1 - The first version string to compare.
+ * @param v2 - The second version string to compare.
+ * @returns A number indicating the order of the versions:
+ *   - 1 if v1 is greater than v2
+ *   - -1 if v1 is less than v2
+ *   - 0 if v1 and v2 are equal
+ */
 export function compareVersions(v1: string, v2: string): number {
   const parts1 = v1.split('.');
   const parts2 = v2.split('.');


### PR DESCRIPTION
we got reports around h264 encrypted tracks publishing only a single layer and also not showing up on the remote side. 

The fix for this is twofold:

- the compare function for the `e2eeSimulcastSupport` was checking the wrong way around
- we now pass codec information to the frame cryptor on track published so that we don't have to rely on the nalu parsing logic for figuring out whether or not the codec is h264 or h265 on Safari