### PR TITLE
Add video autoplay attributes to PublishVideoCheck

### DIFF
--- a/.changeset/chilly-llamas-grow.md
+++ b/.changeset/chilly-llamas-grow.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add video autoplay attributes to PublishVideoCheck

--- a/src/connectionHelper/checks/publishVideo.ts
+++ b/src/connectionHelper/checks/publishVideo.ts
@@ -46,6 +46,11 @@ export class PublishVideoCheck extends Checker {
     const video = document.createElement('video');
     video.srcObject = stream;
     video.muted = true;
+    video.autoplay = true;
+    video.playsInline = true;
+    // For iOS Safari
+    video.setAttribute('playsinline', 'true');
+    document.body.appendChild(video);
 
     await new Promise<void>((resolve) => {
       video.onplay = () => {


### PR DESCRIPTION
Fixes #1636

### Description

When performing checks on application on iOS Safari, checkForVideo check is stuck, iphone Safari may blocked video from playing

### Solution

Add autoplay and playsinline properties to video element so it plays on safari and check won't get stuck