### PR TITLE
[Fix]: Avoid overwriting audio constraint flags in LocalTrackAudio

### DIFF
--- a/src/room/track/create.ts
+++ b/src/room/track/create.ts
@@ -80,18 +80,18 @@ export async function createLocalTracks(
   }
   if (
     internalOptions.audio === true ||
-    (typeof internalOptions.audio === "object" &&
+    (typeof internalOptions.audio === 'object' &&
       !internalOptions.audio.deviceId)
   ) {
     internalOptions.audio = {
-      ...(typeof internalOptions.audio === "object" &&
+      ...(typeof internalOptions.audio === 'object' &&
       internalOptions.audio !== null
         ? internalOptions.audio
         : {}),
       deviceId:
-        (typeof internalOptions.audio === "object" &&
+        (typeof internalOptions.audio === 'object' &&
           internalOptions.audio?.deviceId) ||
-        "default",
+        'default',
     };
   }
   if (internalOptions.video === true) {


### PR DESCRIPTION
If deviceId is not specified in the constraints, other audio constraint flags (e.g. echoCancellation) get overwritten unexpectedly.