### PR TITLE
Add missing async

### DIFF
--- a/.changeset/famous-mails-ring.md
+++ b/.changeset/famous-mails-ring.md
@@ -2,4 +2,4 @@
 'livekit-client': patch
 ---
 
-add missing async
+internal typing fix - add missing async to postAction

--- a/.changeset/famous-mails-ring.md
+++ b/.changeset/famous-mails-ring.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+add missing async

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -970,7 +970,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    * @internal for testing
    */
   async simulateScenario(scenario: SimulationScenario, arg?: any) {
-    let postAction = () => {};
+    let postAction = async () => {};
     let req: SimulateScenario | undefined;
     switch (scenario) {
       case 'signal-reconnect':


### PR DESCRIPTION
Previously, there was a typescript warning when `await postAction()` was being run because when `postAction` was being initialized, the initial value (which was being overridden later) didn't return a promise, so typescript saw that sometimes effectively `await undefined` was running, which it didn't like, even though this seems valid, albeit weird. So, update the function definition to make it always async.