### PR TITLE
fix: do not close AudioContext when checking for silence

### DIFF
--- a/src/room/track/utils.ts
+++ b/src/room/track/utils.ts
@@ -119,7 +119,10 @@ export async function detectSilence(track: AudioTrack, timeOffset = 200): Promis
     await sleep(timeOffset);
     analyser.getByteTimeDomainData(dataArray);
     const someNoise = dataArray.some((sample) => sample !== 128 && sample !== 0);
-    ctx.close();
+    
+    source.disconnect();
+    analyser.disconnect();
+
     return !someNoise;
   }
   return false;


### PR DESCRIPTION
Fixes #1655 