### PR TITLE
Use WebSocketStream for sequential signal processing

### DIFF
--- a/src/api/WebSocketStream.ts
+++ b/src/api/WebSocketStream.ts
@@ -1,0 +1,88 @@
+// https://github.com/CarterLi/websocketstream-polyfill
+
+export interface WebSocketConnection<T extends ArrayBuffer | string = ArrayBuffer | string> {
+  readable: ReadableStream<T>;
+  writable: WritableStream<T>;
+  protocol: string;
+  extensions: string;
+}
+
+export interface WebSocketCloseInfo {
+  closeCode?: number;
+  reason?: string;
+}
+
+export interface WebSocketStreamOptions {
+  protocols?: string[];
+  signal?: AbortSignal;
+}
+
+/**
+ * [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) with [Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API)
+ *
+ * @see https://web.dev/websocketstream/
+ */
+export class WebSocketStream<T extends ArrayBuffer | string = ArrayBuffer | string> {
+  readonly url: string;
+
+  readonly opened: Promise<WebSocketConnection<T>>;
+
+  readonly closed: Promise<WebSocketCloseInfo>;
+
+  readonly close: (closeInfo?: WebSocketCloseInfo) => void;
+
+  constructor(url: string, options: WebSocketStreamOptions = {}) {
+    if (options.signal?.aborted) {
+      throw new DOMException('This operation was aborted', 'AbortError');
+    }
+
+    this.url = url;
+
+    const ws = new WebSocket(url, options.protocols ?? []);
+    ws.binaryType = 'arraybuffer';
+
+    const closeWithInfo = ({ closeCode: code, reason }: WebSocketCloseInfo = {}) =>
+      ws.close(code, reason);
+
+    this.opened = new Promise((resolve, reject) => {
+      ws.onopen = () => {
+        resolve({
+          readable: new ReadableStream<T>({
+            start(controller) {
+              ws.onmessage = ({ data }) => controller.enqueue(data);
+              ws.onerror = (e) => controller.error(e);
+            },
+            cancel: closeWithInfo,
+          }),
+          writable: new WritableStream<T>({
+            write(chunk) {
+              ws.send(chunk);
+            },
+            abort() {
+              ws.close();
+            },
+            close: closeWithInfo,
+          }),
+          protocol: ws.protocol,
+          extensions: ws.extensions,
+        });
+        ws.removeEventListener('error', reject);
+      };
+      ws.addEventListener('error', reject);
+    });
+
+    this.closed = new Promise<WebSocketCloseInfo>((resolve, reject) => {
+      ws.onclose = ({ code, reason }) => {
+        resolve({ closeCode: code, reason });
+        ws.removeEventListener('error', reject);
+      };
+      ws.addEventListener('error', reject);
+    });
+
+    if (options.signal) {
+      options.signal.onabort = () => ws.close();
+    }
+
+    this.close = closeWithInfo;
+  }
+}

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,3 +1,4 @@
+import { SignalResponse } from '@livekit/protocol';
 import { toHttpUrl, toWebsocketUrl } from '../room/utils';
 
 export function createRtcUrl(url: string, searchParams: URLSearchParams) {
@@ -20,4 +21,13 @@ function ensureTrailingSlash(path: string) {
 function appendUrlPath(urlObj: URL, path: string) {
   urlObj.pathname = `${ensureTrailingSlash(urlObj.pathname)}${path}`;
   return urlObj.toString();
+}
+
+export function parseSignalResponse(value: ArrayBuffer | string) {
+  if (typeof value === 'string') {
+    return SignalResponse.fromJson(JSON.parse(value), { ignoreUnknownFields: true });
+  } else if (value instanceof ArrayBuffer) {
+    return SignalResponse.fromBinary(new Uint8Array(value));
+  }
+  throw new Error(`could not decode websocket message: ${typeof value}`);
 }


### PR DESCRIPTION
This is part of a couple of PRs that work towards signalling handling improvements.

As a first step this PR only swaps out `WebSocket` with a `WebSocketStream` which is based on https://developer.mozilla.org/en-US/docs/Web/API/WebSocketStream.

In follow ups I'd like to move closer to a signalling api layer with a swappable transport that holds references to `ReadableStream<SignalResponse>` and `WritableStream<SignalRequest>`. 
 