### PR TITLE
bump up RPC total timeout to 15s, connectionTimeout to 7s

### DIFF
--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1771,9 +1771,9 @@ export default class LocalParticipant extends Participant {
     destinationIdentity,
     method,
     payload,
-    responseTimeout = 10000,
+    responseTimeout = 15000,
   }: PerformRpcParams): Promise<string> {
-    const maxRoundTripLatency = 2000;
+    const maxRoundTripLatency = 7000;
 
     return new Promise(async (resolve, reject) => {
       if (byteLength(payload) > MAX_PAYLOAD_BYTES) {


### PR DESCRIPTION
Checkout https://linear.app/livekit/issue/CLT-2132/increase-rpc-max-rt-time-to-7s for details.

This PR will bump up the max round trip time to 7s, and the response timeout to 8s. 

See similar Rust PR
https://github.com/livekit/rust-sdks/pull/729