### PR TITLE
Close streamcontrollers when datatrack gets unpublished

### DIFF
--- a/.changeset/quiet-suits-matter.md
+++ b/.changeset/quiet-suits-matter.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Close streamcontrollers when datatrack gets unpublished

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -436,6 +436,9 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     this.descriptors.delete(sid);
 
     if (descriptor.subscription.type === 'active') {
+      descriptor.subscription.streamControllers.forEach((controller) => {
+        controller.close();
+      });
       this.subscriptionHandles.delete(descriptor.subscription.subcriptionHandle);
     }
 

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -586,6 +586,10 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       if (descriptor.subscription.type === 'pending') {
         descriptor.subscription.completionFuture.reject?.(DataTrackSubscribeError.disconnected());
       }
+
+      if (descriptor.subscription.type === 'active') {
+        descriptor.subscription.streamControllers.forEach((controller) => controller.close());
+      }
     }
     this.descriptors.clear();
   }


### PR DESCRIPTION
Ensures that `read()` promises of a data track subscription are resolved once the publisher unpublishes the data track