### PR TITLE
Reuse inactive publisher transceivers in RTCEngine to reduce memory growth on republish

### DIFF
--- a/.changeset/sweet-planes-open.md
+++ b/.changeset/sweet-planes-open.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Reuse inactive publisher transceivers in RTCEngine to reduce memory growth on republish


### PR DESCRIPTION
## Why?

I'm developing WorkAdventure, a virtual space platform and we use Livekit for big meetings.

The issue that triggered this PR is that when we start publishing a screen sharing, the memory goes up by about 400MB. We stop publishing the screen sharing with `localParticipant.unpublishTrack`, the memory does not go down. We start publishing another screen sharing again (maybe another window), the memory goes up by another 400MB, etc...
In short, we have a memory leak, where each started screen sharing is never releasing memory.

As a side note, using `track.pauseUpstream` to stop the track then replace the track with another track later seems to work better, but this workflow causes other issues (like the fact that egress CompositeRoom will display a black box for a paused video instead of not showing it at all)

## How to reproduce the issue

You can see the issue in https://meet.livekit.io/

- Simply start a meeting with another user. 
- Open the Google Chrome task manager and note the memory consumption of your current tab
- Start a screen share => the memory goes up
- Stop  the screen share => the memory does not go down
- Start another screen share => the memory keeps going up
- etc...

After 3/4 screenshares, your tab takes more than 1GB RAM.

## Finding the memory leak

I tried to track down where the memory leak was, and after a few trial and errors (and with the help of Codex), I ended up finding that the transceivers in the `RTCEngine` seem to be piling up each time we start a new track. The `RTCRtpTransceiver` seem to hold a reference to the `MediaTrack` that is never freed and eating a lot of memory. I did not find any way to properly free the `MediaTrack` reference, but Codex (again) proposed me the patch below. Basically, it tries to reuse an inactive existing sender that shares the same track "kind".

I tested this with WorkAdventure and the patch works. When I stop / start many screen sharing many times, the memory does not pile up. I also re-read the patch and validated it myself (to avoid any AI slop).

Note: I tried an alternative: freeing the memory as soon as `localParticipant.unpublishTrack` is called (using `replaceTrack(null)`) instead of waiting for the next track to start to reuse the transceiver. Alas, I could not make this work (that would be ideal as the memory would be freed as soon as we finish publishing... here, we have to wait getting out of the Livekit room for the memory to be freed)

What do you think of this patch? I can happily work on it if it needs any improvement.