### PR TITLE
fix: defer PiP visibility refresh on Document Picture-in-Picture enter

### DIFF
--- a/.changeset/busy-icons-notice.md
+++ b/.changeset/busy-icons-notice.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Defer `onEnterPiP` visibility update until after the next microtask and animation frame so Document Picture-in-Picture embedders can append DOM into the PiP window before `isElementInPiP` runs.

--- a/src/room/track/RemoteVideoTrack.ts
+++ b/src/room/track/RemoteVideoTrack.ts
@@ -384,8 +384,14 @@ class HTMLElementInfo implements ElementInfo {
 
   private onEnterPiP = () => {
     window.documentPictureInPicture?.window?.addEventListener('pagehide', this.onLeavePiP);
-    this.isPiP = isElementInPiP(this.element);
-    this.handleVisibilityChanged?.();
+    // Document PiP: the browser may fire 'enter' before the app has appended its subtree into
+    // documentPictureInPicture.window. Defer so pipWin.document.contains(video) is reliable.
+    queueMicrotask(() => {
+      requestAnimationFrame(() => {
+        this.isPiP = isElementInPiP(this.element);
+        this.handleVisibilityChanged?.();
+      });
+    });
   };
 
   private onLeavePiP = () => {


### PR DESCRIPTION
# WorkAdventure usage

WorkAdventure uses Document Picture-in-Picture via documentPictureInPicture.requestWindow(). After the PiP window is created, it appends a root container (meeting UI + \<video> elements) to pipWindow.document.body, then updates app state.

You can test our use case here: [WorkAdventure Virtual Office](https://play.staging.workadventu.re/@/tcm/workadventure/wa-village)

# Issue
For Document Picture-in-Picture, the enter event can be delivered before the host application has finished appending its DOM into documentPictureInPicture.window.document.

If onEnterPiP runs isElementInPiP immediately, pipWin.document.contains(video) may still be false, so adaptive-stream visibility is wrong.

**Symptoms we saw**: remote video appearing “stuck” or wrong adaptive-stream visibility after ~5s when the tab is hidden, and incorrect visibilityChanged on remote video tracks while Document PiP is active.

Reparenting can also leave the SDK’s observers / attachment state inconsistent until the track is re-attached.

Workaround in our app (until / in addition to SDK fixes): we detach and re-attach the RemoteVideoTrack to the same <video> after PiP-related DOM moves so LiveKit re-runs intersection / PiP observation on the element in the correct document:
```js
// On mount: if PiP is already active, after tick() → detach + attach
if ($activePictureInPictureStore) {
    tick().then(() => refreshTrackAttachmentAfterPictureInPictureMove());
}
// On every transition of activePictureInPictureStore (open/close PiP), after tick() → detach + attach
const unsubscribePictureInPicture = activePictureInPictureStore.subscribe((inPip) => {
    if (inPip === pip) return;
    pip = inPip;
    tick().then(() => refreshTrackAttachmentAfterPictureInPictureMove());
});
```

# Changes
In private onEnterPiP (RemoteVideoTrack.ts), defer isElementInPiP and handleVisibilityChanged using queueMicrotask + requestAnimationFrame, so embedders (including WorkAdventure) can finish mounting content in the PiP document before the SDK evaluates PiP visibility.