### PR TITLE
Harden remote data tracks map

### DIFF
--- a/.changeset/gentle-impalas-smoke.md
+++ b/.changeset/gentle-impalas-smoke.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Harden RemoteParticipant.dataTracks map to work when a data track subscription is processed before the room connect is complete

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -2253,10 +2253,15 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   private createParticipant(identity: string, info?: ParticipantInfo): RemoteParticipant {
     let participant: RemoteParticipant;
     if (info) {
-      participant = RemoteParticipant.fromParticipantInfo(this.engine.client, info, {
-        loggerContextCb: () => this.logContext,
-        loggerName: this.options.loggerName,
-      });
+      participant = RemoteParticipant.fromParticipantInfo(
+        this.engine.client,
+        info,
+        {
+          loggerContextCb: () => this.logContext,
+          loggerName: this.options.loggerName,
+        },
+        this.incomingDataTrackManager,
+      );
     } else {
       participant = new RemoteParticipant(
         this.engine.client,

--- a/src/room/participant/RemoteParticipant.ts
+++ b/src/room/participant/RemoteParticipant.ts
@@ -6,7 +6,9 @@ import type {
 } from '@livekit/protocol';
 import type { SignalClient } from '../../api/SignalClient';
 import { DeferrableMap } from '../../utils/deferrable-map';
-import type RemoteDataTrack from '../data-track/RemoteDataTrack';
+import RemoteDataTrack from '../data-track/RemoteDataTrack';
+import type IncomingDataTrackManager from '../data-track/incoming/IncomingDataTrackManager';
+import { DataTrackInfo } from '../data-track/types';
 import { ParticipantEvent, TrackEvent } from '../events';
 import RemoteAudioTrack from '../track/RemoteAudioTrack';
 import type RemoteTrack from '../track/RemoteTrack';
@@ -48,6 +50,7 @@ export default class RemoteParticipant extends Participant {
     signalClient: SignalClient,
     pi: ParticipantInfo,
     loggerOptions: LoggerOptions,
+    manager: IncomingDataTrackManager,
   ): RemoteParticipant {
     return new RemoteParticipant(
       signalClient,
@@ -58,6 +61,10 @@ export default class RemoteParticipant extends Participant {
       pi.attributes,
       loggerOptions,
       pi.kind,
+      pi.dataTracks.map((dti) => {
+        const info = DataTrackInfo.from(dti);
+        return new RemoteDataTrack(info, manager, { publisherIdentity: pi.identity });
+      }),
     );
   }
 
@@ -79,13 +86,18 @@ export default class RemoteParticipant extends Participant {
     attributes?: Record<string, string>,
     loggerOptions?: LoggerOptions,
     kind: ParticipantKind = ParticipantKind.STANDARD,
+    remoteDataTracks: Array<RemoteDataTrack> = [],
   ) {
     super(sid, identity || '', name, metadata, attributes, loggerOptions, kind);
     this.signalClient = signalClient;
     this.trackPublications = new Map();
     this.audioTrackPublications = new Map();
     this.videoTrackPublications = new Map();
-    this.dataTracks = new DeferrableMap();
+    this.dataTracks = new DeferrableMap(
+      remoteDataTracks.map((remoteDataTrack) => {
+        return [remoteDataTrack.info.name, remoteDataTrack];
+      }),
+    );
     this.volumeMap = new Map();
   }
 

--- a/src/utils/deferrable-map.ts
+++ b/src/utils/deferrable-map.ts
@@ -29,7 +29,7 @@ export class DeferrableMap<K, V> extends Map<K, V> {
     super.set(key, value);
 
     // Resolve any futures waiting on this key.
-    const futures = this.pending.get(key);
+    const futures = this.pending?.get(key);
     if (futures) {
       for (const future of futures) {
         if (!future.isResolved) {

--- a/src/utils/deferrable-map.ts
+++ b/src/utils/deferrable-map.ts
@@ -43,7 +43,7 @@ export class DeferrableMap<K, V> extends Map<K, V> {
   }
 
   get [Symbol.toStringTag](): string {
-    return 'WaitableMap';
+    return 'DeferrableMap';
   }
 
   /**


### PR DESCRIPTION
An edge case was observed by a customer:
1. Participant A joins and publishes a data track.
2. Participant B calls `room.connect()`, joins the room, and the `IncomingDataTrackManager` "trackPublished" event fires for all newly discovered data tracks
3. Due to the order in which events process, `room.remoteParticipants` is unset while the "trackPublished" event handler fires, so the data tracks don't get set in the `RemoteParticipant.dataTracks` deferrable map.
4. The user can't find the data tracks in the map and are confused.

To fix this, add logic to ensure that the remote data tracks are set on the map immediately when the remote participant connects, using the data in the `ParticipantInfo` signaling struct. This means that the existing "trackPublished" event path is only ever handling additions AFTER the room.connect call which works because the Room state is fully initialized at that point.

Duplicate events are fine here since the operation is idempotent - `RemoteDataTrack` is purely a pointer to state in `IncomingDataTrackManager` and multiple inserts under the same key result in the same result map.