### PR TITLE
refactor: vendor ts-debounce

### DIFF
--- a/.changeset/silly-views-win.md
+++ b/.changeset/silly-views-win.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Vendored ts-debounce and added critical timers to debounce function

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "jose": "^6.1.0",
     "loglevel": "^1.9.2",
     "sdp-transform": "^2.15.0",
-    "ts-debounce": "^4.0.0",
     "tslib": "2.8.1",
     "typed-emitter": "^2.1.0",
     "webrtc-adapter": "^9.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       sdp-transform:
         specifier: ^2.15.0
         version: 2.15.0
-      ts-debounce:
-        specifier: ^4.0.0
-        version: 4.0.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -3024,8 +3021,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.4:
-    resolution: {integrity: sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==}
+  lru-cache@11.2.5:
+    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -3731,9 +3728,6 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-debounce@4.0.0:
-    resolution: {integrity: sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==}
-
   ts-declaration-location@1.0.7:
     resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
     peerDependencies:
@@ -3797,8 +3791,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.0-dev.20260201:
-    resolution: {integrity: sha512-J+TSa+T2xtF9W3vxgQUZOQ+ZcHr6yONimIL2TY9/UTACBzQZAECBkfSBLRxKlUPjnsbIvJBVebZx9eMWz4BkFA==}
+  typescript@6.0.0-dev.20260203:
+    resolution: {integrity: sha512-uurwjqOjUaUI30dLNR/ujGLEVI5Q1sY1RSmvmWf4lQXZMzqMnrcOK7uoFsRC2G4skJYSxkctGlSa9ZY6+ur2cQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -6333,7 +6327,7 @@ snapshots:
     dependencies:
       semver: 7.6.0
       shelljs: 0.8.5
-      typescript: 6.0.0-dev.20260201
+      typescript: 6.0.0-dev.20260203
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7348,7 +7342,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.4: {}
+  lru-cache@11.2.5: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -7553,7 +7547,7 @@ snapshots:
 
   path-scurry@2.0.1:
     dependencies:
-      lru-cache: 11.2.4
+      lru-cache: 11.2.5
       minipass: 7.1.2
 
   path-type@4.0.0: {}
@@ -7616,7 +7610,7 @@ snapshots:
 
   rechoir@0.6.2:
     dependencies:
-      resolve: 1.22.11
+      resolve: 1.22.10
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -8080,8 +8074,6 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-debounce@4.0.0: {}
-
   ts-declaration-location@1.0.7(typescript@5.8.3):
     dependencies:
       picomatch: 4.0.3
@@ -8171,7 +8163,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@6.0.0-dev.20260201: {}
+  typescript@6.0.0-dev.20260203: {}
 
   uc.micro@2.1.0: {}
 

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -1,9 +1,9 @@
 import { Mutex } from '@livekit/mutex';
 import { EventEmitter } from 'events';
 import { parse, write } from 'sdp-transform';
-import { debounce } from 'ts-debounce';
 import type { MediaDescription, SessionDescription } from 'sdp-transform';
 import log, { LoggerNames, getLogger } from '../logger';
+import { debounce } from './debounce';
 import { NegotiationError, UnexpectedConnectionState } from './errors';
 import type { LoggerOptions } from './types';
 import { ddExtensionURI, isSVCCodec, isSafari } from './utils';

--- a/src/room/debounce.ts
+++ b/src/room/debounce.ts
@@ -1,0 +1,115 @@
+/**
+ * Originally from ts-debounce (https://github.com/chodorowicz/ts-debounce)
+ * with the following license:
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 Jakub Chodorowicz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Modified to use CriticalTimers for reliable timer execution.
+ */
+/* eslint-disable @typescript-eslint/no-this-alias, @typescript-eslint/no-unused-expressions, @typescript-eslint/no-shadow */
+import CriticalTimers from './timers';
+
+export type Options<Result> = {
+  isImmediate?: boolean;
+  maxWait?: number;
+  callback?: (data: Result) => void;
+};
+
+export interface DebouncedFunction<Args extends any[], F extends (...args: Args) => any> {
+  (this: ThisParameterType<F>, ...args: Args & Parameters<F>): Promise<ReturnType<F>>;
+  cancel: (reason?: any) => void;
+}
+
+interface DebouncedPromise<FunctionReturn> {
+  resolve: (result: FunctionReturn) => void;
+  reject: (reason?: any) => void;
+}
+
+export function debounce<Args extends any[], F extends (...args: Args) => any>(
+  func: F,
+  waitMilliseconds = 50,
+  options: Options<ReturnType<F>> = {},
+): DebouncedFunction<Args, F> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const isImmediate = options.isImmediate ?? false;
+  const callback = options.callback ?? false;
+  const maxWait = options.maxWait;
+  let lastInvokeTime = Date.now();
+
+  let promises: DebouncedPromise<ReturnType<F>>[] = [];
+
+  function nextInvokeTimeout() {
+    if (maxWait !== undefined) {
+      const timeSinceLastInvocation = Date.now() - lastInvokeTime;
+
+      if (timeSinceLastInvocation + waitMilliseconds >= maxWait) {
+        return maxWait - timeSinceLastInvocation;
+      }
+    }
+
+    return waitMilliseconds;
+  }
+
+  const debouncedFunction = function (this: ThisParameterType<F>, ...args: Parameters<F>) {
+    const context = this;
+    return new Promise<ReturnType<F>>((resolve, reject) => {
+      const invokeFunction = function () {
+        timeoutId = undefined;
+        lastInvokeTime = Date.now();
+        if (!isImmediate) {
+          const result = func.apply(context, args);
+          callback && callback(result);
+          // biome-ignore lint/suspicious/useIterableCallbackReturn: vendored code
+          promises.forEach(({ resolve }) => resolve(result));
+          promises = [];
+        }
+      };
+
+      const shouldCallNow = isImmediate && timeoutId === undefined;
+
+      if (timeoutId !== undefined) {
+        CriticalTimers.clearTimeout(timeoutId);
+      }
+
+      timeoutId = CriticalTimers.setTimeout(invokeFunction, nextInvokeTimeout());
+
+      if (shouldCallNow) {
+        const result = func.apply(context, args);
+        callback && callback(result);
+        return resolve(result);
+      }
+      promises.push({ resolve, reject });
+    });
+  };
+
+  debouncedFunction.cancel = function (reason?: any) {
+    if (timeoutId !== undefined) {
+      CriticalTimers.clearTimeout(timeoutId);
+    }
+    // biome-ignore lint/suspicious/useIterableCallbackReturn: vendored code
+    promises.forEach(({ reject }) => reject(reason));
+    promises = [];
+  };
+
+  return debouncedFunction;
+}

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -1,7 +1,7 @@
 import { Mutex } from '@livekit/mutex';
-import { debounce } from 'ts-debounce';
 import { getBrowser } from '../../utils/browserParser';
 import DeviceManager from '../DeviceManager';
+import { debounce } from '../debounce';
 import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
 import { TrackEvent } from '../events';
 import type { LoggerOptions } from '../types';

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'ts-debounce';
+import { debounce } from '../debounce';
 import { TrackEvent } from '../events';
 import type { VideoReceiverStats } from '../stats';
 import { computeBitrate } from '../stats';


### PR DESCRIPTION
## Summary
Vendors the `ts-debounce` library and modifies it to use `CriticalTimers` instead of the native `setTimeout`/`clearTimeout`.

This allows the debounce function to work correctly when users override `CriticalTimers` with background-compatible timers (e.g., `react-native-background-timer`), which is necessary for iOS apps that need to maintain LiveKit connections while the screen is locked.

## Related Issues
Fixes https://github.com/livekit/client-sdk-react-native/issues/158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced external debounce with an internal vendored debounce implementation that improves timer reliability, provides promise-based behavior, stronger cancellation, and max-wait handling.

* **Chores**
  * Removed the external debounce dependency and added a changeset recording the patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->