### PR TITLE
Throttle E2EE Decryption Errors to Prevent Memory Leak

### DIFF
--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -133,6 +133,7 @@ export class FrameCryptor extends BaseFrameCryptor {
     workerLogger.debug('unsetting participant', this.logContext);
     this.participantIdentity = undefined;
     this.lastErrorTimestamp = new Map();
+    this.errorCounts = new Map();
   }
 
   isEnabled() {


### PR DESCRIPTION
## Problem

When E2EE workers decrypt frames with invalid keys, they emit hundreds of identical errors per second (≈557 in 2 s), exhausting memory:

```
InvalidKey: Decryption failed:
E2EEManager.onWorkerMessage @ livekit-client.esm.mjs:14005
```

**Root cause:** No throttling in the FrameCryptor → Worker → E2EEManager chain.

## Solution

Added a **three-tier error throttling system** to cap repeated decryption errors without hiding the root issue.

### 1. FrameCryptor

* Introduced `shouldEmitError()` and `emitThrottledError()`
* 1 error / s max, 5 per 60 s window
* Counters auto-reset after window expiry

### 2. Worker

* Global throttle across all cryptors
* Groups errors by participant and type
* Prevents main-thread flooding

### 3. E2EEManager

* Final safeguard against log/memory bloat
* Logs first error as `ERROR`, subsequent as `DEBUG`

## Impact

* log reduction (557 each 2 seconds)
* Stops memory leaks
* Keeps diagnostic visibility
* No breaking changes or API impact

## Files Changed

* `src/e2ee/worker/FrameCryptor.ts`
* `src/e2ee/worker/e2ee.worker.ts`
* `src/e2ee/E2eeManager.ts`
