### PR TITLE
Ensure priority isn't set on all simulcast layers when using Firefox on iOS

### DIFF
--- a/.changeset/four-seas-reflect.md
+++ b/.changeset/four-seas-reflect.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Ensure priority isn't set on all simulcast layers when using Firefox on iOS

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -15,7 +15,6 @@ import type { LoggerOptions } from '../types';
 import {
   compareVersions,
   getReactNativeOs,
-  isFireFox,
   isReactNative,
   isSVCCodec,
   isSafariBased,

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -379,7 +379,8 @@ function encodingsFromPresets(
     if (maxFramerate) {
       encoding.maxFramerate = maxFramerate;
     }
-    const canSetPriority = isFireFox() || idx === 0;
+    const browser = getBrowser();
+    const canSetPriority = (browser?.name === 'Firefox' && browser.os !== 'iOS') || idx === 0;
     if (preset.encoding.priority && canSetPriority) {
       encoding.priority = preset.encoding.priority;
       encoding.networkPriority = preset.encoding.priority;


### PR DESCRIPTION
Priority can be set on all layers only when using Firefox. 
On iOS the underlying browser engine is still Webkit so we need to guard against wrongly treating it as Firefox.