### PR TITLE
Log info about ignored options when unmuting track

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -506,6 +506,18 @@ export default class LocalParticipant extends Participant {
     if (enabled) {
       if (track) {
         await track.unmute();
+        if (options) {
+          this.log.info('ignoring capture options for already published track', {
+            ...this.logContext,
+            source,
+          });
+        }
+        if (publishOptions && publishOptions !== track.options) {
+          this.log.info('ignoring publish options for already published track', {
+            ...this.logContext,
+            source,
+          });
+        }
       } else {
         let localTracks: Array<LocalTrack> | undefined;
         if (this.pendingPublishing.has(source)) {


### PR DESCRIPTION
I'm a bit torn on this – at least in its current state.

The problem is that e.g. `setMicrophoneEnabled` will only consider the CaptureOptions and TrackPublishOptions passed to it the first time it actually results in publishing a track. Subsequent calls only mute/unmute.
That's why it seems reasonable to log an info about the options being ignored. 
However this might get a bit noisy in cases where the same (initial) options get passed each time. 

A couple of ideas that would make it better than the current proposal:

- deep compare of options (for capture options this will get a bit more tricky as we'll have to unwrap the constraints passed to the track itself) and only log when they're not the same as the ones set on the track
- store captureOptions also on the track and do the same shallow compare that we do for TrackPublishOptions in this PR