### PR TITLE
Wrap setE2EEEnabled call in a mutex

### DIFF
--- a/.changeset/tidy-parrots-act.md
+++ b/.changeset/tidy-parrots-act.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Wrap setE2EEEnabled call in a mutex

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -278,7 +278,6 @@ export class E2EEManager
         keyProvider.getKeys().forEach((keyInfo) => {
           this.postKey(keyInfo, latestKeyIndex === (keyInfo.keyIndex ?? 0));
         });
-
         this.setParticipantCryptorEnabled(
           this.room.localParticipant.isE2EEEnabled,
           this.room.localParticipant.identity,
@@ -426,7 +425,6 @@ export class E2EEManager
         participantIdentity: this.room.localParticipant.identity,
       },
     };
-
     this.worker.postMessage(msg);
   }
 

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -278,6 +278,7 @@ export class E2EEManager
         keyProvider.getKeys().forEach((keyInfo) => {
           this.postKey(keyInfo, latestKeyIndex === (keyInfo.keyIndex ?? 0));
         });
+
         this.setParticipantCryptorEnabled(
           this.room.localParticipant.isE2EEEnabled,
           this.room.localParticipant.identity,
@@ -425,6 +426,7 @@ export class E2EEManager
         participantIdentity: this.room.localParticipant.identity,
       },
     };
+
     this.worker.postMessage(msg);
   }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -187,6 +187,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   private e2eeManager: BaseE2EEManager | undefined;
 
+  private e2eeStateMutex: Mutex = new Mutex();
+
   private connectionReconcileInterval?: ReturnType<typeof setInterval>;
 
   private regionUrlProvider?: RegionUrlProvider;
@@ -411,13 +413,21 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
    * @experimental
    */
   async setE2EEEnabled(enabled: boolean) {
-    if (this.e2eeManager) {
-      await Promise.all([this.localParticipant.setE2EEEnabled(enabled)]);
-      if (this.localParticipant.identity !== '') {
-        this.e2eeManager.setParticipantCryptorEnabled(enabled, this.localParticipant.identity);
+    const unlock = await this.e2eeStateMutex.lock();
+    try {
+      if (this.e2eeManager) {
+        if (this.isE2EEEnabled !== enabled) {
+          await Promise.all([this.localParticipant.setE2EEEnabled(enabled)]);
+
+          if (this.localParticipant.identity !== '') {
+            this.e2eeManager.setParticipantCryptorEnabled(enabled, this.localParticipant.identity);
+          }
+        }
+      } else {
+        throw Error('e2ee not configured, please set e2ee settings within the room options');
       }
-    } else {
-      throw Error('e2ee not configured, please set e2ee settings within the room options');
+    } finally {
+      unlock();
     }
   }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -295,7 +295,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       });
 
     this.disconnectLock = new Mutex();
-    this.log.warn('new local participant being created');
     this.localParticipant = new LocalParticipant(
       '',
       '',
@@ -428,7 +427,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       }
     } finally {
       unlock();
-      this.log.warn('encryption has been set to ', enabled);
     }
   }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -295,7 +295,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       });
 
     this.disconnectLock = new Mutex();
-
+    this.log.warn('new local participant being created');
     this.localParticipant = new LocalParticipant(
       '',
       '',
@@ -428,6 +428,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       }
     } finally {
       unlock();
+      this.log.warn('encryption has been set to ', enabled);
     }
   }
 
@@ -460,6 +461,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         this.emit(RoomEvent.EncryptionError, error, participant);
       });
       this.e2eeManager?.setup(this);
+      this.e2eeManager?.setupEngine(this.engine);
     }
   }
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -416,7 +416,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     try {
       if (this.e2eeManager) {
         if (this.isE2EEEnabled !== enabled) {
-          await Promise.all([this.localParticipant.setE2EEEnabled(enabled)]);
+          await this.localParticipant.setE2EEEnabled(enabled);
 
           if (this.localParticipant.identity !== '') {
             this.e2eeManager.setParticipantCryptorEnabled(enabled, this.localParticipant.identity);

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1,3 +1,4 @@
+import { Mutex } from '@livekit/mutex';
 import {
   AddTrackRequest,
   AudioTrackFeature,
@@ -143,6 +144,8 @@ export default class LocalParticipant extends Participant {
 
   private encryptionType: Encryption_Type = Encryption_Type.NONE;
 
+  private e2eeStateMutex = new Mutex();
+
   private reconnectFuture?: Future<void, Error>;
 
   private signalConnectedFuture?: Future<void, Error>;
@@ -218,6 +221,7 @@ export default class LocalParticipant extends Participant {
   }
 
   get isE2EEEnabled(): boolean {
+    this.log.warn('reading e2ee Enabled state from local p', this.encryptionType);
     return this.encryptionType !== Encryption_Type.NONE;
   }
 
@@ -499,15 +503,21 @@ export default class LocalParticipant extends Participant {
 
   /** @internal */
   async setE2EEEnabled(enabled: boolean) {
-    await Promise.all(this.pendingPublishPromises.values());
-    if (
-      (enabled === true && this.encryptionType === Encryption_Type.GCM) ||
-      (enabled === false && Encryption_Type.NONE)
-    ) {
-      return;
+    const unlock = await this.e2eeStateMutex.lock();
+    try {
+      this.encryptionType = enabled ? Encryption_Type.GCM : Encryption_Type.NONE;
+      this.log.warn(`set local participant encryption type to ${this.encryptionType}`);
+      await Promise.all(this.pendingPublishPromises.values());
+      if (
+        this.trackPublications.size === 0 ||
+        Array.from(this.trackPublications.values()).every((pub) => pub.isEncrypted === enabled)
+      ) {
+        return;
+      }
+      await this.republishAllTracks(undefined, false);
+    } finally {
+      unlock();
     }
-    this.encryptionType = enabled ? Encryption_Type.GCM : Encryption_Type.NONE;
-    await this.republishAllTracks(undefined, false);
   }
 
   /**

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -499,6 +499,13 @@ export default class LocalParticipant extends Participant {
 
   /** @internal */
   async setE2EEEnabled(enabled: boolean) {
+    await Promise.all(this.pendingPublishPromises.values());
+    if (
+      (enabled === true && this.encryptionType === Encryption_Type.GCM) ||
+      (enabled === false && Encryption_Type.NONE)
+    ) {
+      return;
+    }
     this.encryptionType = enabled ? Encryption_Type.GCM : Encryption_Type.NONE;
     await this.republishAllTracks(undefined, false);
   }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -221,7 +221,6 @@ export default class LocalParticipant extends Participant {
   }
 
   get isE2EEEnabled(): boolean {
-    this.log.warn('reading e2ee Enabled state from local p', this.encryptionType);
     return this.encryptionType !== Encryption_Type.NONE;
   }
 
@@ -506,7 +505,6 @@ export default class LocalParticipant extends Participant {
     const unlock = await this.e2eeStateMutex.lock();
     try {
       this.encryptionType = enabled ? Encryption_Type.GCM : Encryption_Type.NONE;
-      this.log.warn(`set local participant encryption type to ${this.encryptionType}`);
       await Promise.all(this.pendingPublishPromises.values());
       if (
         this.trackPublications.size === 0 ||


### PR DESCRIPTION
with multiple parallel calls to `room.setE2EEEnabled` the room could get into a wrong state with publications timing out.

This PR ensures that 
- only one setE2EEEnabled call can be processed at a time, queuing up the next ones
- not doing any unnecessary work if the e2ee state is already correct