### PR TITLE
Fix some data track subscription edge cases

### DIFF
--- a/.changeset/soft-lemons-double.md
+++ b/.changeset/soft-lemons-double.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix data tracks related subscript edge cases when the passed abort signal fires across the subscription lifecycle

--- a/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
@@ -630,7 +630,7 @@ describe('DataTrackIncomingManager', () => {
       );
 
       // 5. Unpublish the track - closeStreamControllers must tolerate the already-errored
-      // controller instead of crashing with "Cannot close an errored readable stream"
+      // controller (this used to crashing with "Cannot close an errored readable stream")
       await manager.receiveSfuPublicationUpdates(new Map([[senderIdentity, []]]));
 
       // 6. Make sure the trackUnpublished event fires
@@ -662,20 +662,20 @@ describe('DataTrackIncomingManager', () => {
         sid,
         controller.signal,
       );
-      const reader = stream.getReader();
       await managerEvents.waitFor('sfuUpdateSubscription');
       manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
       await sfuSubscriptionComplete;
 
       // 3. Abort the controller to error the stream's underlying controller
+      const reader = stream.getReader();
       const inFlightReadPromise = reader.read();
       controller.abort();
       await expect(inFlightReadPromise).rejects.toThrowError(
         'Subscription to data track cancelled by caller',
       );
 
-      // 4. Shutdown must not throw even though the controller is already errored
-      expect(() => manager.shutdown()).not.toThrow();
+      // 4. Shutdown the manager, and make sure it doesn't throw
+      manager.shutdown();
 
       // 5. Make sure the trackUnpublished event fires for the descriptor
       const trackUnpublishedEvent = await managerEvents.waitFor('trackUnpublished');
@@ -734,7 +734,7 @@ describe('DataTrackIncomingManager', () => {
       // 5. B's reader closes cleanly
       await readerB.closed;
 
-      // 6. Single unsubscribe event - no double-unsubscribe from A's abort + disconnect
+      // 6. Perform a single unsubscribe event - no double-unsubscribe from A's abort + disconnect
       const endEvent = await managerEvents.waitFor('sfuUpdateSubscription');
       expect(endEvent.sid).toStrictEqual(sid);
       expect(endEvent.subscribe).toStrictEqual(false);

--- a/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
@@ -581,6 +581,230 @@ describe('DataTrackIncomingManager', () => {
       expect(endEvent.subscribe).toStrictEqual(false);
     });
 
+    it('should terminate ACTIVE sfu subscriptions which have been aborted if the track is unpublished', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+        'trackUnpublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      // 1. Make sure the data track publication is registered
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      await managerEvents.waitFor('trackPublished');
+
+      // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
+      const controller = new AbortController();
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const reader = stream.getReader();
+      await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+
+      // 3. Start an in flight stream read
+      await sfuSubscriptionComplete;
+      const inFlightReadPromise = reader.read();
+
+      // 4. Abort the controller - this errors the stream's underlying controller
+      controller.abort();
+      await expect(inFlightReadPromise).rejects.toThrowError(
+        'Subscription to data track cancelled by caller',
+      );
+
+      // 5. Unpublish the track - closeStreamControllers must tolerate the already-errored
+      // controller instead of crashing with "Cannot close an errored readable stream"
+      await manager.receiveSfuPublicationUpdates(new Map([[senderIdentity, []]]));
+
+      // 6. Make sure the trackUnpublished event fires
+      const trackUnpublishedEvent = await managerEvents.waitFor('trackUnpublished');
+      expect(trackUnpublishedEvent.sid).toStrictEqual(sid);
+    });
+
+    it('should not throw when shutting down with an aborted active subscription', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+        'trackUnpublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      // 1. Make sure the data track publication is registered
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      await managerEvents.waitFor('trackPublished');
+
+      // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
+      const controller = new AbortController();
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const reader = stream.getReader();
+      await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+      await sfuSubscriptionComplete;
+
+      // 3. Abort the controller to error the stream's underlying controller
+      const inFlightReadPromise = reader.read();
+      controller.abort();
+      await expect(inFlightReadPromise).rejects.toThrowError(
+        'Subscription to data track cancelled by caller',
+      );
+
+      // 4. Shutdown must not throw even though the controller is already errored
+      expect(() => manager.shutdown()).not.toThrow();
+
+      // 5. Make sure the trackUnpublished event fires for the descriptor
+      const trackUnpublishedEvent = await managerEvents.waitFor('trackUnpublished');
+      expect(trackUnpublishedEvent.sid).toStrictEqual(sid);
+    });
+
+    it('should close the remaining active stream when one of two active subscriptions is aborted before disconnect', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      // 1. Make sure the data track publication is registered
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      await managerEvents.waitFor('trackPublished');
+
+      // 2. Open two subscriptions with separate abort controllers
+      const controllerA = new AbortController();
+      const [streamA, sfuSubscriptionACompletePromise] = manager.openSubscriptionStream(
+        sid,
+        controllerA.signal,
+      );
+      await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+      await sfuSubscriptionACompletePromise;
+
+      const controllerB = new AbortController();
+      const [streamB, sfuSubscriptionBCompletePromise] = manager.openSubscriptionStream(
+        sid,
+        controllerB.signal,
+      );
+      await sfuSubscriptionBCompletePromise;
+
+      const readerA = streamA.getReader();
+      const readerB = streamB.getReader();
+      const inFlightReadAPromise = readerA.read();
+
+      // 3. Abort only A - this errors A's controller
+      controllerA.abort();
+      await expect(inFlightReadAPromise).rejects.toThrowError(
+        'Subscription to data track cancelled by caller',
+      );
+
+      // 4. Disconnect the participant. closeStreamControllers must gracefully close B
+      // without crashing on A's errored controller (which should already have been removed
+      // from the map by onAbort).
+      manager.handleRemoteParticipantDisconnected(senderIdentity);
+
+      // 5. B's reader closes cleanly
+      await readerB.closed;
+
+      // 6. Single unsubscribe event - no double-unsubscribe from A's abort + disconnect
+      const endEvent = await managerEvents.waitFor('sfuUpdateSubscription');
+      expect(endEvent.sid).toStrictEqual(sid);
+      expect(endEvent.subscribe).toStrictEqual(false);
+      expect(managerEvents.areThereBufferedEvents('sfuUpdateSubscription')).toBe(false);
+    });
+
+    it('should error the stream if the descriptor is unpublished between subscribe resolve and post-subscribe setup', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+        'trackUnpublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      // 1. Make sure the data track publication is registered
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      await managerEvents.waitFor('trackPublished');
+
+      // 2. Start subscribing - the .then handler on subscribeRequest is now pending
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid);
+      const reader = stream.getReader();
+      await managerEvents.waitFor('sfuUpdateSubscription');
+
+      // 3. Acknowledge the SFU handle - this synchronously resolves the completionFuture
+      // and flips the subscription state to 'active', but the .then microtask has not run yet
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+
+      // 4. Synchronously unpublish the track before the .then microtask fires
+      manager.handleTrackUnpublished(sid);
+
+      // 5. When .then runs, the descriptor lookup returns undefined and the handler
+      // must error the stream and reject sfuSubscriptionComplete (instead of hanging)
+      await expect(sfuSubscriptionComplete).rejects.toStrictEqual(
+        DataTrackSubscribeError.disconnected(),
+      );
+      await expect(reader.read()).rejects.toStrictEqual(
+        DataTrackSubscribeError.disconnected(),
+      );
+    });
+
+    it('should not throw or emit extra events when aborting after a manager-driven close', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      // 1. Make sure the data track publication is registered
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      await managerEvents.waitFor('trackPublished');
+
+      // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
+      const controller = new AbortController();
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const reader = stream.getReader();
+      await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+      await sfuSubscriptionComplete;
+
+      // 3. Manager-driven close via disconnect. detachSignal must have run so that the
+      // user's AbortSignal no longer triggers onAbort.
+      manager.handleRemoteParticipantDisconnected(senderIdentity);
+      await reader.closed;
+
+      // 4. Consume the unsubscribe event
+      const endEvent = await managerEvents.waitFor('sfuUpdateSubscription');
+      expect(endEvent.subscribe).toBe(false);
+
+      // 5. Aborting after the manager has already closed the stream must be a no-op:
+      // no throw, and no additional sfuUpdateSubscription events
+      expect(() => controller.abort()).not.toThrow();
+      expect(managerEvents.areThereBufferedEvents('sfuUpdateSubscription')).toBe(false);
+    });
+
     it('should terminate the sfu subscription once all downstream ReadableStreams are cancelled', async () => {
       const manager = new IncomingDataTrackManager();
       const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [

--- a/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
@@ -274,9 +274,8 @@ describe('DataTrackIncomingManager', () => {
 
     it('should be unable to subscribe to a non existing data track', async () => {
       const manager = new IncomingDataTrackManager();
-      await expect(manager.subscribeRequest('does not exist')).rejects.toThrowError(
-        'Cannot subscribe to unknown track',
-      );
+      const [, subscriptionPromise] = manager.openSubscriptionStream('does not exist');
+      await expect(subscriptionPromise).rejects.toThrowError('Cannot subscribe to unknown track');
     });
 
     it('should terminate the sfu subscription if the abortsignal is triggered on the only subscription', async () => {
@@ -301,7 +300,10 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track
       const controller = new AbortController();
-      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(
+        sid,
+        controller.signal,
+      );
       await managerEvents.waitFor('sfuUpdateSubscription');
       manager.receivedSfuSubscriberHandles(new Map([[DataTrackHandle.fromNumber(5), sid]]));
 
@@ -350,13 +352,19 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track twice
       const controllerOne = new AbortController();
-      const [streamOne, sfuSubscriptionOneComplete] = manager.openSubscriptionStream(sid, controllerOne.signal);
+      const [streamOne, sfuSubscriptionOneComplete] = manager.openSubscriptionStream(
+        sid,
+        controllerOne.signal,
+      );
       await managerEvents.waitFor('sfuUpdateSubscription'); // Subscription started
       manager.receivedSfuSubscriberHandles(new Map([[DataTrackHandle.fromNumber(5), sid]]));
       await sfuSubscriptionOneComplete;
 
       const controllerTwo = new AbortController();
-      const [streamTwo, sfuSubscriptionTwoComplete] = manager.openSubscriptionStream(sid, controllerTwo.signal);
+      const [streamTwo, sfuSubscriptionTwoComplete] = manager.openSubscriptionStream(
+        sid,
+        controllerTwo.signal,
+      );
       // NOTE: no new sfu subscription here, the first stream handled setting this up
       await sfuSubscriptionTwoComplete;
 
@@ -375,10 +383,9 @@ describe('DataTrackIncomingManager', () => {
 
       // 4. Make sure the other subscription is still active / was untouched by the first stream
       // being aborted.
-      await expect(Promise.race([
-        inFlightReadTwoPromise,
-        Promise.resolve('pending')
-      ])).resolves.toStrictEqual('pending');
+      await expect(
+        Promise.race([inFlightReadTwoPromise, Promise.resolve('pending')]),
+      ).resolves.toStrictEqual('pending');
 
       // 4. Make sure the underlying sfu subscription has not been also cancelled, there still is
       // one data track subscription active
@@ -404,7 +411,7 @@ describe('DataTrackIncomingManager', () => {
       );
 
       // Subscribe to a data track
-      const subscribeRequestPromise = manager.subscribeRequest(
+      const [, subscribeRequestPromise] = manager.openSubscriptionStream(
         sid,
         AbortSignal.abort(/* already aborted */),
       );
@@ -443,14 +450,14 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Create subscription A
       const controllerA = new AbortController();
-      const subscribeAPromise = manager.subscribeRequest(sid, controllerA.signal);
+      const [, subscribeAPromise] = manager.openSubscriptionStream(sid, controllerA.signal);
       const startEvent = await managerEvents.waitFor('sfuUpdateSubscription');
       expect(startEvent.sid).toStrictEqual(sid);
       expect(startEvent.subscribe).toStrictEqual(true);
 
       // 2. Create subscription B
       const controllerB = new AbortController();
-      const subscribeBPromise = manager.subscribeRequest(sid, controllerB.signal);
+      const [, subscribeBPromise] = manager.openSubscriptionStream(sid, controllerB.signal);
       expect(managerEvents.areThereBufferedEvents('sfuUpdateSubscription')).toStrictEqual(false);
 
       // 3. Cancel the subscription A
@@ -485,13 +492,13 @@ describe('DataTrackIncomingManager', () => {
       await managerEvents.waitFor('trackPublished');
 
       // 2. Begin subscribing to a data track
-      const promise = manager.subscribeRequest(sid);
+      const [, subscriptionCompletePromise] = manager.openSubscriptionStream(sid);
 
       // 3. Simulate the remote participant disconnecting
       manager.handleRemoteParticipantDisconnected(senderIdentity);
 
       // 4. Make sure the pending subscribe was terminated
-      await expect(promise).rejects.toThrowError(
+      await expect(subscriptionCompletePromise).rejects.toThrowError(
         'Cannot subscribe to data track when disconnected',
       );
     });
@@ -555,13 +562,16 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
       const controller = new AbortController();
-      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(
+        sid,
+        controller.signal,
+      );
       const reader = stream.getReader();
       const sfuUpdateSubscriptionEvent = await managerEvents.waitFor('sfuUpdateSubscription');
       expect(sfuUpdateSubscriptionEvent.sid).toStrictEqual(sid);
       expect(sfuUpdateSubscriptionEvent.subscribe).toStrictEqual(true);
       manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
-  
+
       // 3. Start an in flight stream read
       await sfuSubscriptionComplete;
       const inFlightReadPromise = reader.read();
@@ -601,7 +611,10 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
       const controller = new AbortController();
-      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(
+        sid,
+        controller.signal,
+      );
       const reader = stream.getReader();
       await managerEvents.waitFor('sfuUpdateSubscription');
       manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
@@ -645,7 +658,10 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
       const controller = new AbortController();
-      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(
+        sid,
+        controller.signal,
+      );
       const reader = stream.getReader();
       await managerEvents.waitFor('sfuUpdateSubscription');
       manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
@@ -760,9 +776,7 @@ describe('DataTrackIncomingManager', () => {
       await expect(sfuSubscriptionComplete).rejects.toStrictEqual(
         DataTrackSubscribeError.disconnected(),
       );
-      await expect(reader.read()).rejects.toStrictEqual(
-        DataTrackSubscribeError.disconnected(),
-      );
+      await expect(reader.read()).rejects.toStrictEqual(DataTrackSubscribeError.disconnected());
     });
 
     it('should not throw or emit extra events when aborting after a manager-driven close', async () => {
@@ -784,7 +798,10 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
       const controller = new AbortController();
-      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(
+        sid,
+        controller.signal,
+      );
       const reader = stream.getReader();
       await managerEvents.waitFor('sfuUpdateSubscription');
       manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));

--- a/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
@@ -301,20 +301,31 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track
       const controller = new AbortController();
-      const subscribeRequestPromise = manager.subscribeRequest(sid, controller.signal);
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
       await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[DataTrackHandle.fromNumber(5), sid]]));
 
-      // 3. Cancel the subscription
+      // 3. Wait for the subscription to be fully established
+      await sfuSubscriptionComplete;
+
+      // 4. Start consuming the readable stream
+      const reader = stream.getReader();
+      const inFlightReadPromise = reader.read();
+
+      // 5. Cancel the subscription
       controller.abort();
-      await expect(subscribeRequestPromise).rejects.toThrowError(
+      await expect(inFlightReadPromise).rejects.toThrowError(
         'Subscription to data track cancelled by caller',
       );
 
-      // 4. Make sure the underlying sfu subscription is also terminated, since nothing needs it
+      // 6. Make sure the underlying sfu subscription is also terminated, since nothing needs it
       // anymore.
       const sfuUpdateSubscriptionEvent = await managerEvents.waitFor('sfuUpdateSubscription');
       expect(sfuUpdateSubscriptionEvent.sid).toStrictEqual(sid);
       expect(sfuUpdateSubscriptionEvent.subscribe).toStrictEqual(false);
+
+      // 7. Make sure shutting down the manager doesn't throw errors
+      manager.shutdown();
     });
 
     it('should NOT terminate the sfu subscription if the abortsignal is triggered on one of two active subscriptions', async () => {
@@ -339,17 +350,35 @@ describe('DataTrackIncomingManager', () => {
 
       // 2. Subscribe to a data track twice
       const controllerOne = new AbortController();
-      const subscribeRequestOnePromise = manager.subscribeRequest(sid, controllerOne.signal);
+      const [streamOne, sfuSubscriptionOneComplete] = manager.openSubscriptionStream(sid, controllerOne.signal);
       await managerEvents.waitFor('sfuUpdateSubscription'); // Subscription started
+      manager.receivedSfuSubscriberHandles(new Map([[DataTrackHandle.fromNumber(5), sid]]));
+      await sfuSubscriptionOneComplete;
 
       const controllerTwo = new AbortController();
-      manager.subscribeRequest(sid, controllerTwo.signal);
+      const [streamTwo, sfuSubscriptionTwoComplete] = manager.openSubscriptionStream(sid, controllerTwo.signal);
+      // NOTE: no new sfu subscription here, the first stream handled setting this up
+      await sfuSubscriptionTwoComplete;
 
-      // 3. Cancel the first subscription
+      // 3. Start consuming the both subscription's readable streams
+      const readerOne = streamOne.getReader();
+      const inFlightReadOnePromise = readerOne.read();
+
+      const readerTwo = streamTwo.getReader();
+      const inFlightReadTwoPromise = readerTwo.read();
+
+      // 3. Cancel the first subscription, make sure JUST that subscription is cancelled
       controllerOne.abort();
-      await expect(subscribeRequestOnePromise).rejects.toThrowError(
+      await expect(inFlightReadOnePromise).rejects.toThrowError(
         'Subscription to data track cancelled by caller',
       );
+
+      // 4. Make sure the other subscription is still active / was untouched by the first stream
+      // being aborted.
+      await expect(Promise.race([
+        inFlightReadTwoPromise,
+        Promise.resolve('pending')
+      ])).resolves.toStrictEqual('pending');
 
       // 4. Make sure the underlying sfu subscription has not been also cancelled, there still is
       // one data track subscription active
@@ -505,6 +534,51 @@ describe('DataTrackIncomingManager', () => {
 
       // 6. Make sure the in flight stream read was closed
       await reader.closed;
+    });
+
+    it('should terminate ACTIVE sfu subscriptions which have been aborted if the participant disconnects', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      // 1. Make sure the data track publication is registered
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      await managerEvents.waitFor('trackPublished');
+
+      // 2. Subscribe to a data track, and send the handle back as if the SFU acknowledged it
+      const controller = new AbortController();
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid, controller.signal);
+      const reader = stream.getReader();
+      const sfuUpdateSubscriptionEvent = await managerEvents.waitFor('sfuUpdateSubscription');
+      expect(sfuUpdateSubscriptionEvent.sid).toStrictEqual(sid);
+      expect(sfuUpdateSubscriptionEvent.subscribe).toStrictEqual(true);
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+  
+      // 3. Start an in flight stream read
+      await sfuSubscriptionComplete;
+      const inFlightReadPromise = reader.read();
+
+      // 4. Abort the abort controller, which should abort the in flight stream read
+      controller.abort();
+      await expect(inFlightReadPromise).rejects.toThrowError(
+        'Subscription to data track cancelled by caller',
+      );
+
+      // 4. Simulate the remote participant disconnecting
+      manager.handleRemoteParticipantDisconnected(senderIdentity);
+
+      // 5. Make sure the sfu unsubscribes
+      const endEvent = await managerEvents.waitFor('sfuUpdateSubscription');
+      expect(endEvent.sid).toStrictEqual(sid);
+      expect(endEvent.subscribe).toStrictEqual(false);
     });
 
     it('should terminate the sfu subscription once all downstream ReadableStreams are cancelled', async () => {

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -126,15 +126,51 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     let streamController: ReadableStreamDefaultController<DataTrackFrame> | null = null;
     const sfuSubscriptionComplete = new Future<void, DataTrackSubscribeError>();
 
+    const cleanup = () => {
+      signal?.removeEventListener('abort', onAbort);
+
+      if (!streamController) {
+        log.warn(`ReadableStream subscribed to ${sid} was not started.`);
+        return;
+      }
+      const descriptor = this.descriptors.get(sid);
+      if (!descriptor) {
+        log.warn(`Unknown track ${sid}, skipping cancel...`);
+        return;
+      }
+      if (descriptor.subscription.type !== 'active') {
+        log.warn(`Subscription for track ${sid} is not active, skipping cancel...`);
+        return;
+      }
+
+      descriptor.subscription.streamControllers.delete(streamController);
+
+      // If no active stream controllers are left, also unsubscribe on the SFU end.
+      if (descriptor.subscription.streamControllers.size === 0) {
+        this.unSubscribeRequest(descriptor.info.sid);
+      }
+    };
+
+    const onAbort = () => {
+      if (!streamController) {
+        return;
+      }
+      console.log('ABORT');
+      const currentDescriptor = this.descriptors.get(sid);
+      if (currentDescriptor?.subscription.type === 'active') {
+        currentDescriptor.subscription.streamControllers.delete(streamController);
+      }
+
+      streamController.error(DataTrackSubscribeError.cancelled());
+      sfuSubscriptionComplete.reject?.(DataTrackSubscribeError.cancelled());
+
+      cleanup();
+    };
+
     const stream = new ReadableStream<DataTrackFrame>(
       {
         start: (controller) => {
           streamController = controller;
-
-          const onAbort = () => {
-            controller.error(DataTrackSubscribeError.cancelled());
-            sfuSubscriptionComplete.reject?.(DataTrackSubscribeError.cancelled());
-          };
 
           this.subscribeRequest(sid, signal)
             .then(async () => {
@@ -157,31 +193,9 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
               controller.error(err);
               sfuSubscriptionComplete.reject?.(err);
             })
-            .finally(() => {
-              signal?.removeEventListener('abort', onAbort);
-            });
         },
         cancel: () => {
-          if (!streamController) {
-            log.warn(`ReadableStream subscribed to ${sid} was not started.`);
-            return;
-          }
-          const descriptor = this.descriptors.get(sid);
-          if (!descriptor) {
-            log.warn(`Unknown track ${sid}, skipping cancel...`);
-            return;
-          }
-          if (descriptor.subscription.type !== 'active') {
-            log.warn(`Subscription for track ${sid} is not active, skipping cancel...`);
-            return;
-          }
-
-          descriptor.subscription.streamControllers.delete(streamController);
-
-          // If no active stream controllers are left, also unsubscribe on the SFU end.
-          if (descriptor.subscription.streamControllers.size === 0) {
-            this.unSubscribeRequest(descriptor.info.sid);
-          }
+          cleanup();
         },
       },
       new CountQueuingStrategy({ highWaterMark: bufferSize }),

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -52,7 +52,10 @@ type SubscriptionStateActive = {
   type: 'active';
   subcriptionHandle: DataTrackHandle;
   pipeline: IncomingDataTrackPipeline;
-  streamControllers: Set<ReadableStreamDefaultController<DataTrackFrame>>;
+  /** Map from each downstream ReadableStream's controller to a function that detaches the user's
+   * abort signal listener for that stream. Stored together so that whoever ends the stream
+   * (consumer cancel, user abort, or manager-driven close) can remove the associated listener. */
+  streamControllers: Map<ReadableStreamDefaultController<DataTrackFrame>, () => void>;
 };
 
 type SubscriptionState = SubscriptionStateNone | SubscriptionStatePending | SubscriptionStateActive;
@@ -126,8 +129,12 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     let streamController: ReadableStreamDefaultController<DataTrackFrame> | null = null;
     const sfuSubscriptionComplete = new Future<void, DataTrackSubscribeError>();
 
-    const cleanup = () => {
+    const detachSignal = () => {
       signal?.removeEventListener('abort', onAbort);
+    };
+
+    const cleanup = () => {
+      detachSignal();
 
       if (!streamController) {
         log.warn(`ReadableStream subscribed to ${sid} was not started.`);
@@ -155,7 +162,6 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       if (!streamController) {
         return;
       }
-      console.log('ABORT');
       const currentDescriptor = this.descriptors.get(sid);
       if (currentDescriptor?.subscription.type === 'active') {
         currentDescriptor.subscription.streamControllers.delete(streamController);
@@ -174,25 +180,39 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
 
           this.subscribeRequest(sid, signal)
             .then(async () => {
-              signal?.addEventListener('abort', onAbort);
-
               const descriptor = this.descriptors.get(sid);
               if (!descriptor) {
                 log.error(`Unknown track ${sid}`);
+                const err = DataTrackSubscribeError.disconnected();
+                controller.error(err);
+                sfuSubscriptionComplete.reject?.(err);
                 return;
               }
               if (descriptor.subscription.type !== 'active') {
                 log.error(`Subscription for track ${sid} is not active`);
+                const err = DataTrackSubscribeError.disconnected();
+                controller.error(err);
+                sfuSubscriptionComplete.reject?.(err);
                 return;
               }
 
-              descriptor.subscription.streamControllers.add(controller);
+              // Attach the abort signal, aborting immediately if the abort signal was fired while
+              // subscribeRequest was in flight.
+              if (signal?.aborted) {
+                onAbort();
+                return;
+              }
+              signal?.addEventListener('abort', onAbort);
+
+              descriptor.subscription.streamControllers.set(controller, detachSignal);
               sfuSubscriptionComplete.resolve?.();
             })
             .catch((err) => {
+              // subscribeRequest rejected (cancelled, timed out, disconnected). The signal
+              // listener was never attached in this path, so nothing to detach.
               controller.error(err);
               sfuSubscriptionComplete.reject?.(err);
-            })
+            });
         },
         cancel: () => {
           cleanup();
@@ -362,9 +382,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       return;
     }
 
-    for (const controller of descriptor.subscription.streamControllers) {
-      controller.close();
-    }
+    this.closeStreamControllers(descriptor.subscription.streamControllers, sid);
 
     // FIXME: this might be wrong? Shouldn't this only occur if it is the last subscription to
     // terminate?
@@ -373,6 +391,27 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     this.subscriptionHandles.delete(previousDescriptorSubscription.subcriptionHandle);
 
     this.emit('sfuUpdateSubscription', { sid, subscribe: false });
+  }
+
+  /** Detach abort-signal listeners and close all downstream stream controllers for an active
+   * subscription. Used when the subscription is being torn down by the manager (unsubscribe,
+   * unpublish, or shutdown). */
+  private closeStreamControllers(
+    streamControllers: SubscriptionStateActive['streamControllers'],
+    sid: DataTrackSid,
+  ) {
+    for (const [controller, detachSignal] of streamControllers) {
+      // Detach before close so we don't leak a listener on the user's AbortSignal.
+      detachSignal();
+      try {
+        controller.close();
+      } catch (err) {
+        // Defensive: if the controller has already been errored (e.g. by a racing abort whose
+        // listener removed itself before we got here), close() throws. There's nothing
+        // meaningful to do other than log — the stream is already terminal.
+        log.warn(`Failed to close readable stream for track ${sid}: ${err}`);
+      }
+    }
   }
 
   /** SFU notification that track publications have changed.
@@ -450,9 +489,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     this.descriptors.delete(sid);
 
     if (descriptor.subscription.type === 'active') {
-      for (const controller of descriptor.subscription.streamControllers) {
-        controller.close();
-      }
+      this.closeStreamControllers(descriptor.subscription.streamControllers, sid);
       this.subscriptionHandles.delete(descriptor.subscription.subcriptionHandle);
     }
 
@@ -500,7 +537,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
           type: 'active',
           subcriptionHandle: assignedHandle,
           pipeline,
-          streamControllers: new Set(),
+          streamControllers: new Map(),
         };
         this.subscriptionHandles.set(assignedHandle, sid);
 
@@ -543,7 +580,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     }
 
     // Broadcast to all downstream subscribers
-    for (const controller of descriptor.subscription.streamControllers) {
+    for (const controller of descriptor.subscription.streamControllers.keys()) {
       if (controller.desiredSize !== null && controller.desiredSize <= 0) {
         log.warn(
           `Cannot send frame to subscribers: readable stream is full (desiredSize is ${controller.desiredSize}). To increase this threshold, set a higher 'options.highWaterMark' when calling .subscribe().`,
@@ -602,9 +639,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       }
 
       if (descriptor.subscription.type === 'active') {
-        for (const controller of descriptor.subscription.streamControllers) {
-          controller.close();
-        }
+        this.closeStreamControllers(descriptor.subscription.streamControllers, descriptor.info.sid);
       }
     }
     this.descriptors.clear();

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -450,9 +450,9 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     this.descriptors.delete(sid);
 
     if (descriptor.subscription.type === 'active') {
-      descriptor.subscription.streamControllers.forEach((controller) => {
+      for (const controller of descriptor.subscription.streamControllers) {
         controller.close();
-      });
+      }
       this.subscriptionHandles.delete(descriptor.subscription.subcriptionHandle);
     }
 
@@ -602,7 +602,9 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       }
 
       if (descriptor.subscription.type === 'active') {
-        descriptor.subscription.streamControllers.forEach((controller) => controller.close());
+        for (const controller of descriptor.subscription.streamControllers) {
+          controller.close();
+        }
       }
     }
     this.descriptors.clear();


### PR DESCRIPTION
A customer surfaced some issues with the `signal` parameter passed to data track subscriptions - when this was passed and aborted during certain parts of the subscription / participant connection lifecycle outside the happy path, it was possible that things could get into an inconsistent state:

- Aborting after participant disconnect - the stream would throw a `Cannot close an errored readable stream` error in this case because the manager tried to clean up a subscription that the user had already manually aborted. So, make sure the stream controller gets removed from the list so it doesn't get double-closed.

- The data track is unpublished during the brief window of time between the sfu subscription being established and the readable stream finishing being setup. If this happened, the readable stream would hang forever isntead of explicitly aborting.

- Abort signal listener not being cleaned up properly in all cases - if the manager closes the stream (the stream doesn't get into an error state, it is explicitly closed), then this wouldn't clean up the abort signal listener, so if a user triggered the abort signal later, it would cause an error to be throw.

These cases now all have explicit tests that test a few variations to ensure that this doesn't regress.