### PR TITLE
fix: ensure we never try to reset region strategy if engine doesn't exist

### DIFF
--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -782,12 +782,10 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.regionUrlProvider?.getServerUrl().toString() !== ensureTrailingSlash(url)) {
       this.regionUrl = undefined;
       this.regionUrlProvider = undefined;
-      this.engine?.setRegionStrategy(undefined);
     }
     if (isCloud(new URL(url))) {
       if (this.regionUrlProvider === undefined) {
         this.regionUrlProvider = new RegionUrlProvider(url, token);
-        this.engine.setRegionStrategy(this.createRegionStrategy());
       } else {
         this.regionUrlProvider.updateToken(token);
       }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -782,7 +782,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     if (this.regionUrlProvider?.getServerUrl().toString() !== ensureTrailingSlash(url)) {
       this.regionUrl = undefined;
       this.regionUrlProvider = undefined;
-      this.engine.setRegionStrategy(undefined);
+      this.engine?.setRegionStrategy(undefined);
     }
     if (isCloud(new URL(url))) {
       if (this.regionUrlProvider === undefined) {


### PR DESCRIPTION
follow up for #1900


the strategy is always set as part of `attemptConnection` _after_ the engine is created. 

Trying to do it before could result in undefined access