### PR TITLE
fix: handle race between `LocalTrackSubscribed` signal and `publishTrack` completion

### DIFF
--- a/.changeset/curvy-bugs-live.md
+++ b/.changeset/curvy-bugs-live.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: handle race between `LocalTrackSubscribed` signal and `publishTrack` completion

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -578,22 +578,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         this.emit(RoomEvent.DCBufferStatusChanged, status, kind);
       })
       .on(EngineEvent.LocalTrackSubscribed, (subscribedSid) => {
-        const trackPublication = this.localParticipant
-          .getTrackPublications()
-          .find(({ trackSid }) => trackSid === subscribedSid) as LocalTrackPublication | undefined;
-        if (!trackPublication) {
-          this.log.warn(
-            'could not find local track subscription for subscribed event',
-            this.logContext,
-          );
-          return;
-        }
-        this.localParticipant.emit(ParticipantEvent.LocalTrackSubscribed, trackPublication);
-        this.emitWhenConnected(
-          RoomEvent.LocalTrackSubscribed,
-          trackPublication,
-          this.localParticipant,
-        );
+        this.handleLocalTrackSubscribed(subscribedSid);
       })
       .on(EngineEvent.RoomMoved, (roomMoved) => {
         this.log.debug('room moved', roomMoved);
@@ -1626,6 +1611,65 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         ),
       );
     }
+  }
+
+  private handleLocalTrackSubscribed(subscribedSid: string) {
+    const findPublication = () =>
+      this.localParticipant
+        .getTrackPublications()
+        .find(({ trackSid }) => trackSid === subscribedSid) as LocalTrackPublication | undefined;
+
+    const trackPublication = findPublication();
+    if (trackPublication) {
+      this.emitLocalTrackSubscribed(trackPublication);
+      return;
+    }
+
+    // the track publication may not be registered yet if the server signals
+    // the subscription before publishTrack has finished adding the publication.
+    // defer with a timeout until LocalTrackPublished fires for the matching trackSid
+    this.log.debug('deferring LocalTrackSubscribed, publication not yet available', {
+      ...this.logContext,
+      subscribedSid,
+    });
+
+    const TIMEOUT_MS = 10_000;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const onPublished = (pub: LocalTrackPublication) => {
+      if (pub.trackSid === subscribedSid) {
+        cleanup();
+        this.emitLocalTrackSubscribed(pub);
+      }
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      this.localParticipant.off(ParticipantEvent.LocalTrackPublished, onPublished);
+      this.off(RoomEvent.Disconnected, cleanup);
+    };
+
+    this.localParticipant.on(ParticipantEvent.LocalTrackPublished, onPublished);
+    this.once(RoomEvent.Disconnected, cleanup);
+
+    timer = setTimeout(() => {
+      cleanup();
+      // final attempt in case the publication was added without emitting the event
+      const pub = findPublication();
+      if (pub) {
+        this.emitLocalTrackSubscribed(pub);
+      } else {
+        this.log.warn(
+          'could not find local track publication for LocalTrackSubscribed event after timeout',
+          { ...this.logContext, subscribedSid },
+        );
+      }
+    }, TIMEOUT_MS);
+  }
+
+  private emitLocalTrackSubscribed(trackPublication: LocalTrackPublication) {
+    this.localParticipant.emit(ParticipantEvent.LocalTrackSubscribed, trackPublication);
+    this.emitWhenConnected(RoomEvent.LocalTrackSubscribed, trackPublication, this.localParticipant);
   }
 
   private handleRestarting = () => {


### PR DESCRIPTION
### Problem

When a local participant publishes a track, there is a race condition between two asynchronous flows:

1. **Signaling path**: The SFU confirms the subscription and the engine emits `EngineEvent.LocalTrackSubscribed` with the track SID.
2. **SDK path**: `LocalParticipant.publishTrack()` finishes its async work and calls `addTrackPublication()` to register the `LocalTrackPublication`.

If the signaling confirmation arrives *before* `addTrackPublication()` completes, the `LocalTrackSubscribed` handler in Room.ts calls `getTrackPublications().find(...)`, finds nothing, logs a warning (`"could not find local track subscription for subscribed event"`), and **silently drops the event**. Neither `ParticipantEvent.LocalTrackSubscribed` nor `RoomEvent.LocalTrackSubscribed` is ever emitted for that track because the warning log statement will just return without defering the event:

```typescript
.on(EngineEvent.LocalTrackSubscribed, (subscribedSid) => {
  const trackPublication = this.localParticipant
    .getTrackPublications()
    .find(({ trackSid }) => trackSid === subscribedSid);
  if (!trackPublication) {
    this.log.warn('could not find local track subscription for subscribed event', ...);
    return; // event dropped!!
  }
  // emit events...
})
```

I have been able to replicate this behavior consistently in a high concurrency scenario, where many users connect, publish and subscribe multiple tracks to the same Room at the same time.

### Fix

This PR replaces the inline handler with `handleLocalTrackSubscribed()`, which uses a **deferred-emit pattern**. That is consistent with the existing **`onTrackAdded`** defer logic to already present in Room.ts, that helps handling it when the participant is in `Connecting` or `Reconnecting` state (see [here](https://github.com/livekit/client-sdk-js/blob/d1e0a5d3b5f996921e6e19724dc6d7929b980750/src/room/Room.ts#L1521-L1528)).

My proposal for the defering logic of the LocalTrackSubscribed event follows this path:

1. Fast path: look up the publication immediately. If found, emit events and return.
2. Deferred path: if the publication is not yet registered, listen for `ParticipantEvent.LocalTrackPublished` on the local participant. When the matching `trackSid` appears, emit the `LocalTrackSubscribed` events.
3. Timeout safety net (10 s): if the publication never arrives (e.g., publish failed silently), perform one final lookup attempt, then clean up listeners. This prevents leaking event listeners indefinitely.
4. Disconnect cleanup: all listeners are removed if the room disconnects before resolution.

A small `emitLocalTrackSubscribed()` helper is extracted to deduplicate the two-event emission (`ParticipantEvent` + `RoomEvent`).