### PR TITLE
fix: prevent unnecessary track restarts on unmute when using ideal device constraints

### DIFF
--- a/.changeset/funny-masks-strive.md
+++ b/.changeset/funny-masks-strive.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix unnecessary track restarts on unmute when using ideal device constraints

--- a/src/room/track/LocalAudioTrack.ts
+++ b/src/room/track/LocalAudioTrack.ts
@@ -3,7 +3,7 @@ import { TrackEvent } from '../events';
 import { computeBitrate, monitorFrequency } from '../stats';
 import type { AudioSenderStats } from '../stats';
 import type { LoggerOptions } from '../types';
-import { isReactNative, isWeb, unwrapConstraint } from '../utils';
+import { isReactNative, isWeb } from '../utils';
 import LocalTrack from './LocalTrack';
 import { Track } from './Track';
 import type { AudioCaptureOptions } from './options';
@@ -74,14 +74,11 @@ export default class LocalAudioTrack extends LocalTrack<Track.Kind.Audio> {
         return this;
       }
 
-      const deviceHasChanged =
-        this._constraints.deviceId &&
-        this._mediaStreamTrack.getSettings().deviceId !==
-          unwrapConstraint(this._constraints.deviceId);
-
       if (
         this.source === Track.Source.Microphone &&
-        (this.stopOnMute || this._mediaStreamTrack.readyState === 'ended' || deviceHasChanged) &&
+        (this.stopOnMute ||
+          this._mediaStreamTrack.readyState === 'ended' ||
+          this.pendingDeviceChange) &&
         !this.isUserProvided
       ) {
         this.log.debug('reacquiring mic track', this.logContext);

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -65,6 +65,8 @@ export default abstract class LocalTrack<
 
   protected trackChangeLock: Mutex;
 
+  protected pendingDeviceChange: boolean = false;
+
   /**
    *
    * @param mediaTrack
@@ -246,6 +248,7 @@ export default abstract class LocalTrack<
     // when track is muted, underlying media stream track is stopped and
     // will be restarted later
     if (this.isMuted) {
+      this.pendingDeviceChange = true;
       return true;
     }
 
@@ -365,6 +368,7 @@ export default abstract class LocalTrack<
 
       await this.setMediaStreamTrack(newTrack);
       this._constraints = constraints;
+      this.pendingDeviceChange = false;
       this.emit(TrackEvent.Restarted, this);
       if (this.manuallyStopped) {
         this.log.warn(


### PR DESCRIPTION
When using `{ ideal: 'default' }` device constraints (the default), unmuting
would trigger unnecessary track restarts because the comparison between the
constraint value ('default') and actual device ID (e.g. 'audio') would always
fail.

This adds a `pendingDeviceChange` flag that is only set when `setDeviceId()`
is explicitly called while the track is muted. The unmute logic now checks
this flag instead of comparing constraint values against the actual device,
ensuring restarts only happen when the user actually requested a device change.

## Related issues
- https://github.com/livekit/react-native-webrtc/issues/66
- https://github.com/livekit/client-sdk-react-native/issues/287

## Test plan
- Tested muting and unmuting microphone on iOS with default device constraints
- Verified no unnecessary restarts occur on unmute
- Verified `setDeviceId()` while muted still triggers restart on unmute

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary audio track restarts when unmuting with ideal device constraints; device changes made while muted now apply on unmute without forcing a restart.
* **Chores**
  * Added release changeset entry for this patch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->