### PR TITLE
Avoid uncaught errors related to send/disconnect races

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -267,7 +267,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
       // create offer
       if (!this.subscriberPrimary || joinResponse.fastPublish) {
-        this.negotiate();
+        this.negotiate().catch((err) => {
+          log.error(err, this.logContext);
+        });
       }
 
       this.registerOnLineListener();
@@ -1338,7 +1340,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
     if (needNegotiation) {
       // start negotiation
-      this.negotiate();
+      this.negotiate().catch((err) => {
+        log.error(err, this.logContext);
+      });
     }
 
     const targetChannel = this.dataChannelForKind(kind, subscriber);

--- a/src/room/data-stream/incoming/IncomingDataStreamManager.ts
+++ b/src/room/data-stream/incoming/IncomingDataStreamManager.ts
@@ -124,6 +124,9 @@ export default class IncomingDataStreamManager {
 
       let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
       const outOfBandFailureRejectingFuture = new Future<never>();
+      outOfBandFailureRejectingFuture.promise.catch((err) => {
+        this.log.error(err);
+      });
 
       const info: ByteStreamInfo = {
         id: streamHeader.streamId,
@@ -178,6 +181,10 @@ export default class IncomingDataStreamManager {
 
       let streamController: ReadableStreamDefaultController<DataStream_Chunk>;
       const outOfBandFailureRejectingFuture = new Future<never>();
+      outOfBandFailureRejectingFuture.promise.catch((err) => {
+        this.log.error(err);
+      });
+
       const info: TextStreamInfo = {
         id: streamHeader.streamId,
         mimeType: streamHeader.mimeType,


### PR DESCRIPTION
This adds `catch` in a few places to log instead of throwing uncaught errors.

Fixes https://github.com/livekit/client-sdk-js/issues/1673

The RTCEngine change is prompted by the issue description, and is not awaited per https://github.com/livekit/client-sdk-js/issues/1673#issuecomment-3356968383.

The `outOfBandFailureRejectingFuture` catch is prompted by a similar setup to this issue, where the promise can be rejected before anything even starts iterating the stream. In this case, I observed an uncaught "Participant ... unexpectedly disconnected in the middle of sending data" on Participant A when Participant B sends and disconnects concurrently. This probably needs a little extra review as it seems more subtle, but I think the approach is valid. I also confirmed it avoided the uncaught errors in my test app.

No tests here as I didn't find any precedent for such.