### PR TITLE
Fix local package links breaking on build

### DIFF
--- a/.github/workflows/size-limit.yaml
+++ b/.github/workflows/size-limit.yaml
@@ -24,4 +24,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           script: npx size-limit --json
           package_manager: pnpm
-          build_script: build
+          build_script: build:clean

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,5 +31,5 @@ jobs:
 
     - name: Check browser target compatibility
       run: |
-        pnpm build
+        pnpm build:clean
         pnpm compat

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "rollup --config --bundleConfigAsCjs && rollup --config rollup.config.worker.js --bundleConfigAsCjs && pnpm downlevel-dts",
+    "build:clean": "rm -rf ./dist && pnpm build",
     "build:watch": "rollup --watch --config --bundleConfigAsCjs",
     "build:worker:watch": "rollup --watch --config rollup.config.worker.js --bundleConfigAsCjs",
     "build-docs": "typedoc && mkdir -p docs/assets/github && cp .github/*.png docs/assets/github/ && find docs -name '*.html' -type f -exec sed -i.bak 's|=\"/.github/|=\"assets/github/|g' {} + && find docs -name '*.bak' -delete",
@@ -48,7 +49,7 @@
     "deploy": "gh-pages -d examples/demo/dist",
     "format": "prettier --write src examples/**/*.ts",
     "format:check": "prettier --check src examples/**/*.ts",
-    "ci:publish": "pnpm build && pnpm compat && changeset publish",
+    "ci:publish": "pnpm build:clean && pnpm compat && changeset publish",
     "downlevel-dts": "downlevel-dts ./dist/ ./dist/ts4.2 --to=4.2",
     "compat": "eslint --no-eslintrc --config ./.eslintrc.dist.cjs ./dist/livekit-client.umd.js",
     "size-limit": "size-limit"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
-import del from 'rollup-plugin-delete';
 import typescript from 'rollup-plugin-typescript2';
 import packageJson from './package.json';
 
@@ -51,9 +50,5 @@ export default {
       plugins: [terser()],
     },
   ],
-  plugins: [
-    del({ targets: 'dist/*' }),
-    typescript({ tsconfig: './tsconfig.json' }),
-    ...commonPlugins,
-  ],
+  plugins: [typescript({ tsconfig: './tsconfig.json' }), ...commonPlugins],
 };


### PR DESCRIPTION
previously the rollup build would delete contents of `dist` on every build, which breaks local linking of packages. 