### PR TITLE
Ignore engine closed events for data track packets which are in flight / un delivered on engine close

### DIFF
--- a/.changeset/beige-cases-show.md
+++ b/.changeset/beige-cases-show.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ignore engine closed events for data track packets which are in flight / un delivered on engine close

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1519,7 +1519,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         // buffer status to not be low before continuing.
         switch (bufferStatusLowBehavior) {
           case 'wait':
-            await this.waitForBufferStatusLow(kind);
+            await this.waitForBufferStatusLow(kind, 'ignore');
             break;
           case 'drop':
             // this.log.warn(`dropping lossy data channel message`, this.logContext);
@@ -1580,9 +1580,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
   };
 
-  async waitForBufferStatusLow(kind: DataChannelKind) {
+  async waitForBufferStatusLow(
+    kind: DataChannelKind,
+    engineCloseBehavior: 'throw' | 'ignore' = 'throw',
+  ) {
     return new TypedPromise<void, UnexpectedConnectionState>(async (resolve, reject) => {
-      if (this.isClosed) {
+      if (this.isClosed && engineCloseBehavior === 'throw') {
         reject(new UnexpectedConnectionState('engine closed'));
       }
       if (this.isBufferStatusLow(kind)) {
@@ -1593,7 +1596,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           reject(new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`));
           return;
         }
-        this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
+        if (engineCloseBehavior === 'throw') {
+          this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
+        }
         dc.addEventListener('bufferedamountlow', () => resolve(), {
           once: true,
         });

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1519,7 +1519,17 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         // buffer status to not be low before continuing.
         switch (bufferStatusLowBehavior) {
           case 'wait':
-            await this.waitForBufferStatusLow(kind, 'ignore');
+            try {
+              await this.waitForBufferStatusLow(kind);
+            } catch (err) {
+              // Swallow engine closed errors - if there are lossy packets waiting for the buffer
+              // status to go low and the engine closes, these packets should just be silently
+              // dropped.
+              if (err instanceof UnexpectedConnectionState && err.message === 'engine closed') {
+                return;
+              }
+              throw err;
+            }
             break;
           case 'drop':
             // this.log.warn(`dropping lossy data channel message`, this.logContext);
@@ -1580,12 +1590,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
   };
 
-  async waitForBufferStatusLow(
-    kind: DataChannelKind,
-    engineCloseBehavior: 'throw' | 'ignore' = 'throw',
-  ) {
+  async waitForBufferStatusLow(kind: DataChannelKind) {
     return new TypedPromise<void, UnexpectedConnectionState>(async (resolve, reject) => {
-      if (this.isClosed && engineCloseBehavior === 'throw') {
+      if (this.isClosed) {
         reject(new UnexpectedConnectionState('engine closed'));
       }
       if (this.isBufferStatusLow(kind)) {
@@ -1596,9 +1603,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           reject(new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`));
           return;
         }
-        if (engineCloseBehavior === 'throw') {
-          this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
-        }
+        this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
         dc.addEventListener('bufferedamountlow', () => resolve(), {
           once: true,
         });


### PR DESCRIPTION
I have noticed in running the data track test, that "engine closed" gets thrown fairly often at the end of the test, AFTER the actual test case passes. I had seemingly fixed this in https://github.com/livekit/client-sdk-js/pull/1892 but after merging this on top of `main`, it turns out https://github.com/livekit/client-sdk-js/pull/1877 changed the semantics of how this worked and caused it to break subtly in a different way. It looks like the same error but it's being triggered for a reason now.

What I think is happening now: I think the move away from the while/sleep loop in waitForBufferStatusLow https://github.com/livekit/client-sdk-js/pull/1877 (which wasn't in my data track subscription updates PR) has newly resulted in more `waitForBufferStatusLow` calls being in flight at once so there's now a much higher likelihood that the data channel won't be fully drained upon engine close. Before, the `sleep(10)` inadvertently throttled this.

To fix this, I've added a param to `waitForBufferStatusLow` to allow ignoring engine closed events. I am not sure if this is the best thing to do, but it fixes the tests. And I think matches the ethos of "send packets as fast as possible" / doesn't introduce any sort of explicit locking - if packets aren't delivered when the engine closes, there isn't really a good reason to throw an error if the data being sent is lossy anyway.

There's an argument also that maybe the better thing to do here is to make `tryPush` return a promise that resolves once the whole pipeline (including all packets being enqueued into the data channel, and then a subsequent buffer low event occurring) completes. But the downside to that is then you're blocking extra time on each `tryPush` call which lengthens the amount of time each frame takes to send, which is antithetical to the whole data track "send data as fast as possible" / lossy delivery notion.