### PR TITLE
fix: avoid attaching a new Closing event listener for each waitForBufferStatusLow call

### DIFF
--- a/.changeset/modern-birds-lose.md
+++ b/.changeset/modern-birds-lose.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Avoid attaching a new Closing event listener for each waitForBufferStatusLow call

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1594,13 +1594,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           return;
         }
         this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
-        dc.addEventListener(
-          'bufferedamountlow',
-          () => resolve(),
-          {
-            once: true,
-          },
-        );
+        dc.addEventListener('bufferedamountlow', () => resolve(), {
+          once: true,
+        });
       }
     });
   }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -250,7 +250,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** used to indicate whether the browser is currently waiting to reconnect */
   private isWaitingForNetworkReconnect: boolean = false;
 
-  private bufferStatusLowClosingFuture = new Future<void, UnexpectedConnectionState>();
+  private bufferStatusLowClosingFuture = new Future<never, UnexpectedConnectionState>();
 
   constructor(private options: InternalRoomOptions) {
     super();

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -86,6 +86,7 @@ import type { TrackPublishOptions, VideoCodec } from './track/options';
 import { getTrackPublicationInfo } from './track/utils';
 import type { LoggerOptions } from './types';
 import {
+  Future,
   isCompressionStreamSupported,
   isVideoCodec,
   isVideoTrack,
@@ -249,6 +250,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** used to indicate whether the browser is currently waiting to reconnect */
   private isWaitingForNetworkReconnect: boolean = false;
 
+  private bufferStatusLowClosingFuture = new Future<void, UnexpectedConnectionState>();
+
   constructor(private options: InternalRoomOptions) {
     super();
     this.log = getLogger(options.loggerName ?? LoggerNames.Engine);
@@ -282,6 +285,13 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.client.onParticipantUpdate = (updates) =>
       this.emit(EngineEvent.ParticipantUpdate, updates);
     this.client.onJoined = (joinResponse) => this.emit(EngineEvent.Joined, joinResponse);
+
+    this.on(EngineEvent.Closing, () => {
+      this.bufferStatusLowClosingFuture.reject?.(new UnexpectedConnectionState('engine closed'));
+    });
+    // Swallow the rejection at the source so it doesn't surface as an unhandled promise rejection
+    // when no waitForBufferStatusLow callers are attached.
+    this.bufferStatusLowClosingFuture.promise.catch(() => {});
   }
 
   /** @internal */
@@ -1578,19 +1588,15 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       if (this.isBufferStatusLow(kind)) {
         resolve();
       } else {
-        const onClosing = () => reject(new UnexpectedConnectionState('engine closed'));
-        this.once(EngineEvent.Closing, onClosing);
         const dc = this.dataChannelForKind(kind);
         if (!dc) {
           reject(new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`));
           return;
         }
+        this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
         dc.addEventListener(
           'bufferedamountlow',
-          () => {
-            this.off(EngineEvent.Closing, onClosing);
-            resolve();
-          },
+          () => resolve(),
           {
             once: true,
           },


### PR DESCRIPTION
In the `waitForBufferStatusLow` method of RTCEngine, a bunch of this.once calls are currently being made to listen for `RTCEngine` `Closing` events. This can result potentially in errors like the below if `waitForBufferStatusLow` is called at a high rate (the below was captured in firefox, fwiw):

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 closing  
listeners added. Use emitter.setMaxListeners() to increase limit                     
    _addListener events.js:211                                                       
    addListener events.js:227                                                        
    once events.js:257                                                               
    waitForBufferStatusLow RTCEngine.ts:1569                                         
    __awaiter livekit-client.esm.mjs:8244                                            
    __awaiter livekit-client.esm.mjs:8240                                            
    waitForBufferStatusLow RTCEngine.ts:1561                                         
    TypedPromise TypedPromise.ts:8                                                   
    waitForBufferStatusLow RTCEngine.ts:1561                                         
    __awaiter livekit-client.esm.mjs:8244                                            
    __awaiter livekit-client.esm.mjs:8240                                            
    waitForBufferStatusLow livekit-client.esm.mjs:21539                              
    sendLossyBytes RTCEngine.ts:1499                                                 
    fulfilled livekit-client.esm.mjs:8241                                            
    promise callback*step livekit-client.esm.mjs:8243                                
    __awaiter livekit-client.esm.mjs:8244                                            
    __awaiter livekit-client.esm.mjs:8240                                            
    sendLossyBytes RTCEngine.ts:1485                                                 
    Room Room.ts:294                                                                 
    emit events.js:153                                                               
    tryProcessAndSend OutgoingDataTrackManager.ts:157                                
```

While this seems to have been a problem in theory for a while, the recent shift to listening to `bufferedamountlow` events in https://github.com/livekit/client-sdk-js/pull/1877 rather than `await sleep(10)` in a loop I think has made this inadvertently worse, as the `sleep`s previously were giving the listeners time to drain and keeping the RtcEngine listener count below the threshold.

So instead, listen once and fan out that single event to all in flight `waitForBufferStatusLow` calls.