### PR TITLE
fix: await screen share audio unpublish before returning setEnabled

### DIFF
--- a/.changeset/four-wolves-try.md
+++ b/.changeset/four-wolves-try.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+await screen share audio unpublish before returning setEnabled

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -656,11 +656,12 @@ export default class LocalParticipant extends Participant {
       if (track && track.track) {
         // screenshare cannot be muted, unpublish instead
         if (source === Track.Source.ScreenShare) {
-          track = await this.unpublishTrack(track.track);
+          const unpublishPromises = [this.unpublishTrack(track.track)];
           const screenAudioTrack = this.getTrackPublication(Track.Source.ScreenShareAudio);
           if (screenAudioTrack && screenAudioTrack.track) {
-            this.unpublishTrack(screenAudioTrack.track);
+            unpublishPromises.push(this.unpublishTrack(screenAudioTrack.track));
           }
+          [track] = await Promise.all(unpublishPromises);
         } else {
           await track.mute();
         }


### PR DESCRIPTION
closes https://github.com/livekit/client-sdk-js/issues/1814