### PR TITLE
Make "connected to" log show up after every join, not just after fresh connections

### DIFF
--- a/.changeset/spotty-pumas-jog.md
+++ b/.changeset/spotty-pumas-jog.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Moves "connected to Livekit Server" log within RTCEngine.join so it shows up for reconnects as well as connects

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -26,6 +26,7 @@ import {
   RoomMovedResponse,
   RpcAck,
   RpcResponse,
+  ServerInfo,
   SessionDescription,
   SignalTarget,
   SpeakerInfo,
@@ -298,7 +299,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     abortSignal?: AbortSignal,
     /** setting this to true results in dual peer connection mode being used */
     useV0Path: boolean = false,
-  ): Promise<JoinResponse> {
+  ): Promise<{ joinResponse: JoinResponse; serverInfo: Partial<ServerInfo> }> {
     this._isNewlyCreated = false;
     this.url = url;
     this.token = token;
@@ -353,7 +354,23 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.registerOnLineListener();
       this.clientConfiguration = joinResponse.clientConfiguration;
       this.emit(EngineEvent.SignalConnected, joinResponse);
-      return joinResponse;
+
+      let serverInfo: Partial<ServerInfo> | undefined = joinResponse.serverInfo;
+      if (!serverInfo) {
+        serverInfo = { version: joinResponse.serverVersion, region: joinResponse.serverRegion };
+      }
+      this.log.debug(
+        `connected to Livekit Server ${Object.entries(serverInfo)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join(', ')}`,
+        {
+          room: joinResponse.room?.name,
+          roomSid: joinResponse.room?.sid,
+          identity: joinResponse.participant?.identity,
+        },
+      );
+
+      return { joinResponse, serverInfo };
     } catch (e) {
       if (e instanceof ConnectionError) {
         if (e.reason === ConnectionErrorReason.ServerUnreachable) {
@@ -1212,13 +1229,15 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           throw new SignalReconnectError();
         }
         // in case a regionUrl is passed, the region URL takes precedence
-        joinResponse = await this.join(
-          regionUrl ?? this.url,
-          this.token,
-          this.signalOpts,
-          undefined,
-          !this.options.singlePeerConnection,
-        );
+        joinResponse = (
+          await this.join(
+            regionUrl ?? this.url,
+            this.token,
+            this.signalOpts,
+            undefined,
+            !this.options.singlePeerConnection,
+          )
+        ).joinResponse;
       } catch (e) {
         if (e instanceof ConnectionError && e.reason === ConnectionErrorReason.NotAllowed) {
           throw new UnexpectedConnectionState('could not reconnect, token might be expired');

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -895,7 +895,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     roomOptions: InternalRoomOptions,
     abortController: AbortController,
   ): Promise<JoinResponse> => {
-    const joinResponse = await engine.join(
+    const { joinResponse, serverInfo } = await engine.join(
       url,
       token,
       {
@@ -910,22 +910,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       !roomOptions.singlePeerConnection,
     );
 
-    let serverInfo: Partial<ServerInfo> | undefined = joinResponse.serverInfo;
-    if (!serverInfo) {
-      serverInfo = { version: joinResponse.serverVersion, region: joinResponse.serverRegion };
-    }
     this.serverInfo = serverInfo;
-
-    this.log.debug(
-      `connected to Livekit Server ${Object.entries(serverInfo)
-        .map(([key, value]) => `${key}: ${value}`)
-        .join(', ')}`,
-      {
-        room: joinResponse.room?.name,
-        roomSid: joinResponse.room?.sid,
-        identity: joinResponse.participant?.identity,
-      },
-    );
 
     if (!serverInfo.version) {
       throw new UnsupportedServer('unknown server version');


### PR DESCRIPTION
Previously, the code roughly did this:
```tsx
// in Room.connectSignal:
const joinResponse = await engine.join(/* ... */);

this.serverInfo = /* computed from joinResponse */;

this.log.debug('connected to Livekit Server ... (with this.serverInfo data in here)'); 
```

This meant that the `connected to Livekit Server ...` log would log only on connect, not for reconnects.

So instead, I moved the log one level deeper, into `RTCEngine.join`:
```tsx
// in RTCEngine.join:
// (preexisting join logic unchanged, joinResponse still comes from lower level this.client.join call)
const serverInfo = /* computed from joinResponse */;
this.log.debug('connected to Livekit Server ... (with serverInfo data in here)'); 
return { joinResponse, serverInfo };

// in Room.connectSignal:
const { joinResponse, serverInfo } = await engine.join(/* ... */);
this.serverInfo = serverInfo;
// (Log not here anymore)
```

With this change, the log shows up anytime a join occurs, whether it be fresh or for a reconnect. And the log still shows up in the same place on a fresh connect so the existing behavior should remain the same.

@boks1971 Does this address your concern? Is there a need to somehow disambiguate the log that is shown to determine if it is from a fresh connect or some type of reconnect, or is the context before / after the log good enough to tell this?