### PR TITLE
Add ability to use `TokenSource` in `Room` constructor

### DIFF
--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -3,7 +3,7 @@ import E2EEWorker from '../../src/e2ee/worker/e2ee.worker?worker';
 import type {
   ChatMessage,
   RoomConnectOptions,
-  RoomOptions,
+  RoomOptionsWithTokenSource,
   ScalabilityMode,
   SimulationScenario,
   VideoCaptureOptions,
@@ -109,7 +109,8 @@ const appActions = {
 
     updateSearchParams(url, token, cryptoKey);
 
-    const roomOpts: RoomOptions = {
+    const roomOpts: RoomOptionsWithTokenSource = {
+      tokenSource: TokenSource.literal({ serverUrl: url, participantToken: token }),
       adaptiveStream,
       dynacast,
       audioOutput: {
@@ -151,22 +152,17 @@ const appActions = {
         iceTransportPolicy: 'relay',
       };
     }
-    await appActions.connectToRoom(url, token, roomOpts, connectOpts, shouldPublish);
+    await appActions.connectToRoom(roomOpts, connectOpts, shouldPublish);
 
     state.bitrateInterval = setInterval(renderBitrate, 1000);
   },
 
   connectToRoom: async (
-    url: string,
-    token: string,
-    roomOptions?: RoomOptions,
+    roomOptions?: RoomOptionsWithTokenSource,
     connectOptions?: RoomConnectOptions,
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {
-    const room = new Room({
-      roomOptions,
-      tokenSource: TokenSource.literal({ serverUrl: url, participantToken: token }),
-    });
+    const room = new Room(roomOptions);
 
     startTime = Date.now();
     await room.prepareConnection();

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -130,10 +130,10 @@ const appActions = {
       videoCaptureDefaults: {
         resolution: VideoPresets.h720.resolution,
       },
-      encryption: e2eeEnabled
-        ? { keyProvider: state.e2eeKeyProvider, worker: new E2EEWorker() }
-        : undefined,
-    } satisfies RoomOptionsWithTokenSourceFixed;
+      // encryption: e2eeEnabled
+      //   ? { keyProvider: state.e2eeKeyProvider, worker: new E2EEWorker() }
+      //   : undefined,
+    };
     if (
       roomOpts.publishDefaults?.videoCodec === 'av1' ||
       roomOpts.publishDefaults?.videoCodec === 'vp9'

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -6,6 +6,9 @@ import type {
   RoomOptionsWithTokenSource,
   ScalabilityMode,
   SimulationScenario,
+  TokenSourceConfigurable,
+  TokenSourceFixed,
+  TokenSourceLiteral,
   VideoCaptureOptions,
   VideoCodec,
 } from '../../src/index';
@@ -109,7 +112,7 @@ const appActions = {
 
     updateSearchParams(url, token, cryptoKey);
 
-    const roomOpts: RoomOptionsWithTokenSource = {
+    const roomOpts = {
       tokenSource: TokenSource.literal({ serverUrl: url, participantToken: token }),
       adaptiveStream,
       dynacast,
@@ -133,7 +136,7 @@ const appActions = {
       encryption: e2eeEnabled
         ? { keyProvider: state.e2eeKeyProvider, worker: new E2EEWorker() }
         : undefined,
-    };
+    } satisfies RoomOptionsWithTokenSource;
     if (
       roomOpts.publishDefaults?.videoCodec === 'av1' ||
       roomOpts.publishDefaults?.videoCodec === 'vp9'
@@ -158,7 +161,7 @@ const appActions = {
   },
 
   connectToRoom: async (
-    roomOptions?: RoomOptionsWithTokenSource,
+    roomOptions?: RoomOptionsWithTokenSource<TokenSourceFixed>,
     connectOptions?: RoomConnectOptions,
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -3,12 +3,9 @@ import E2EEWorker from '../../src/e2ee/worker/e2ee.worker?worker';
 import type {
   ChatMessage,
   RoomConnectOptions,
-  RoomOptionsWithTokenSourceFixed,
+  RoomOptionsTokenSourceFixed,
   ScalabilityMode,
   SimulationScenario,
-  TokenSourceConfigurable,
-  TokenSourceFixed,
-  TokenSourceLiteral,
   VideoCaptureOptions,
   VideoCodec,
 } from '../../src/index';
@@ -26,7 +23,6 @@ import {
   RemoteTrackPublication,
   Room,
   RoomEvent,
-  RoomOptions,
   ScreenSharePresets,
   TokenSource,
   Track,
@@ -113,7 +109,7 @@ const appActions = {
 
     updateSearchParams(url, token, cryptoKey);
 
-    const roomOpts = {
+    const roomOpts: RoomOptionsTokenSourceFixed = {
       tokenSource: TokenSource.literal({ serverUrl: url, participantToken: token }),
       adaptiveStream,
       dynacast,
@@ -162,7 +158,7 @@ const appActions = {
   },
 
   connectToRoom: async (
-    roomOptions?: RoomOptionsWithTokenSourceFixed,
+    roomOptions?: RoomOptionsTokenSourceFixed,
     connectOptions?: RoomConnectOptions,
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -3,7 +3,7 @@ import E2EEWorker from '../../src/e2ee/worker/e2ee.worker?worker';
 import type {
   ChatMessage,
   RoomConnectOptions,
-  RoomOptionsWithTokenSource,
+  RoomOptionsWithTokenSourceFixed,
   ScalabilityMode,
   SimulationScenario,
   TokenSourceConfigurable,
@@ -26,6 +26,7 @@ import {
   RemoteTrackPublication,
   Room,
   RoomEvent,
+  RoomOptions,
   ScreenSharePresets,
   TokenSource,
   Track,
@@ -136,7 +137,7 @@ const appActions = {
       encryption: e2eeEnabled
         ? { keyProvider: state.e2eeKeyProvider, worker: new E2EEWorker() }
         : undefined,
-    } satisfies RoomOptionsWithTokenSource;
+    } satisfies RoomOptionsWithTokenSourceFixed;
     if (
       roomOpts.publishDefaults?.videoCodec === 'av1' ||
       roomOpts.publishDefaults?.videoCodec === 'vp9'
@@ -161,7 +162,7 @@ const appActions = {
   },
 
   connectToRoom: async (
-    roomOptions?: RoomOptionsWithTokenSource<TokenSourceFixed>,
+    roomOptions?: RoomOptionsWithTokenSourceFixed,
     connectOptions?: RoomConnectOptions,
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -24,6 +24,7 @@ import {
   Room,
   RoomEvent,
   ScreenSharePresets,
+  TokenSource,
   Track,
   TrackPublication,
   VideoPresets,
@@ -162,10 +163,13 @@ const appActions = {
     connectOptions?: RoomConnectOptions,
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {
-    const room = new Room(roomOptions);
+    const room = Room.withTokenSource(
+      TokenSource.literal({ serverUrl: url, participantToken: token }),
+      roomOptions,
+    );
 
     startTime = Date.now();
-    await room.prepareConnection(url, token);
+    await room.prepareConnection();
     const prewarmTime = Date.now() - startTime;
     appendLog(`prewarmed connection in ${prewarmTime}ms`);
     room.localParticipant.on(ParticipantEvent.LocalTrackCpuConstrained, (track, publication) => {
@@ -407,7 +411,7 @@ const appActions = {
           reject(error);
         }
       });
-      await Promise.all([room.connect(url, token, connectOptions), publishPromise]);
+      await Promise.all([room.connect(connectOptions), publishPromise]);
       const elapsed = Date.now() - startTime;
       appendLog(
         `successfully connected to ${room.name} in ${Math.round(elapsed)}ms`,

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -163,10 +163,10 @@ const appActions = {
     connectOptions?: RoomConnectOptions,
     shouldPublish?: boolean,
   ): Promise<Room | undefined> => {
-    const room = Room.withTokenSource(
-      TokenSource.literal({ serverUrl: url, participantToken: token }),
+    const room = new Room({
       roomOptions,
-    );
+      tokenSource: TokenSource.literal({ serverUrl: url, participantToken: token }),
+    });
 
     startTime = Date.now();
     await room.prepareConnection();

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,7 +16,7 @@ export interface WebAudioSettings {
 /**
  * @internal
  */
-export interface InternalRoomOptions {
+export interface InternalRoomOptions extends Partial<TokenSourceFetchOptions> {
   /**
    * AdaptiveStream lets LiveKit automatically manage quality of subscribed
    * video tracks to optimize for bandwidth and CPU.
@@ -102,26 +102,23 @@ export interface InternalRoomOptions {
   loggerName?: string;
 
   tokenSource?: TokenSourceConfigurable | TokenSourceFixed;
-  tokenSourceFetchOptions?: TokenSourceFetchOptions;
 }
 
 /**
  * Options for when creating a new room
  */
-export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'encryption'>> {}
+export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'tokenSource' | 'encryption'>> {}
 
-export interface RoomOptionsWithTokenSourceConfigurable extends Partial<Omit<InternalRoomOptions, 'encryption'>> {
+export interface RoomOptionsWithTokenSourceConfigurable extends Partial<Omit<InternalRoomOptions, 'tokenSource' | 'encryption'>> {
   tokenSource: TokenSourceConfigurable;
-  tokenSourceFetchOptions: TokenSourceFetchOptions;
 }
 
-export interface RoomOptionsWithTokenSourceFixed extends Partial<Omit<InternalRoomOptions, 'encryption'>> {
+export interface RoomOptionsWithTokenSourceFixed extends Partial<
+  Omit<InternalRoomOptions, 'tokenSource' | keyof TokenSourceFetchOptions | 'encryption'> &
+  { [P in keyof TokenSourceFetchOptions]: never }
+> {
   tokenSource: TokenSourceFixed;
 }
-
-export type RoomOptionsWithTokenSource<
-  TokenSource extends TokenSourceConfigurable | TokenSourceFixed = TokenSourceConfigurable | TokenSourceFixed,
-> = TokenSource extends TokenSourceConfigurable ? RoomOptionsWithTokenSourceConfigurable : RoomOptionsWithTokenSourceFixed;
 
 /**
  * @internal

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import type { E2EEOptions } from './e2ee/types';
 import type { ReconnectPolicy } from './room/ReconnectPolicy';
-import type { TokenSourceConfigurable, TokenSourceFixed } from './room/token-source/types';
+import type { TokenSourceConfigurable, TokenSourceFetchOptions, TokenSourceFixed } from './room/token-source/types';
 import type {
   AudioCaptureOptions,
   AudioOutputOptions,
@@ -100,6 +100,9 @@ export interface InternalRoomOptions {
   encryption?: E2EEOptions;
 
   loggerName?: string;
+
+  tokenSource?: TokenSourceConfigurable | TokenSourceFixed;
+  tokenSourceFetchOptions?: TokenSourceFetchOptions;
 }
 
 /**
@@ -107,11 +110,18 @@ export interface InternalRoomOptions {
  */
 export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'encryption'>> {}
 
-export interface RoomOptionsWithTokenSource<
-  TokenSource extends TokenSourceConfigurable | TokenSourceFixed = TokenSourceConfigurable | TokenSourceFixed,
-> extends Partial<InternalRoomOptions> {
-  tokenSource: TokenSource;
+export interface RoomOptionsWithTokenSourceConfigurable extends Partial<Omit<InternalRoomOptions, 'encryption'>> {
+  tokenSource: TokenSourceConfigurable;
+  tokenSourceFetchOptions: TokenSourceFetchOptions;
 }
+
+export interface RoomOptionsWithTokenSourceFixed extends Partial<Omit<InternalRoomOptions, 'encryption'>> {
+  tokenSource: TokenSourceFixed;
+}
+
+export type RoomOptionsWithTokenSource<
+  TokenSource extends TokenSourceConfigurable | TokenSourceFixed = TokenSourceConfigurable | TokenSourceFixed,
+> = TokenSource extends TokenSourceConfigurable ? RoomOptionsWithTokenSourceConfigurable : RoomOptionsWithTokenSourceFixed;
 
 /**
  * @internal

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import type { E2EEOptions } from './e2ee/types';
 import type { ReconnectPolicy } from './room/ReconnectPolicy';
-import type { TokenSourceConfigurable, TokenSourceFetchOptions, TokenSourceFixed } from './room/token-source/types';
+import type { TokenSourceConfigurable, TokenSourceFixed } from './room/token-source/types';
 import type {
   AudioCaptureOptions,
   AudioOutputOptions,
@@ -107,10 +107,8 @@ export interface InternalRoomOptions {
  */
 export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'encryption'>> {}
 
-export interface RoomOptionsWithTokenSource<
-  TokenSource extends TokenSourceConfigurable | TokenSourceFixed = TokenSourceConfigurable | TokenSourceFixed,
-> extends Partial<InternalRoomOptions> {
-  tokenSource: TokenSource;
+export interface RoomOptionsWithTokenSource extends Partial<InternalRoomOptions> {
+  tokenSource: TokenSourceConfigurable | TokenSourceFixed;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import type { E2EEOptions } from './e2ee/types';
 import type { ReconnectPolicy } from './room/ReconnectPolicy';
-import type { TokenSource } from './room/token-source/types';
+import type { TokenSourceConfigurable, TokenSourceFixed } from './room/token-source/types';
 import type {
   AudioCaptureOptions,
   AudioOutputOptions,
@@ -100,8 +100,6 @@ export interface InternalRoomOptions {
   encryption?: E2EEOptions;
 
   loggerName?: string;
-
-  tokenSource: TokenSource;
 }
 
 /**
@@ -110,7 +108,7 @@ export interface InternalRoomOptions {
 export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'encryption'>> {}
 
 export interface RoomOptionsWithTokenSource extends Partial<InternalRoomOptions> {
-  tokenSource: TokenSource;
+  tokenSource: TokenSourceConfigurable | TokenSourceFixed;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -107,8 +107,10 @@ export interface InternalRoomOptions {
  */
 export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'encryption'>> {}
 
-export interface RoomOptionsWithTokenSource extends Partial<InternalRoomOptions> {
-  tokenSource: TokenSourceConfigurable | TokenSourceFixed;
+export interface RoomOptionsWithTokenSource<
+  TokenSource extends TokenSourceConfigurable | TokenSourceFixed = TokenSourceConfigurable | TokenSourceFixed,
+> extends Partial<InternalRoomOptions> {
+  tokenSource: TokenSource;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import type { E2EEOptions } from './e2ee/types';
 import type { ReconnectPolicy } from './room/ReconnectPolicy';
-import type { TokenSourceConfigurable, TokenSourceFixed } from './room/token-source/types';
+import type { TokenSourceConfigurable, TokenSourceFetchOptions, TokenSourceFixed } from './room/token-source/types';
 import type {
   AudioCaptureOptions,
   AudioOutputOptions,
@@ -107,8 +107,10 @@ export interface InternalRoomOptions {
  */
 export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'encryption'>> {}
 
-export interface RoomOptionsWithTokenSource extends Partial<InternalRoomOptions> {
-  tokenSource: TokenSourceConfigurable | TokenSourceFixed;
+export interface RoomOptionsWithTokenSource<
+  TokenSource extends TokenSourceConfigurable | TokenSourceFixed = TokenSourceConfigurable | TokenSourceFixed,
+> extends Partial<InternalRoomOptions> {
+  tokenSource: TokenSource;
 }
 
 /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,6 @@
 import type { E2EEOptions } from './e2ee/types';
 import type { ReconnectPolicy } from './room/ReconnectPolicy';
+import type { TokenSource } from './room/token-source/types';
 import type {
   AudioCaptureOptions,
   AudioOutputOptions,
@@ -99,12 +100,18 @@ export interface InternalRoomOptions {
   encryption?: E2EEOptions;
 
   loggerName?: string;
+
+  tokenSource: TokenSource;
 }
 
 /**
  * Options for when creating a new room
  */
 export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'encryption'>> {}
+
+export interface RoomOptionsWithTokenSource extends Partial<InternalRoomOptions> {
+  tokenSource: TokenSource;
+}
 
 /**
  * @internal

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,10 +13,7 @@ export interface WebAudioSettings {
   audioContext: AudioContext;
 }
 
-/**
- * @internal
- */
-export interface InternalRoomOptions extends Partial<TokenSourceFetchOptions> {
+interface InternalRoomOptionsBase {
   /**
    * AdaptiveStream lets LiveKit automatically manage quality of subscribed
    * video tracks to optimize for bandwidth and CPU.
@@ -105,20 +102,24 @@ export interface InternalRoomOptions extends Partial<TokenSourceFetchOptions> {
 }
 
 /**
+ * @internal
+ */
+export type InternalRoomOptions = InternalRoomOptionsBase & Partial<TokenSourceFetchOptions> & {
+  tokenSource?: TokenSourceFixed | TokenSourceConfigurable;
+};
+
+/**
  * Options for when creating a new room
  */
-export interface RoomOptions extends Partial<Omit<InternalRoomOptions, 'tokenSource' | 'encryption'>> {}
+export type RoomOptions = Partial<Omit<InternalRoomOptions, 'tokenSource' | 'encryption'>>;
 
-export interface RoomOptionsWithTokenSourceConfigurable extends Partial<Omit<InternalRoomOptions, 'tokenSource' | 'encryption'>> {
-  tokenSource: TokenSourceConfigurable;
-}
-
-export interface RoomOptionsWithTokenSourceFixed extends Partial<
-  Omit<InternalRoomOptions, 'tokenSource' | keyof TokenSourceFetchOptions | 'encryption'> &
-  { [P in keyof TokenSourceFetchOptions]: never }
-> {
+export type RoomOptionsTokenSourceFixed = RoomOptions & {
   tokenSource: TokenSourceFixed;
-}
+};
+
+export type RoomOptionsTokenSourceConfigurable = RoomOptions & TokenSourceFetchOptions & {
+  tokenSource: TokenSourceConfigurable;
+};
 
 /**
  * @internal

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -41,8 +41,8 @@ import type {
   InternalRoomOptions,
   RoomConnectOptions,
   RoomOptions,
-  RoomOptionsWithTokenSourceConfigurable,
-  RoomOptionsWithTokenSourceFixed,
+  RoomOptionsTokenSourceConfigurable,
+  RoomOptionsTokenSourceFixed,
 } from '../options';
 import { getBrowser } from '../utils/browserParser';
 import DeviceManager from './DeviceManager';
@@ -72,6 +72,7 @@ import CriticalTimers from './timers';
 import {
   TokenSourceConfigurable,
   TokenSourceFixed,
+  type TokenSourceFetchOptions,
   type TokenSourceResponseObject,
 } from './token-source/types';
 import LocalAudioTrack from './track/LocalAudioTrack';
@@ -125,6 +126,8 @@ export enum ConnectionState {
 
 const connectionReconcileFrequency = 4 * 1000;
 
+type BlockTokenSourceFetchOptions = { [P in keyof TokenSourceFetchOptions]: never };
+
 /**
  * In LiveKit, a room is the logical grouping for a list of participants.
  * Participants in a room can publish tracks, and subscribe to others' tracks.
@@ -134,7 +137,7 @@ const connectionReconcileFrequency = 4 * 1000;
  * @noInheritDoc
  */
 class Room<
-  Options extends RoomOptionsWithTokenSourceFixed | RoomOptionsWithTokenSourceConfigurable | RoomOptions = RoomOptions,
+  Options extends (RoomOptionsTokenSourceFixed & BlockTokenSourceFetchOptions) | RoomOptionsTokenSourceConfigurable | (RoomOptions & BlockTokenSourceFetchOptions) = RoomOptions,
 > extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) {
   state: ConnectionState = ConnectionState.Disconnected;
 
@@ -609,7 +612,7 @@ class Room<
    * With LiveKit Cloud, it will also determine the best edge data center for
    * the current client to connect to if a token is provided.
    */
-  prepareConnection: Options extends RoomOptionsWithTokenSourceConfigurable | RoomOptionsWithTokenSourceFixed
+  prepareConnection: Options extends RoomOptionsTokenSourceConfigurable | RoomOptionsTokenSourceFixed
     ? {
         (): Promise<void>;
       }
@@ -654,7 +657,7 @@ class Room<
     }
   };
 
-  connect: Options extends RoomOptionsWithTokenSourceConfigurable | RoomOptionsWithTokenSourceFixed
+  connect: Options extends RoomOptionsTokenSourceConfigurable | RoomOptionsTokenSourceFixed
     ? {
         (opts?: RoomConnectOptions): Promise<void>;
       }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -70,7 +70,6 @@ import { MAX_PAYLOAD_BYTES, RpcError, type RpcInvocationData, byteLength } from 
 import CriticalTimers from './timers';
 import {
   TokenSourceConfigurable,
-  type TokenSourceFetchOptions,
   TokenSourceFixed,
   type TokenSourceResponseObject,
 } from './token-source/types';
@@ -178,10 +177,6 @@ class Room<
 
   /** future holding client initiated connection attempt */
   private connectFuture?: Future<void>;
-
-  private tokenSource?: Options extends RoomOptionsWithTokenSource<infer TS> ? TS : never;
-
-  private tokenSourceFetchOptions: TokenSourceFetchOptions = {};
 
   private disconnectLock: Mutex;
 
@@ -593,10 +588,10 @@ class Room<
     });
 
   async tokenSourceFetch(): Promise<TokenSourceResponseObject | null> {
-    if (this.tokenSource instanceof TokenSourceConfigurable) {
-      return this.tokenSource.fetch(this.tokenSourceFetchOptions);
-    } else if (this.tokenSource instanceof TokenSourceFixed) {
-      return this.tokenSource.fetch();
+    if (this.options.tokenSource instanceof TokenSourceConfigurable) {
+      return this.options.tokenSource.fetch(this.options.tokenSourceFetchOptions ?? {});
+    } else if (this.options.tokenSource instanceof TokenSourceFixed) {
+      return this.options.tokenSource.fetch();
     } else {
       return null;
     }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -133,7 +133,7 @@ const connectionReconcileFrequency = 4 * 1000;
  * @noInheritDoc
  */
 class Room<
-  OPTIONS extends RoomOptionsWithTokenSource | RoomOptions = RoomOptions,
+  Options extends RoomOptionsWithTokenSource | RoomOptions = RoomOptions,
 > extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) {
   state: ConnectionState = ConnectionState.Disconnected;
 
@@ -179,7 +179,7 @@ class Room<
   /** future holding client initiated connection attempt */
   private connectFuture?: Future<void>;
 
-  private tokenSource?: TokenSourceConfigurable | TokenSourceFixed;
+  private tokenSource?: Options extends RoomOptionsWithTokenSource<infer TS> ? TS : never;
 
   private tokenSourceFetchOptions: TokenSourceFetchOptions = {};
 
@@ -220,7 +220,7 @@ class Room<
    * Creates a new Room, the primary construct for a LiveKit session.
    * @param options
    */
-  constructor(options?: OPTIONS) {
+  constructor(options?: Options) {
     super();
     this.setMaxListeners(100);
     this.remoteParticipants = new Map();
@@ -611,7 +611,7 @@ class Room<
    * With LiveKit Cloud, it will also determine the best edge data center for
    * the current client to connect to if a token is provided.
    */
-  prepareConnection: OPTIONS extends RoomOptionsWithTokenSource
+  prepareConnection: Options extends RoomOptionsWithTokenSource
     ? {
         (): Promise<void>;
       }
@@ -656,7 +656,7 @@ class Room<
     }
   };
 
-  connect: OPTIONS extends RoomOptionsWithTokenSource
+  connect: Options extends RoomOptionsWithTokenSource
     ? {
         (opts?: RoomConnectOptions): Promise<void>;
       }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -41,6 +41,7 @@ import type {
   InternalRoomOptions,
   RoomConnectOptions,
   RoomOptions,
+  RoomOptionsWithTokenSource,
 } from '../options';
 import { getBrowser } from '../utils/browserParser';
 import DeviceManager from './DeviceManager';
@@ -73,7 +74,6 @@ import {
   TokenSourceFixed,
   type TokenSourceResponseObject,
 } from './token-source/types';
-import { extractTokenSourceOptionsFromObject } from './token-source/utils';
 import LocalAudioTrack from './track/LocalAudioTrack';
 import type LocalTrack from './track/LocalTrack';
 import LocalTrackPublication from './track/LocalTrackPublication';
@@ -133,7 +133,7 @@ const connectionReconcileFrequency = 4 * 1000;
  * @noInheritDoc
  */
 class Room<
-  RoomTokenSource extends TokenSource | undefined = TokenSource | undefined,
+  OPTIONS extends RoomOptionsWithTokenSource | RoomOptions = RoomOptions,
 > extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) {
   state: ConnectionState = ConnectionState.Disconnected;
 
@@ -220,7 +220,7 @@ class Room<
    * Creates a new Room, the primary construct for a LiveKit session.
    * @param options
    */
-  constructor(options?: RoomOptions) {
+  constructor(options?: OPTIONS) {
     super();
     this.setMaxListeners(100);
     this.remoteParticipants = new Map();
@@ -298,22 +298,6 @@ class Room<
         });
       }
     }
-  }
-
-  static withTokenSource<TS extends TokenSourceFixed>(
-    tokenSource: TS,
-    options?: RoomOptions,
-  ): Room<TS>;
-  static withTokenSource<TS extends TokenSourceConfigurable>(
-    tokenSource: TS,
-    options?: RoomOptions & TokenSourceOptions,
-  ): Room<TS>;
-  static withTokenSource(tokenSource: TokenSource, options?: RoomOptions & TokenSourceOptions) {
-    const tokenSourceOptions = extractTokenSourceOptionsFromObject(options ?? {});
-    const room = new Room<TokenSource>(options);
-    room.tokenSource = tokenSource;
-    room.tokenSourceOptions = tokenSourceOptions;
-    return room;
   }
 
   registerTextStreamHandler(topic: string, callback: TextStreamHandler) {
@@ -627,13 +611,12 @@ class Room<
    * With LiveKit Cloud, it will also determine the best edge data center for
    * the current client to connect to if a token is provided.
    */
-  prepareConnection: RoomTokenSource extends undefined
+  prepareConnection: OPTIONS extends RoomOptionsWithTokenSource
     ? {
-        /** @deprecated use Room.withTokenSource(tokenSource, roomOpts) instead. */
-        (url: string, token?: string): Promise<void>;
+        (): Promise<void>;
       }
     : {
-        (): Promise<void>;
+        (url: string, token?: string): Promise<void>;
       } = async (urlOrUnset?: string, tokenOrUnset?: string) => {
     let url;
     let token = tokenOrUnset;
@@ -673,13 +656,12 @@ class Room<
     }
   };
 
-  connect: RoomTokenSource extends undefined
+  connect: OPTIONS extends RoomOptionsWithTokenSource
     ? {
-        /** @deprecated use Room.withTokenSource(tokenSource, roomOpts) instead. */
-        (url: string, token: string, opts?: RoomConnectOptions): Promise<void>;
+        (opts?: RoomConnectOptions): Promise<void>;
       }
     : {
-        (opts?: RoomConnectOptions): Promise<void>;
+        (url: string, token: string, opts?: RoomConnectOptions): Promise<void>;
       } = async (
     urlOrOpts: RoomConnectOptions extends undefined ? string : any,
     tokenOrUnset?: string,

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -113,7 +113,6 @@ import {
   unpackStreamId,
   unwrapConstraint,
 } from './utils';
-import { extractTokenSourceOptionsFromObject } from './token-source/utils';
 
 export enum ConnectionState {
   Disconnected = 'disconnected',
@@ -180,7 +179,9 @@ class Room<
   /** future holding client initiated connection attempt */
   private connectFuture?: Future<void>;
 
-  /* private */ tokenSource?: Options extends RoomOptionsWithTokenSource<infer TS> ? TS : never;
+  private tokenSource?: Options extends RoomOptionsWithTokenSource<infer TS> ? TS : never;
+
+  private tokenSourceFetchOptions: TokenSourceFetchOptions = {};
 
   private disconnectLock: Mutex;
 
@@ -591,9 +592,9 @@ class Room<
       cleanup();
     });
 
-  private async tokenSourceFetch(options: TokenSourceFetchOptions = {}): Promise<TokenSourceResponseObject | null> {
+  async tokenSourceFetch(): Promise<TokenSourceResponseObject | null> {
     if (this.tokenSource instanceof TokenSourceConfigurable) {
-      return this.tokenSource.fetch(options);
+      return this.tokenSource.fetch(this.tokenSourceFetchOptions);
     } else if (this.tokenSource instanceof TokenSourceFixed) {
       return this.tokenSource.fetch();
     } else {
@@ -610,25 +611,26 @@ class Room<
    * With LiveKit Cloud, it will also determine the best edge data center for
    * the current client to connect to if a token is provided.
    */
-  prepareConnection = (async (
-    urlOrOptionsOrUnset?: string | TokenSourceFetchOptions,
-    tokenOrUnset?: string
-  ) => {
+  prepareConnection: Options extends RoomOptionsWithTokenSource
+    ? {
+        (): Promise<void>;
+      }
+    : {
+        (url: string, token?: string): Promise<void>;
+      } = async (urlOrUnset?: string, tokenOrUnset?: string) => {
     let url;
     let token = tokenOrUnset;
 
-    if (typeof urlOrOptionsOrUnset === 'string') {
-      url = urlOrOptionsOrUnset;
+    const tokenSourceFetchResponse = await this.tokenSourceFetch();
+    if (tokenSourceFetchResponse) {
+      url = tokenSourceFetchResponse.serverUrl;
+      token = token ?? tokenSourceFetchResponse.participantToken;
+    } else if (typeof urlOrUnset === 'string') {
+      url = urlOrUnset;
     } else {
-      const tokenSourceFetchResponse = await this.tokenSourceFetch(urlOrOptionsOrUnset);
-      if (tokenSourceFetchResponse) {
-        url = tokenSourceFetchResponse.serverUrl;
-        token = token ?? tokenSourceFetchResponse.participantToken;
-      } else {
-        throw new Error(
-          `Room.prepareConnection received invalid parameters - expected url, url/token or tokenSource, received ${urlOrOptionsOrUnset}, ${tokenOrUnset}.`,
-        );
-      }
+      throw new Error(
+        `Room.prepareConnection received invalid parameters - expected url, url/token or tokenSource, received ${urlOrUnset}, ${tokenOrUnset}.`,
+      );
     }
 
     if (this.state !== ConnectionState.Disconnected) {
@@ -652,10 +654,16 @@ class Room<
     } catch (e) {
       this.log.warn('could not prepare connection', { ...this.logContext, error: e });
     }
-  }) as RoomPrepareConnectionFn<Options>;
+  };
 
-  connect = (async (
-    urlOrOpts: string | RoomConnectOptions | (TokenSourceFetchOptions & RoomConnectOptions),
+  connect: Options extends RoomOptionsWithTokenSource
+    ? {
+        (opts?: RoomConnectOptions): Promise<void>;
+      }
+    : {
+        (url: string, token: string, opts?: RoomConnectOptions): Promise<void>;
+      } = async (
+    urlOrOpts: RoomConnectOptions extends undefined ? string : any,
     tokenOrUnset?: string,
     optsOrUnset?: RoomConnectOptions,
   ) => {
@@ -663,22 +671,15 @@ class Room<
     let token: string;
     let opts: RoomConnectOptions | undefined;
 
-    if (typeof urlOrOpts === 'string' && typeof tokenOrUnset === 'string') {
+    const tokenSourceFetchResponse = await this.tokenSourceFetch();
+    if (tokenSourceFetchResponse && typeof urlOrOpts !== 'string') {
+      url = tokenSourceFetchResponse.serverUrl;
+      token = tokenSourceFetchResponse.participantToken;
+      opts = urlOrOpts;
+    } else if (typeof urlOrOpts === 'string' && typeof tokenOrUnset === 'string') {
       url = urlOrOpts;
       token = tokenOrUnset;
       opts = optsOrUnset;
-    } else if (typeof urlOrOpts !== 'string') {
-      const [tokenSourceFetchOptions, roomConnectOptions] = extractTokenSourceOptionsFromObject<RoomConnectOptions>(urlOrOpts);
-      const tokenSourceFetchResponse = await this.tokenSourceFetch(tokenSourceFetchOptions);
-      if (tokenSourceFetchResponse) {
-        url = tokenSourceFetchResponse.serverUrl;
-        token = tokenSourceFetchResponse.participantToken;
-        opts = roomConnectOptions;
-      } else {
-        throw new Error(
-          `Room.connect constructed without TokenSource received invalid parameters - expected url/token, received ${urlOrOpts}`,
-        );
-      }
     } else {
       throw new Error(
         `Room.connect received invalid parameters - expected url/token or tokenSource, received ${urlOrOpts}, ${tokenOrUnset}, ${optsOrUnset}`,
@@ -813,7 +814,7 @@ class Room<
     );
 
     return this.connectFuture.promise;
-  }) as RoomConnectFn<Options>;
+  };
 
   private connectSignal = async (
     url: string,
@@ -1030,6 +1031,7 @@ class Room<
       this.handleDisconnect(stopTracks, DisconnectReason.CLIENT_INITIATED);
       /* @ts-ignore */
       this.engine = undefined;
+      this.tokenSourceFetch();
     } finally {
       unlock();
     }
@@ -2726,30 +2728,4 @@ export type RoomEventCallbacks = {
   localTrackSubscribed: (publication: LocalTrackPublication, participant: LocalParticipant) => void;
   metricsReceived: (metrics: MetricsBatch, participant?: Participant) => void;
   participantActive: (participant: Participant) => void;
-};
-
-type RoomPrepareConnectionFn<
-  Options extends RoomOptionsWithTokenSource | RoomOptions
-> = Options extends RoomOptionsWithTokenSource<infer TokenSource> ? (
-  TokenSource extends TokenSourceFixed ? {
-    (): Promise<void>;
-  } : {
-    (options?: TokenSourceFetchOptions): Promise<void>;
-  }
-) : {
-  /** @deprecated */
-  (url: string, token?: string): Promise<void>;
-};
-
-type RoomConnectFn<
-  Options extends RoomOptionsWithTokenSource | RoomOptions
-> = Options extends RoomOptionsWithTokenSource<infer TokenSource> ? (
-  TokenSource extends TokenSourceFixed ? {
-    (options?: RoomConnectOptions): Promise<void>;
-  } : {
-    (options?: RoomConnectOptions & TokenSourceFetchOptions): Promise<void>;
-  }
-) : {
-  /** @deprecated */
-  (url: string, token: string): Promise<void>;
 };

--- a/src/room/token-source/types.ts
+++ b/src/room/token-source/types.ts
@@ -51,6 +51,7 @@ export type RoomConfigurationObject = NonNullable<
  * The most common downstream implementer is {@link TokenSourceLiteral}.
  */
 export abstract class TokenSourceFixed {
+  type = 'f' as const;
   abstract fetch(): Promise<TokenSourceResponseObject>;
 }
 
@@ -77,6 +78,7 @@ export type TokenSourceFetchOptions = {
  * and {@link TokenSourceCustom}.
  */
 export abstract class TokenSourceConfigurable {
+  type = 'c' as const;
   abstract fetch(options: TokenSourceFetchOptions): Promise<TokenSourceResponseObject>;
 }
 

--- a/src/room/token-source/types.ts
+++ b/src/room/token-source/types.ts
@@ -51,6 +51,7 @@ export type RoomConfigurationObject = NonNullable<
  * The most common downstream implementer is {@link TokenSourceLiteral}.
  */
 export abstract class TokenSourceFixed {
+  type = 'fixed' as const;
   abstract fetch(): Promise<TokenSourceResponseObject>;
 }
 
@@ -77,6 +78,7 @@ export type TokenSourceFetchOptions = {
  * and {@link TokenSourceCustom}.
  */
 export abstract class TokenSourceConfigurable {
+  type = 'configurable' as const;
   abstract fetch(options: TokenSourceFetchOptions): Promise<TokenSourceResponseObject>;
 }
 

--- a/src/room/token-source/types.ts
+++ b/src/room/token-source/types.ts
@@ -51,7 +51,6 @@ export type RoomConfigurationObject = NonNullable<
  * The most common downstream implementer is {@link TokenSourceLiteral}.
  */
 export abstract class TokenSourceFixed {
-  type = 'f' as const;
   abstract fetch(): Promise<TokenSourceResponseObject>;
 }
 
@@ -78,7 +77,6 @@ export type TokenSourceFetchOptions = {
  * and {@link TokenSourceCustom}.
  */
 export abstract class TokenSourceConfigurable {
-  type = 'c' as const;
   abstract fetch(options: TokenSourceFetchOptions): Promise<TokenSourceResponseObject>;
 }
 

--- a/src/room/token-source/utils.ts
+++ b/src/room/token-source/utils.ts
@@ -35,9 +35,10 @@ export function decodeTokenPayload(token: string) {
 }
 
 export function extractTokenSourceOptionsFromObject<
-  Input extends TokenSourceFetchOptions & Rest,
   Rest extends object,
->(input: Input): TokenSourceFetchOptions {
+  Input extends TokenSourceFetchOptions & Rest = TokenSourceFetchOptions & Rest,
+>(input: Input): [TokenSourceFetchOptions, Rest] {
+  const output: Partial<Input> = { ...input };
   const options: TokenSourceFetchOptions = {};
 
   for (const key of Object.keys(input) as Array<keyof TokenSourceFetchOptions>) {
@@ -49,10 +50,12 @@ export function extractTokenSourceOptionsFromObject<
       case 'agentName':
       case 'agentMetadata':
         options[key] = input[key];
+        delete output[key];
         break;
 
       case 'participantAttributes':
         options.participantAttributes = options.participantAttributes ?? {};
+        delete output.participantAttributes;
         break;
 
       default:
@@ -62,5 +65,5 @@ export function extractTokenSourceOptionsFromObject<
     }
   }
 
-  return options;
+  return [options, output as Rest];
 }

--- a/src/room/token-source/utils.ts
+++ b/src/room/token-source/utils.ts
@@ -1,6 +1,6 @@
 import { RoomConfiguration, type TokenSourceResponse } from '@livekit/protocol';
 import { decodeJwt } from 'jose';
-import type { RoomConfigurationObject, TokenPayload } from './types';
+import type { RoomConfigurationObject, TokenPayload, TokenSourceFetchOptions } from './types';
 
 const ONE_SECOND_IN_MILLISECONDS = 1000;
 const ONE_MINUTE_IN_MILLISECONDS = 60 * ONE_SECOND_IN_MILLISECONDS;
@@ -32,4 +32,35 @@ export function decodeTokenPayload(token: string) {
   };
 
   return mappedPayload;
+}
+
+export function extractTokenSourceOptionsFromObject<
+  Input extends TokenSourceFetchOptions & Rest,
+  Rest extends object,
+>(input: Input): TokenSourceFetchOptions {
+  const options: TokenSourceFetchOptions = {};
+
+  for (const key of Object.keys(input) as Array<keyof TokenSourceFetchOptions>) {
+    switch (key) {
+      case 'roomName':
+      case 'participantName':
+      case 'participantIdentity':
+      case 'participantMetadata':
+      case 'agentName':
+      case 'agentMetadata':
+        options[key] = input[key];
+        break;
+
+      case 'participantAttributes':
+        options.participantAttributes = options.participantAttributes ?? {};
+        break;
+
+      default:
+        // ref: https://stackoverflow.com/a/58009992
+        key satisfies never;
+        break;
+    }
+  }
+
+  return options;
 }

--- a/src/room/token-source/utils.ts
+++ b/src/room/token-source/utils.ts
@@ -35,10 +35,9 @@ export function decodeTokenPayload(token: string) {
 }
 
 export function extractTokenSourceOptionsFromObject<
+  Input extends TokenSourceFetchOptions & Rest,
   Rest extends object,
-  Input extends TokenSourceFetchOptions & Rest = TokenSourceFetchOptions & Rest,
->(input: Input): [TokenSourceFetchOptions, Rest] {
-  const output: Partial<Input> = { ...input };
+>(input: Input): TokenSourceFetchOptions {
   const options: TokenSourceFetchOptions = {};
 
   for (const key of Object.keys(input) as Array<keyof TokenSourceFetchOptions>) {
@@ -50,12 +49,10 @@ export function extractTokenSourceOptionsFromObject<
       case 'agentName':
       case 'agentMetadata':
         options[key] = input[key];
-        delete output[key];
         break;
 
       case 'participantAttributes':
         options.participantAttributes = options.participantAttributes ?? {};
-        delete output.participantAttributes;
         break;
 
       default:
@@ -65,5 +62,5 @@ export function extractTokenSourceOptionsFromObject<
     }
   }
 
-  return [options, output as Rest];
+  return options;
 }


### PR DESCRIPTION
Adds the ability to use a `TokenSource` in the `Room`'s constructor to avoid passing in duplicate credentials in `connect` and `prepareConnection`.

## Fixed token source example:
```typescript
const roomA = new Room({
  tokenSource: TokenSource.literal({ serverUrl: "...", participantToken: "..." }),
  // Note: no fetch options can be passed here because TokenSource.literal is
  // not a configurable token source
});
roomA.prepareConnection(); // Note: no parameters required here, because of the token source passed in to the constructor!
roomA.connect(); // Note: no parameters required, but optionally `RoomConnectOptions` can still be passed
```

## Configurable token source example:
```typescript
const roomB = new Room({
  tokenSource: TokenSource.sandboxTokenServer("sandbox id here"),
  agentName: "agent name here", // Note: fetch options can be specified here, but are optional
});
roomB.prepareConnection(); // Note: no parameters required here, because of the token source passed in to the constructor!
roomB.connect(); // Note: no parameters required, but optionally `RoomConnectOptions` can still be passed
```

## Legacy example
This change is fully backwards compatible, so the existing call pattern still works as expected:
```typescript
const roomB = new Room();
roomB.prepareConnection("server url", "optional participant token");
roomB.connect("server url", "participant token");
```