### PR TITLE
Add RTCEngine sendLossyBytes explicit queue to better handle sending large data track packets

### DIFF
--- a/.changeset/heavy-ants-mix.md
+++ b/.changeset/heavy-ants-mix.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add RTCEngine sendLossyBytes explicit queue to better handle sending large data track packets

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -249,7 +249,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
   /** used to buffer lossy data track packets which arrive quickly so they don't overwhelm the data
    * channel buffer */
-  private lossyBytesWaitBuffer = new Map<DataChannelKind, Array<Future<void, never>>>();
+  private lossyBytesWaitQueue = new Map<DataChannelKind, Array<Future<void, never>>>();
   private lossyBytesMutexByKind = new Map<DataChannelKind, Mutex>();
 
   constructor(private options: InternalRoomOptions) {
@@ -1500,9 +1500,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           // drain and go into "low status" before continuing.
           if (!this.isBufferStatusLow(kind)) {
             const future = new Future<void, never>();
-            const entries = this.lossyBytesWaitBuffer.get(kind) ?? [];
+            const entries = this.lossyBytesWaitQueue.get(kind) ?? [];
             entries.push(future);
-            this.lossyBytesWaitBuffer.set(kind, entries);
+            this.lossyBytesWaitQueue.set(kind, entries);
             await future.promise;
           }
           break;
@@ -1560,7 +1560,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
       // Now that there is space on the data channel buffer, attempt to fill up the remaining space
       // with bytes ready to be sent.
-      const buffer = this.lossyBytesWaitBuffer.get(kind) ?? [];
+      const buffer = this.lossyBytesWaitQueue.get(kind) ?? [];
       while (this.isBufferStatusLow(kind)) {
         let continueSendingFuture = buffer.shift();
         if (!continueSendingFuture) {
@@ -1569,7 +1569,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         continueSendingFuture.resolve?.();
       }
       if (buffer.length === 0) {
-        this.lossyBytesWaitBuffer.delete(kind);
+        this.lossyBytesWaitQueue.delete(kind);
       }
     }
   };

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -85,6 +85,7 @@ import type { TrackPublishOptions, VideoCodec } from './track/options';
 import { getTrackPublicationInfo } from './track/utils';
 import type { LoggerOptions } from './types';
 import {
+  Future,
   isCompressionStreamSupported,
   isVideoCodec,
   isVideoTrack,
@@ -1461,6 +1462,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
   }
 
