### PR TITLE
fix: avoid hard DOMException dependency in RN Hermes

### DIFF
--- a/.changeset/neat-pugs-tickle.md
+++ b/.changeset/neat-pugs-tickle.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Avoid hard dependency on global `DOMException` so React Native Hermes environments can initialize `livekit-client` without a manual polyfill.

--- a/src/api/WebSocketStream.ts
+++ b/src/api/WebSocketStream.ts
@@ -2,6 +2,7 @@
 import { ConnectionError } from '../room/errors';
 import { sleep } from '../room/utils';
 import TypedPromise from '../utils/TypedPromise';
+import { createDOMException } from '../utils/dom-exception';
 
 export interface WebSocketConnection<T extends ArrayBuffer | string = ArrayBuffer | string> {
   readable: ReadableStream<T>;
@@ -44,7 +45,7 @@ export class WebSocketStream<T extends ArrayBuffer | string = ArrayBuffer | stri
 
   constructor(url: string, options: WebSocketStreamOptions = {}) {
     if (options.signal?.aborted) {
-      throw new DOMException('This operation was aborted', 'AbortError');
+      throw createDOMException('This operation was aborted', 'AbortError');
     }
 
     this.url = url;

--- a/src/room/track/LocalTrack.ts
+++ b/src/room/track/LocalTrack.ts
@@ -1,5 +1,6 @@
 import { Mutex } from '@livekit/mutex';
 import { getBrowser } from '../../utils/browserParser';
+import { isDOMException } from '../../utils/dom-exception';
 import DeviceManager from '../DeviceManager';
 import { debounce } from '../debounce';
 import { DeviceUnsupportedError, TrackInvalidError } from '../errors';
@@ -558,7 +559,7 @@ export default abstract class LocalTrack<
       processorElement.muted = true;
 
       processorElement.play().catch((error) => {
-        if (error instanceof DOMException && error.name === 'AbortError') {
+        if (isDOMException(error, 'AbortError')) {
           // This happens on Safari when the processor is restarted, try again after a delay
           this.log.warn('failed to play processor element, retrying', {
             ...this.logContext,

--- a/src/utils/abort-signal-polyfill.ts
+++ b/src/utils/abort-signal-polyfill.ts
@@ -1,3 +1,5 @@
+import { createDOMException } from './dom-exception';
+
 /**
  * Implementation of AbortSignal.any
  * Creates a signal that will be aborted when any of the given signals is aborted.
@@ -56,7 +58,7 @@ export function abortSignalTimeout(ms: number): AbortSignal {
   const controller = new AbortController();
 
   setTimeout(() => {
-    controller.abort(new DOMException(`signal timed out after ${ms} ms`, 'TimeoutError'));
+    controller.abort(createDOMException(`signal timed out after ${ms} ms`, 'TimeoutError'));
   }, ms);
 
   return controller.signal;

--- a/src/utils/deferrable-map.ts
+++ b/src/utils/deferrable-map.ts
@@ -3,11 +3,15 @@ import { Future } from '../room/utils';
 
 /** An error which is thrown if a {@link DeferrableMap#getDeferred} call is aborted midway
  * through. */
-export class DeferrableMapAbortError extends DOMException {
+export class DeferrableMapAbortError extends Error {
+  code: number;
+
   reason: unknown;
 
   constructor(message: string, reason?: unknown) {
-    super(message, 'AbortError');
+    super(message);
+    this.name = 'AbortError';
+    this.code = 0;
     this.reason = reason;
   }
 }

--- a/src/utils/dom-exception.test.ts
+++ b/src/utils/dom-exception.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDOMException, isDOMException } from './dom-exception';
+
+const originalDOMException = (globalThis as { DOMException?: unknown }).DOMException;
+
+afterEach(() => {
+  (globalThis as { DOMException?: unknown }).DOMException = originalDOMException;
+});
+
+describe('dom-exception helpers', () => {
+  it('creates a fallback error when DOMException is unavailable', () => {
+    (globalThis as { DOMException?: unknown }).DOMException = undefined;
+
+    const error = createDOMException('aborted', 'AbortError') as Error & { code?: number };
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('AbortError');
+    expect(error.message).toBe('aborted');
+    expect(error.code).toBe(0);
+  });
+
+  it('still identifies fallback errors by name when DOMException is unavailable', () => {
+    (globalThis as { DOMException?: unknown }).DOMException = undefined;
+
+    const error = createDOMException('aborted', 'AbortError');
+    expect(isDOMException(error, 'AbortError')).toBe(true);
+    expect(isDOMException(error, 'TimeoutError')).toBe(false);
+  });
+});

--- a/src/utils/dom-exception.ts
+++ b/src/utils/dom-exception.ts
@@ -1,0 +1,35 @@
+type DOMExceptionCtor = new (message?: string, name?: string) => Error;
+
+function getDOMExceptionCtor(): DOMExceptionCtor | undefined {
+  const maybeCtor = (globalThis as { DOMException?: unknown }).DOMException;
+  return typeof maybeCtor === 'function' ? (maybeCtor as DOMExceptionCtor) : undefined;
+}
+
+export function createDOMException(message: string, name: string): Error {
+  const DOMExceptionClass = getDOMExceptionCtor();
+  if (DOMExceptionClass) {
+    return new DOMExceptionClass(message, name);
+  }
+
+  const fallbackError = new Error(message) as Error & { code?: number };
+  fallbackError.name = name;
+  fallbackError.code = 0;
+  return fallbackError;
+}
+
+export function isDOMException(error: unknown, name?: string): error is Error {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (name && error.name !== name) {
+    return false;
+  }
+
+  const DOMExceptionClass = getDOMExceptionCtor();
+  if (!DOMExceptionClass) {
+    return true;
+  }
+
+  return error instanceof DOMExceptionClass;
+}


### PR DESCRIPTION
## Summary
- avoid hard dependency on global `DOMException` in runtime paths that run on React Native Hermes
- replace direct `new DOMException(...)` and `instanceof DOMException` usage with helper utilities that gracefully fall back when `DOMException` is unavailable
- remove `extends DOMException` from `DeferrableMapAbortError` to prevent module-load crash and add tests + patch changeset

## Motivation
`livekit-client@2.18.1` can crash at module load in React Native Hermes with:
`ReferenceError: Property 'DOMException' doesn't exist`

This is triggered by top-level `class DeferrableMapAbortError extends DOMException` and other direct `DOMException` references.

Fixes #1871

## Validation
- `pnpm format:check`
- `pnpm throws:check`
- `pnpm test`
- `pnpm build:clean`
- `pnpm compat`