### PR TITLE
[fix]: Refactor audio options to preserve existing properties

### DIFF
--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -83,8 +83,8 @@ export async function createLocalTracks(
     (typeof internalOptions.audio === 'object' && !internalOptions.audio.deviceId)
   ) {
       internalOptions.audio = {
-        ...internalOptions.audio,
-        deviceId: 'default'
+        ...(typeof internalOptions.audio === 'object' && internalOptions.audio !== null ? internalOptions.audio : {}),
+        deviceId: (typeof internalOptions.audio === 'object' && internalOptions.audio?.deviceId) || 'default',
       };
   }
   if (internalOptions.video === true) {


### PR DESCRIPTION
If deviceId is not specified in the constraints, other audio constraint flags (e.g. echoCancellation) get overwritten unexpectedly.