+  private lossyBytesWaitBuffer = new Map<DataChannelKind, Array<Future<void, never>>>();
+
   /* @internal */
   async sendLossyBytes(
     bytes: Uint8Array,
@@ -1477,7 +1480,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         // buffer status to not be low before continuing.
         switch (bufferStatusLowBehavior) {
           case 'wait':
-            await this.waitForBufferStatusLow(kind);
+            if (this.isBufferStatusLow(kind)) {
+              const future = new Future<void, never>();
+              (window as any).lossyBytesWaitBuffer = this.lossyBytesWaitBuffer;
+              const entries = this.lossyBytesWaitBuffer.get(kind) ?? [];
+              entries.push(future);
+              this.lossyBytesWaitBuffer.set(kind, entries);
+              await future.promise;
+            }
             break;
           case 'drop':
             // this.log.warn(`dropping lossy data channel message`, this.logContext);
@@ -1528,6 +1538,20 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (typeof status !== 'undefined' && status !== this.dcBufferStatus.get(kind)) {
       this.dcBufferStatus.set(kind, status);
       this.emit(EngineEvent.DCBufferStatusChanged, status, kind);
+
+      // Now that there is space on the data channel buffer, attempt to fill up the remaining space
+      // with bytes ready to be sent.
+      const buffer = this.lossyBytesWaitBuffer.get(kind) ?? [];
+      while (this.isBufferStatusLow(kind)) {
+        let continueSendingFuture = buffer.shift();
+        if (!continueSendingFuture) {
+          break;
+        }
+        continueSendingFuture.resolve?.();
+      }
+      if (buffer.length === 0) {
+        this.lossyBytesWaitBuffer.delete(kind);
+      }
     }
   };
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -250,6 +250,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** used to buffer lossy data track packets which arrive quickly so they don't overwhelm the data
    * channel buffer */
   private lossyBytesWaitQueue = new Map<DataChannelKind, Array<Future<void, never>>>();
+
   private lossyBytesMutexByKind = new Map<DataChannelKind, Mutex>();
 
   constructor(private options: InternalRoomOptions) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -247,6 +247,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** used to indicate whether the browser is currently waiting to reconnect */
   private isWaitingForNetworkReconnect: boolean = false;
 
+  /** used to buffer lossy data track packets which arrive quickly so they don't overwhelm the data
+   * channel buffer */
+  private lossyBytesWaitBuffer = new Map<DataChannelKind, Array<Future<void, never>>>();
+
   constructor(private options: InternalRoomOptions) {
     super();
     this.log = getLogger(options.loggerName ?? LoggerNames.Engine);
@@ -1462,8 +1466,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
   }
 
-  private lossyBytesWaitBuffer = new Map<DataChannelKind, Array<Future<void, never>>>();
-
   /* @internal */
   async sendLossyBytes(
     bytes: Uint8Array,
@@ -1478,11 +1480,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       if (!this.isBufferStatusLow(kind)) {
         // Depending on the exact circumstance that data is being sent, either drop or wait for the
         // buffer status to not be low before continuing.
+        //
+        // An example of where this is used: data tracks, so that a large DataTrackFrame's worth of
+        // packets doesn't have the last half of the packets dropped due to not fitting into the
+        // data channel buffer all at once.
         switch (bufferStatusLowBehavior) {
           case 'wait':
             if (this.isBufferStatusLow(kind)) {
               const future = new Future<void, never>();
-              (window as any).lossyBytesWaitBuffer = this.lossyBytesWaitBuffer;
               const entries = this.lossyBytesWaitBuffer.get(kind) ?? [];
               entries.push(future);
               this.lossyBytesWaitBuffer.set(kind, entries);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1486,13 +1486,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         // data channel buffer all at once.
         switch (bufferStatusLowBehavior) {
           case 'wait':
-            if (this.isBufferStatusLow(kind)) {
-              const future = new Future<void, never>();
-              const entries = this.lossyBytesWaitBuffer.get(kind) ?? [];
-              entries.push(future);
-              this.lossyBytesWaitBuffer.set(kind, entries);
-              await future.promise;
-            }
+            const future = new Future<void, never>();
+            const entries = this.lossyBytesWaitBuffer.get(kind) ?? [];
+            entries.push(future);
+            this.lossyBytesWaitBuffer.set(kind, entries);
+            await future.promise;
             break;
           case 'drop':
             // this.log.warn(`dropping lossy data channel message`, this.logContext);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -250,6 +250,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** used to buffer lossy data track packets which arrive quickly so they don't overwhelm the data
    * channel buffer */
   private lossyBytesWaitBuffer = new Map<DataChannelKind, Array<Future<void, never>>>();
+  private lossyBytesMutexByKind = new Map<DataChannelKind, Mutex>();
 
   constructor(private options: InternalRoomOptions) {
     super();
@@ -1472,27 +1473,41 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     kind: Exclude<DataChannelKind, DataChannelKind.RELIABLE>,
     bufferStatusLowBehavior: 'drop' | 'wait' = 'drop',
   ) {
+    let unlock: (() => void) | undefined;
+
     // make sure we do have a data connection
     await this.ensurePublisherConnected(kind);
 
     const dc = this.dataChannelForKind(kind);
     if (dc) {
-      if (!this.isBufferStatusLow(kind)) {
-        // Depending on the exact circumstance that data is being sent, either drop or wait for the
-        // buffer status to not be low before continuing.
-        //
-        // An example of where this is used: data tracks, so that a large DataTrackFrame's worth of
-        // packets doesn't have the last half of the packets dropped due to not fitting into the
-        // data channel buffer all at once.
-        switch (bufferStatusLowBehavior) {
-          case 'wait':
+      // Depending on the exact circumstance that data is being sent, either drop or wait for the
+      // buffer status to not be low before continuing.
+      //
+      // An example of where this is used: data tracks, so that a large DataTrackFrame's worth of
+      // packets doesn't have the last half of the packets dropped due to not fitting into the
+      // data channel buffer all at once.
+      switch (bufferStatusLowBehavior) {
+        case 'wait':
+          // Wait for any past enqueued data to be drained before enqueing the next byte
+          let mutex = this.lossyBytesMutexByKind.get(kind);
+          if (!mutex) {
+            mutex = new Mutex();
+            this.lossyBytesMutexByKind.set(kind, mutex);
+          }
+          unlock = await mutex?.lock();
+
+          // If there isn't room in the data channel buffer, then wait for the rtc data channel to
+          // drain and go into "low status" before continuing.
+          if (!this.isBufferStatusLow(kind)) {
             const future = new Future<void, never>();
             const entries = this.lossyBytesWaitBuffer.get(kind) ?? [];
             entries.push(future);
             this.lossyBytesWaitBuffer.set(kind, entries);
             await future.promise;
-            break;
-          case 'drop':
+          }
+          break;
+        case 'drop':
+          if (!this.isBufferStatusLow(kind)) {
             // this.log.warn(`dropping lossy data channel message`, this.logContext);
             // Drop messages to reduce latency
             this.lossyDataDropCount += 1;
@@ -1503,7 +1518,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
               );
             }
             return;
-        }
+          }
       }
       this.lossyDataStatCurrentBytes += bytes.byteLength;
 
@@ -1515,6 +1530,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
 
     this.updateAndEmitDCBufferStatus(kind);
+    unlock?.();
   }
 
   private async resendReliableMessagesForResume(lastMessageSeq: number) {


### PR DESCRIPTION
Previously, sendLossyBytes ran `await this.waitForBufferStatusLow(kind);` to pause before enqueuing new data track packets onto the `_data_tracks` rtc data channel. In local cases this worked fairly well and the promises seemed to resolve in the order they were triggered.

However, when running the e2e tests, @boks1971 noticed an excessive number of out of order packets - in some cases the e2e tests returning as low as a 20% delivery rate for the low frequency large payload test.

I had a suspicion this `await this.waitForBufferStatusLow(kind);` bit was the problem, so I swapped it over to an explicit queuing implementation, and when I did, the packet delivery rate went up to 89-90%. In hindsight, relying on the promise resolution order like this was sloppy so I'm glad I'm getting this fixed now.