### PR TITLE
Ensure permission event is only emitted once for local participant

### DIFF
--- a/.changeset/brown-masks-stop.md
+++ b/.changeset/brown-masks-stop.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ensure permission event is only emitted once for local participant

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -9,7 +9,6 @@ import {
   Encryption_Type,
   JoinResponse,
   ParticipantInfo,
-  ParticipantPermission,
   RequestResponse,
   RequestResponse_Reason,
   RpcAck,
@@ -451,16 +450,6 @@ export default class LocalParticipant extends Participant {
     publishOptions?: TrackPublishOptions,
   ): Promise<LocalTrackPublication | undefined> {
     return this.setTrackEnabled(Track.Source.ScreenShare, enabled, options, publishOptions);
-  }
-
-  /** @internal */
-  setPermissions(permissions: ParticipantPermission): boolean {
-    const prevPermissions = this.permissions;
-    const changed = super.setPermissions(permissions);
-    if (changed && prevPermissions) {
-      this.emit(ParticipantEvent.ParticipantPermissionsChanged, prevPermissions);
-    }
-    return changed;
   }
 
   /** @internal */


### PR DESCRIPTION
fixes #1637 

This was introduced as an oversight when merging initial e2ee encryption https://github.com/livekit/client-sdk-js/pull/557. 

The intention of https://github.com/livekit/client-sdk-js/issues/569 was to move the permission handling logic entirely into the `Participant` class, but #557 re introduced explicit handling on the LocalParticipant by accident