### PR TITLE
Clean pending initial offer when close pc

### DIFF
--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -165,7 +165,7 @@ export default class PCTransport extends EventEmitter {
       this.remoteStereoMids = stereoMids;
       this.remoteNackMids = nackMids;
     } else if (sd.type === 'answer') {
-      if (this.pendingInitialOffer) {
+      if (this.pendingInitialOffer && this._pc) {
         const initialOffer = this.pendingInitialOffer;
         this.pendingInitialOffer = undefined;
         const sdpParsed = parse(initialOffer.sdp ?? '');

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -166,15 +166,15 @@ export default class PCTransport extends EventEmitter {
       this.remoteNackMids = nackMids;
     } else if (sd.type === 'answer') {
       if (this.pendingInitialOffer) {
-            const initialOffer = this.pendingInitialOffer;
-            this.pendingInitialOffer = undefined;
-            const sdpParsed = parse(initialOffer.sdp ?? '');
-            sdpParsed.media.forEach((media) => {
-              ensureIPAddrMatchVersion(media);
-            });
+        const initialOffer = this.pendingInitialOffer;
+        this.pendingInitialOffer = undefined;
+        const sdpParsed = parse(initialOffer.sdp ?? '');
+        sdpParsed.media.forEach((media) => {
+          ensureIPAddrMatchVersion(media);
+        });
         this.log.debug('setting pending initial offer before processing answer', this.logContext);
-            await this.setMungedSDP(initialOffer, write(sdpParsed));
-          }
+        await this.setMungedSDP(initialOffer, write(sdpParsed));
+      }
       const sdpParsed = parse(sd.sdp ?? '');
       sdpParsed.media.forEach((media) => {
         const mid = getMidString(media.mid!);

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -166,15 +166,15 @@ export default class PCTransport extends EventEmitter {
       this.remoteNackMids = nackMids;
     } else if (sd.type === 'answer') {
       if (this.pendingInitialOffer) {
-        const initialOffer = this.pendingInitialOffer;
-        this.pendingInitialOffer = undefined;
-        const sdpParsed = parse(initialOffer.sdp ?? '');
-        sdpParsed.media.forEach((media) => {
-          ensureIPAddrMatchVersion(media);
-        });
+            const initialOffer = this.pendingInitialOffer;
+            this.pendingInitialOffer = undefined;
+            const sdpParsed = parse(initialOffer.sdp ?? '');
+            sdpParsed.media.forEach((media) => {
+              ensureIPAddrMatchVersion(media);
+            });
         this.log.debug('setting pending initial offer before processing answer', this.logContext);
-        await this.setMungedSDP(initialOffer, write(sdpParsed));
-      }
+            await this.setMungedSDP(initialOffer, write(sdpParsed));
+          }
       const sdpParsed = parse(sd.sdp ?? '');
       sdpParsed.media.forEach((media) => {
         const mid = getMidString(media.mid!);
@@ -523,6 +523,7 @@ export default class PCTransport extends EventEmitter {
     if (!this._pc) {
       return;
     }
+    this.pendingInitialOffer = undefined;
     this._pc.close();
     this._pc.onconnectionstatechange = null;
     this._pc.oniceconnectionstatechange = null;
@@ -565,9 +566,9 @@ export default class PCTransport extends EventEmitter {
 
     try {
       if (remote) {
-        await this.pc.setRemoteDescription(sd);
+        await this._pc?.setRemoteDescription(sd);
       } else {
-        await this.pc.setLocalDescription(sd);
+        await this._pc?.setLocalDescription(sd);
       }
     } catch (e) {
       let msg = 'unknown error';


### PR DESCRIPTION
Also don't recreate pc in setMungedSDP fallback path to avoid applying initial offer to a newly create pc.