### PR TITLE
add changeset for #1686 (increase RPC timeouts)

### DIFF
--- a/.changeset/increase-rpc-timeouts.md
+++ b/.changeset/increase-rpc-timeouts.md
@@ -1,0 +1,5 @@
+---
+"livekit": patch
+---
+
+Increase RPC total timeout to 15s and connection timeout to 7s for better reliability under network latency.


### PR DESCRIPTION
Adds a missing changeset for [#1686](https://github.com/livekit/livekit/pull/1686)
.

This ensures the RPC timeout changes are included in the next release’s CHANGELOG.

Related issue: [CLT-2132](https://linear.app/livekit/issue/CLT-2132/increase-rpc-max-rt-time-to-7s)