### PR TITLE
Initial draft of tokensource readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,9 +354,9 @@ await literal2.fetch() // { serverUrl: "ws://localhost:7800", participantToken: 
 #### TokenSource.Endpoint
 A configurable token source which makes a request to an endpoint to generate credentials. By
 default, a `POST` request with a `Content-Type: application/json` header is made, and the request
-body is expected to follow the [standard token format](https://github.com/livekit-examples/token-server-node/blob/main/TEMPLATE.md#sandbox). If
+body is expected to follow the [standard token format](https://cloud.livekit.io/projects/p_/sandbox/templates/token-server). If
 credentials generation is successful, the endpoint returns a 2xx status code with a body following
-the [standard token response format](https://github.com/livekit-examples/token-server-node/blob/main/TEMPLATE.md#sandbox).
+the [standard token response format](https://cloud.livekit.io/projects/p_/sandbox/templates/token-server).
 
 Example:
 ```ts


### PR DESCRIPTION
Added a section to the readme about the `TokenSource` and how to use it currently.

I'll admit I'm not sure if all this really should be in the README - it might make more sense to move most of this to docs pages and just link to it directly. But I'll leave thoughts about exactly how this is formatted up to the docs team!