### PR TITLE
Update example links to use absolute urls rather than relative to fix broken links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,11 +372,11 @@ You may throw errors of the type `RpcError` with a string `message` in an RPC me
 
 ### Demo App
 
-[examples/demo](examples/demo/) contains a demo webapp that uses the SDK. Run it with `pnpm install && pnpm examples:demo`
+[examples/demo](https://github.com/livekit/client-sdk-js/tree/main/examples/demo/) contains a demo webapp that uses the SDK. Run it with `pnpm install && pnpm examples:demo`
 
 ### RPC Demo
 
-[examples/rpc](examples/rpc/) contains a demo webapp that uses the SDK to showcase the RPC capabilities. Run it with `pnpm install && pnpm dev` from the `examples/rpc` directory.
+[examples/rpc](https://github.com/livekit/client-sdk-js/tree/main/examples/rpc/) contains a demo webapp that uses the SDK to showcase the RPC capabilities. Run it with `pnpm install && pnpm dev` from the `examples/rpc` directory.
 
 ## Browser Support
 


### PR DESCRIPTION
The links to the RPC and Demo App examples in this repo are broken in the [reference docs](https://docs.livekit.io/reference/client-sdk-js/) due to using relative links.  This changes them to use absolute links and should properly work.