### PR TITLE
fix: differentiate different 404 responses on validate path

### DIFF
--- a/.changeset/dry-actors-rule.md
+++ b/.changeset/dry-actors-rule.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Differentiate different 404 responses on validate path

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -1081,6 +1081,10 @@ export class SignalClient {
 
       switch (resp.status) {
         case 404:
+          const errorMsg = await resp.text();
+          if (errorMsg.includes('requested room does not exist')) {
+            return ConnectionError.notAllowed(errorMsg, resp.status);
+          }
           return ConnectionError.serviceNotFound(
             'v1 RTC path not found. Consider upgrading your LiveKit server version',
             'v0-rtc',


### PR DESCRIPTION
closes https://github.com/livekit/client-sdk-js/issues/1883