### PR TITLE
Improved data tracks depacketizer to support mutliple in flight packets

### DIFF
--- a/.changeset/chatty-wolves-play.md
+++ b/.changeset/chatty-wolves-play.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Improved data tracks depacketizer to support mutliple in flight packets

--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -2,7 +2,7 @@ module.exports = [
   {
     path: 'dist/livekit-client.esm.mjs',
     import: '{ Room }',
-    limit: '101 kB',
+    limit: '150 kB',
   },
   {
     path: 'dist/livekit-client.umd.js',

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import type { ReconnectContext, ReconnectPolicy } from './room/ReconnectPolicy';
 import Room, { ConnectionState, type RoomEventCallbacks } from './room/Room';
 import * as attributes from './room/attribute-typings';
 import LocalDataTrack from './room/data-track/LocalDataTrack';
-import RemoteDataTrack, { type DataTrackSubscribeOptions } from './room/data-track/RemoteDataTrack';
+import RemoteDataTrack, { type DataTrackSubscribeOptions, type RemoteDataTrackPipelineOptions } from './room/data-track/RemoteDataTrack';
 import LocalParticipant from './room/participant/LocalParticipant';
 import Participant, {
   ConnectionQuality,
@@ -164,6 +164,7 @@ export type {
   ParticipantEventCallbacks,
   PublicationEventCallbacks,
   DataTrackSubscribeOptions,
+  RemoteDataTrackPipelineOptions,
 };
 export { DataTrackPacket, type DataTrackPacketHeader } from './room/data-track/packet';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ import type { ReconnectContext, ReconnectPolicy } from './room/ReconnectPolicy';
 import Room, { ConnectionState, type RoomEventCallbacks } from './room/Room';
 import * as attributes from './room/attribute-typings';
 import LocalDataTrack from './room/data-track/LocalDataTrack';
-import RemoteDataTrack, { type DataTrackSubscribeOptions, type RemoteDataTrackPipelineOptions } from './room/data-track/RemoteDataTrack';
+import RemoteDataTrack, { type DataTrackSubscribeOptions } from './room/data-track/RemoteDataTrack';
+import { type RemoteDataTrackPipelineOptions } from './room/data-track/types';
 import LocalParticipant from './room/participant/LocalParticipant';
 import Participant, {
   ConnectionQuality,

--- a/src/room/data-track/RemoteDataTrack.ts
+++ b/src/room/data-track/RemoteDataTrack.ts
@@ -80,4 +80,15 @@ export default class RemoteDataTrack implements IRemoteTrack, IDataTrack {
       throw err;
     }
   }
+
+  /** Set the maximum number of in-flight partial frames the depacketizer will track
+   * concurrently for this track. Higher values give more out-of-order tolerance for
+   * high-frequency senders.
+   *
+   * The value applies to all current and future subscribers of this track. May be called
+   * before or after {@link RemoteDataTrack.subscribe}; live subscriptions pick up the new value
+   * immediately. Defaults to 1. */
+  setMaxPartialFrames(n: number): void {
+    this.manager.setTrackMaxPartialFrames(this.info.sid, n);
+  }
 }

--- a/src/room/data-track/RemoteDataTrack.ts
+++ b/src/room/data-track/RemoteDataTrack.ts
@@ -21,6 +21,14 @@ export type DataTrackSubscribeOptions = {
   bufferSize?: number;
 };
 
+export type RemoteDataTrackPipelineOptions = {
+  /** Set the maximum number of in-flight partial frames the depacketizer will track
+   * concurrently for this track. Higher values give more out-of-order tolerance for
+   * high-frequency senders. Defaults to 1.
+   */
+  maxPartialFrames?: number;
+};
+
 export default class RemoteDataTrack implements IRemoteTrack, IDataTrack {
   readonly trackSymbol = TrackSymbol;
 
@@ -81,14 +89,10 @@ export default class RemoteDataTrack implements IRemoteTrack, IDataTrack {
     }
   }
 
-  /** Set the maximum number of in-flight partial frames the depacketizer will track
-   * concurrently for this track. Higher values give more out-of-order tolerance for
-   * high-frequency senders.
-   *
-   * The value applies to all current and future subscribers of this track. May be called
-   * before or after {@link RemoteDataTrack.subscribe}; live subscriptions pick up the new value
-   * immediately. Defaults to 1. */
-  setMaxPartialFrames(n: number): void {
-    this.manager.setTrackMaxPartialFrames(this.info.sid, n);
+  /** Configure how incoming frames for this track are processed before they are handed out to
+   * subscribers (the "pipeline"). These options apply to all current and future subscriptions
+   * of this track, and may be set at any time. */
+  setPipelineOptions(options: RemoteDataTrackPipelineOptions): void {
+    this.manager.setTrackMaxPartialFrames(this.info.sid, options.maxPartialFrames ?? null);
   }
 }

--- a/src/room/data-track/RemoteDataTrack.ts
+++ b/src/room/data-track/RemoteDataTrack.ts
@@ -7,7 +7,7 @@ import {
   type IRemoteTrack,
   TrackSymbol,
 } from './track-interfaces';
-import { type DataTrackInfo } from './types';
+import { type DataTrackInfo, type RemoteDataTrackPipelineOptions } from './types';
 
 type RemoteDataTrackOptions = {
   publisherIdentity: Participant['identity'];
@@ -19,14 +19,6 @@ export type DataTrackSubscribeOptions = {
   /** The number of {@link DataTrackFrame}s to hold in the ReadableStream before disgarding extra
    * frames. Defaults to 16, but this may not be good enough for especially high frequency data. */
   bufferSize?: number;
-};
-
-export type RemoteDataTrackPipelineOptions = {
-  /** Set the maximum number of in-flight partial frames the depacketizer will track
-   * concurrently for this track. Higher values give more out-of-order tolerance for
-   * high-frequency senders. Defaults to 1.
-   */
-  maxPartialFrames?: number;
 };
 
 export default class RemoteDataTrack implements IRemoteTrack, IDataTrack {
@@ -93,6 +85,6 @@ export default class RemoteDataTrack implements IRemoteTrack, IDataTrack {
    * subscribers (the "pipeline"). These options apply to all current and future subscriptions
    * of this track, and may be set at any time. */
   setPipelineOptions(options: RemoteDataTrackPipelineOptions): void {
-    this.manager.setTrackMaxPartialFrames(this.info.sid, options.maxPartialFrames ?? null);
+    this.manager.setPipelineOptions(this.info.sid, options);
   }
 }

--- a/src/room/data-track/depacketizer.test.ts
+++ b/src/room/data-track/depacketizer.test.ts
@@ -652,4 +652,148 @@ describe('DataTrackDepacketizer', () => {
     expect(producedFrames).toStrictEqual(5);
     expect(unknownFrameErrors).toStrictEqual(5);
   });
+
+  it('should throw unknownFrame for late Inter and Final packets belonging to an evicted frame', () => {
+    const depacketizer = new DataTrackDepacketizer();
+    const pushOptions = { throwOnInterruption: false, maxPartialFrames: 3 };
+
+    const packetPayload = new Uint8Array(8);
+    const baseHeaderParams = {
+      trackHandle: DataTrackHandle.fromNumber(101),
+      timestamp: DataTrackTimestamp.fromRtpTicks(104),
+    };
+
+    // Fill the partials map with three in-flight frames.
+    for (let i = 1; i <= 3; i += 1) {
+      const start = new DataTrackPacket(
+        new DataTrackPacketHeader({
+          ...baseHeaderParams,
+          marker: FrameMarker.Start,
+          sequence: WrapAroundUnsignedInt.u16(i * 100),
+          frameNumber: WrapAroundUnsignedInt.u16(i),
+        }),
+        packetPayload,
+      );
+      expect(depacketizer.push(start, pushOptions)).toBeNull();
+    }
+
+    // A fourth Start evicts the oldest (frame 1).
+    const startFour = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(400),
+        frameNumber: WrapAroundUnsignedInt.u16(4),
+      }),
+      packetPayload,
+    );
+    expect(depacketizer.push(startFour, pushOptions)).toBeNull();
+
+    // A late Inter for the evicted frame 1 should throw unknownFrame.
+    const lateInterOne = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Inter,
+        sequence: WrapAroundUnsignedInt.u16(101),
+        frameNumber: WrapAroundUnsignedInt.u16(1),
+      }),
+      packetPayload,
+    );
+    expect(() => depacketizer.push(lateInterOne, pushOptions)).toThrowError(
+      'Frame 1 dropped: Initial packet was never received.',
+    );
+
+    // A late Final for the evicted frame 1 should also throw unknownFrame.
+    const lateFinalOne = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Final,
+        sequence: WrapAroundUnsignedInt.u16(102),
+        frameNumber: WrapAroundUnsignedInt.u16(1),
+      }),
+      packetPayload,
+    );
+    expect(() => depacketizer.push(lateFinalOne, pushOptions)).toThrowError(
+      'Frame 1 dropped: Initial packet was never received.',
+    );
+
+    // Frames 2, 3 and 4 should all still complete cleanly despite the late packets for frame 1.
+    for (const frameNumber of [2, 3, 4]) {
+      const final = new DataTrackPacket(
+        new DataTrackPacketHeader({
+          ...baseHeaderParams,
+          marker: FrameMarker.Final,
+          sequence: WrapAroundUnsignedInt.u16(frameNumber * 100 + 1),
+          frameNumber: WrapAroundUnsignedInt.u16(frameNumber),
+        }),
+        packetPayload,
+      );
+      expect(depacketizer.push(final, pushOptions)).not.toBeNull();
+    }
+  });
+
+  it('should keep partial frame state isolated when packets for multiple frames are heavily interleaved', () => {
+    const depacketizer = new DataTrackDepacketizer();
+    const pushOptions = { throwOnInterruption: true, maxPartialFrames: 3 };
+    const baseHeaderParams = {
+      trackHandle: DataTrackHandle.fromNumber(101),
+      timestamp: DataTrackTimestamp.fromRtpTicks(104),
+    };
+
+    // Three frames each carrying three uniquely-tagged payloads. Sequence ranges are chosen so
+    // that no two frames share a sequence value.
+    const frames = [
+      {
+        frameNumber: 1,
+        startSequence: 0,
+        payloads: [new Uint8Array([0xa1]), new Uint8Array([0xa2]), new Uint8Array([0xa3])],
+      },
+      {
+        frameNumber: 2,
+        startSequence: 100,
+        payloads: [new Uint8Array([0xb1]), new Uint8Array([0xb2]), new Uint8Array([0xb3])],
+      },
+      {
+        frameNumber: 3,
+        startSequence: 200,
+        payloads: [new Uint8Array([0xc1]), new Uint8Array([0xc2]), new Uint8Array([0xc3])],
+      },
+    ];
+
+    const buildPacket = (
+      frameIndex: number,
+      packetIndex: number,
+      marker: FrameMarker,
+    ): DataTrackPacket =>
+      new DataTrackPacket(
+        new DataTrackPacketHeader({
+          ...baseHeaderParams,
+          marker,
+          sequence: WrapAroundUnsignedInt.u16(frames[frameIndex].startSequence + packetIndex),
+          frameNumber: WrapAroundUnsignedInt.u16(frames[frameIndex].frameNumber),
+        }),
+        frames[frameIndex].payloads[packetIndex],
+      );
+
+    // Round-robin Starts and Inters across all three frames.
+    expect(depacketizer.push(buildPacket(0, 0, FrameMarker.Start), pushOptions)).toBeNull();
+    expect(depacketizer.push(buildPacket(1, 0, FrameMarker.Start), pushOptions)).toBeNull();
+    expect(depacketizer.push(buildPacket(2, 0, FrameMarker.Start), pushOptions)).toBeNull();
+    expect(depacketizer.push(buildPacket(0, 1, FrameMarker.Inter), pushOptions)).toBeNull();
+    expect(depacketizer.push(buildPacket(1, 1, FrameMarker.Inter), pushOptions)).toBeNull();
+    expect(depacketizer.push(buildPacket(2, 1, FrameMarker.Inter), pushOptions)).toBeNull();
+
+    // Finals arrive in a different order than the Starts to confirm per-frame isolation.
+    const frameTwo = depacketizer.push(buildPacket(1, 2, FrameMarker.Final), pushOptions);
+    expect(frameTwo).not.toBeNull();
+    expect(frameTwo!.payload).toStrictEqual(new Uint8Array([0xb1, 0xb2, 0xb3]));
+
+    const frameZero = depacketizer.push(buildPacket(0, 2, FrameMarker.Final), pushOptions);
+    expect(frameZero).not.toBeNull();
+    expect(frameZero!.payload).toStrictEqual(new Uint8Array([0xa1, 0xa2, 0xa3]));
+
+    const frameThree = depacketizer.push(buildPacket(2, 2, FrameMarker.Final), pushOptions);
+    expect(frameThree).not.toBeNull();
+    expect(frameThree!.payload).toStrictEqual(new Uint8Array([0xc1, 0xc2, 0xc3]));
+  });
 });

--- a/src/room/data-track/depacketizer.test.ts
+++ b/src/room/data-track/depacketizer.test.ts
@@ -106,7 +106,7 @@ describe('DataTrackDepacketizer', () => {
       new Uint8Array(8),
     );
 
-    expect(() => depacketizer.push(packetB, { errorOnPartialFrames: true })).toThrowError(
+    expect(() => depacketizer.push(packetB, { throwOnInterruption: true })).toThrowError(
       'Frame 5 dropped: Interrupted by the start of a new frame',
     );
   });
@@ -438,5 +438,218 @@ describe('DataTrackDepacketizer', () => {
     expect(depacketizer.push(finalPacket)!.payload).toStrictEqual(
       new Uint8Array([0x01, 0x02, 0x03]),
     );
+  });
+
+  it('should assemble multiple partial frames concurrently when maxPartialFrames is set', () => {
+    const depacketizer = new DataTrackDepacketizer();
+    const pushOptions = { throwOnInterruption: true, maxPartialFrames: 2 };
+
+    const packetPayload = new Uint8Array(8);
+    const baseHeaderParams = {
+      trackHandle: DataTrackHandle.fromNumber(101),
+      timestamp: DataTrackTimestamp.fromRtpTicks(104),
+    };
+
+    // Begin frame A
+    const startA = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(0),
+        frameNumber: WrapAroundUnsignedInt.u16(1),
+      }),
+      packetPayload,
+    );
+    expect(depacketizer.push(startA, pushOptions)).toBeNull();
+
+    // Begin frame B - should not throw because we're under capacity
+    const startB = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(100),
+        frameNumber: WrapAroundUnsignedInt.u16(2),
+      }),
+      packetPayload,
+    );
+    expect(depacketizer.push(startB, pushOptions)).toBeNull();
+
+    // Complete frame A out of order - should produce a frame
+    const finalA = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Final,
+        sequence: WrapAroundUnsignedInt.u16(1),
+        frameNumber: WrapAroundUnsignedInt.u16(1),
+      }),
+      packetPayload,
+    );
+    const frameA = depacketizer.push(finalA, pushOptions);
+    expect(frameA).not.toBeNull();
+    expect(frameA!.payload.byteLength).toStrictEqual(packetPayload.byteLength * 2);
+
+    // Frame B is still in flight and should still complete cleanly
+    const finalB = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Final,
+        sequence: WrapAroundUnsignedInt.u16(101),
+        frameNumber: WrapAroundUnsignedInt.u16(2),
+      }),
+      packetPayload,
+    );
+    const frameB = depacketizer.push(finalB, pushOptions);
+    expect(frameB).not.toBeNull();
+    expect(frameB!.payload.byteLength).toStrictEqual(packetPayload.byteLength * 2);
+  });
+
+  it('should throw when starting a new partial frame would exceed maxPartialFrames', () => {
+    const depacketizer = new DataTrackDepacketizer();
+    const pushOptions = { throwOnInterruption: true, maxPartialFrames: 2 };
+
+    const packetPayload = new Uint8Array(8);
+    const baseHeaderParams = {
+      trackHandle: DataTrackHandle.fromNumber(101),
+      timestamp: DataTrackTimestamp.fromRtpTicks(104),
+    };
+
+    // Fill the partials map with two in-flight frames
+    const startA = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(0),
+        frameNumber: WrapAroundUnsignedInt.u16(1),
+      }),
+      packetPayload,
+    );
+    expect(depacketizer.push(startA, pushOptions)).toBeNull();
+
+    const startB = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(100),
+        frameNumber: WrapAroundUnsignedInt.u16(2),
+      }),
+      packetPayload,
+    );
+    expect(depacketizer.push(startB, pushOptions)).toBeNull();
+
+    // A third in-flight start should throw, naming the oldest evicted frame (1) and the new one (3)
+    const startC = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(200),
+        frameNumber: WrapAroundUnsignedInt.u16(3),
+      }),
+      packetPayload,
+    );
+    expect(() => depacketizer.push(startC, pushOptions)).toThrowError(
+      'Frame 1 dropped: Interrupted by the start of a new frame 3',
+    );
+  });
+
+  it('should throw when a single-packet frame arrives while the partials map is at capacity', () => {
+    const depacketizer = new DataTrackDepacketizer();
+    const pushOptions = { throwOnInterruption: true, maxPartialFrames: 2 };
+
+    const packetPayload = new Uint8Array(8);
+    const baseHeaderParams = {
+      trackHandle: DataTrackHandle.fromNumber(101),
+      timestamp: DataTrackTimestamp.fromRtpTicks(104),
+    };
+
+    // Fill the partials map with two in-flight frames
+    const startA = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(0),
+        frameNumber: WrapAroundUnsignedInt.u16(1),
+      }),
+      packetPayload,
+    );
+    expect(depacketizer.push(startA, pushOptions)).toBeNull();
+
+    const startB = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Start,
+        sequence: WrapAroundUnsignedInt.u16(100),
+        frameNumber: WrapAroundUnsignedInt.u16(2),
+      }),
+      packetPayload,
+    );
+    expect(depacketizer.push(startB, pushOptions)).toBeNull();
+
+    // A single-packet frame arriving at capacity should evict the oldest (frame 1) and throw
+    const singleC = new DataTrackPacket(
+      new DataTrackPacketHeader({
+        ...baseHeaderParams,
+        marker: FrameMarker.Single,
+        sequence: WrapAroundUnsignedInt.u16(200),
+        frameNumber: WrapAroundUnsignedInt.u16(3),
+      }),
+      packetPayload,
+    );
+    expect(() => depacketizer.push(singleC, pushOptions)).toThrowError(
+      'Frame 1 dropped: Interrupted by the start of a new frame 3',
+    );
+  });
+
+  it('should evict the oldest partial frame when start packets exceed maxPartialFrames', () => {
+    const depacketizer = new DataTrackDepacketizer();
+    const pushOptions = { throwOnInterruption: false, maxPartialFrames: 5 };
+    const totalFrames = 10;
+
+    const packetPayload = new Uint8Array(8);
+    const baseHeaderParams = {
+      trackHandle: DataTrackHandle.fromNumber(101),
+      timestamp: DataTrackTimestamp.fromRtpTicks(104),
+    };
+
+    // Begin 10 partial frames. Each frame's Start uses sequence i*2; its Final uses i*2 + 1.
+    // After all 10 starts, only frames 6..10 remain in the partials map (oldest evicted first).
+    for (let i = 0; i < totalFrames; i += 1) {
+      const start = new DataTrackPacket(
+        new DataTrackPacketHeader({
+          ...baseHeaderParams,
+          marker: FrameMarker.Start,
+          sequence: WrapAroundUnsignedInt.u16(i * 2),
+          frameNumber: WrapAroundUnsignedInt.u16(i + 1),
+        }),
+        packetPayload,
+      );
+      expect(depacketizer.push(start, pushOptions)).toBeNull();
+    }
+
+    // Send Final for each frame. Frames 1..5 were evicted → unknownFrame; frames 6..10 produce.
+    let producedFrames = 0;
+    let unknownFrameErrors = 0;
+    for (let i = 0; i < totalFrames; i += 1) {
+      const final = new DataTrackPacket(
+        new DataTrackPacketHeader({
+          ...baseHeaderParams,
+          marker: FrameMarker.Final,
+          sequence: WrapAroundUnsignedInt.u16(i * 2 + 1),
+          frameNumber: WrapAroundUnsignedInt.u16(i + 1),
+        }),
+        packetPayload,
+      );
+      try {
+        const frame = depacketizer.push(final, pushOptions);
+        if (frame) {
+          producedFrames += 1;
+        }
+      } catch (err) {
+        expect((err as Error).message).toContain('Initial packet was never received.');
+        unknownFrameErrors += 1;
+      }
+    }
+
+    expect(producedFrames).toStrictEqual(5);
+    expect(unknownFrameErrors).toStrictEqual(5);
   });
 });

--- a/src/room/data-track/depacketizer.test.ts
+++ b/src/room/data-track/depacketizer.test.ts
@@ -796,4 +796,79 @@ describe('DataTrackDepacketizer', () => {
     expect(frameThree).not.toBeNull();
     expect(frameThree!.payload).toStrictEqual(new Uint8Array([0xc1, 0xc2, 0xc3]));
   });
+
+  it('should respect maxPartialFrames changing across push calls, both expanding to allow more in-flight frames and shrinking to evict older ones', () => {
+    const depacketizer = new DataTrackDepacketizer();
+
+    const packetPayload = new Uint8Array(8);
+    const baseHeaderParams = {
+      trackHandle: DataTrackHandle.fromNumber(101),
+      timestamp: DataTrackTimestamp.fromRtpTicks(104),
+    };
+
+    const startFor = (frameNumber: number) =>
+      new DataTrackPacket(
+        new DataTrackPacketHeader({
+          ...baseHeaderParams,
+          marker: FrameMarker.Start,
+          sequence: WrapAroundUnsignedInt.u16(frameNumber * 100),
+          frameNumber: WrapAroundUnsignedInt.u16(frameNumber),
+        }),
+        packetPayload,
+      );
+
+    const finalFor = (frameNumber: number) =>
+      new DataTrackPacket(
+        new DataTrackPacketHeader({
+          ...baseHeaderParams,
+          marker: FrameMarker.Final,
+          sequence: WrapAroundUnsignedInt.u16(frameNumber * 100 + 1),
+          frameNumber: WrapAroundUnsignedInt.u16(frameNumber),
+        }),
+        packetPayload,
+      );
+
+    // Fill the partials map exactly with maxPartialFrames=2.
+    expect(
+      depacketizer.push(startFor(1), { throwOnInterruption: true, maxPartialFrames: 2 }),
+    ).toBeNull();
+    expect(
+      depacketizer.push(startFor(2), { throwOnInterruption: true, maxPartialFrames: 2 }),
+    ).toBeNull();
+
+    // Expand maxPartialFrames to 4 mid-stream. Frames 3 and 4 should be added without evicting
+    // anything, and throwOnInterruption: true confirms no interruption fires.
+    expect(
+      depacketizer.push(startFor(3), { throwOnInterruption: true, maxPartialFrames: 4 }),
+    ).toBeNull();
+    expect(
+      depacketizer.push(startFor(4), { throwOnInterruption: true, maxPartialFrames: 4 }),
+    ).toBeNull();
+
+    // Spot-check that frame 1 is still tracked despite the cap changes.
+    expect(
+      depacketizer.push(finalFor(1), { throwOnInterruption: true, maxPartialFrames: 4 }),
+    ).not.toBeNull();
+    // Three partials remain in flight: frames 2, 3, 4.
+
+    // Shrink maxPartialFrames to 2. Adding frame 5 should evict frames 2 and 3 in this single
+    // push call to bring the in-flight count back under the new cap.
+    expect(
+      depacketizer.push(startFor(5), { throwOnInterruption: false, maxPartialFrames: 2 }),
+    ).toBeNull();
+
+    // Only frames 4 and 5 should remain in the map.
+    expect(() =>
+      depacketizer.push(finalFor(2), { throwOnInterruption: false, maxPartialFrames: 2 }),
+    ).toThrowError('Frame 2 dropped: Initial packet was never received.');
+    expect(() =>
+      depacketizer.push(finalFor(3), { throwOnInterruption: false, maxPartialFrames: 2 }),
+    ).toThrowError('Frame 3 dropped: Initial packet was never received.');
+    expect(
+      depacketizer.push(finalFor(4), { throwOnInterruption: false, maxPartialFrames: 2 }),
+    ).not.toBeNull();
+    expect(
+      depacketizer.push(finalFor(5), { throwOnInterruption: false, maxPartialFrames: 2 }),
+    ).not.toBeNull();
+  });
 });

--- a/src/room/data-track/depacketizer.ts
+++ b/src/room/data-track/depacketizer.ts
@@ -188,14 +188,16 @@ export default class DataTrackDepacketizer {
       payloads: new Map([[startSequence.value, packet.payload]]),
     };
 
+    // Loop in case `maxPartialFrames` shrunk relative to a previous push call - evict the
+    // oldest partials until there is room for the new one. With `throwOnInterruption` set the
+    // throw inside the loop short-circuits on the first eviction, matching the single-eviction
+    // behavior callers expect when they ask to be told about interruptions.
     const maxPartialFrames = options?.maxPartialFrames ?? 1;
-    if (this.partials.size >= maxPartialFrames) {
+    while (this.partials.size >= maxPartialFrames) {
       const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
       if (typeof oldestPartialFrameNumber !== 'number') {
-        // @throws-transformer ignore - this should be treated as a "panic" and not be caught
-        throw new Error(
-          `Depacketizer.beginPartial: no oldest frame number found, but partials.size is ${this.partials.size}.`,
-        );
+        // partials map is empty - nothing more to evict
+        break;
       }
       this.partials.delete(oldestPartialFrameNumber);
 

--- a/src/room/data-track/depacketizer.ts
+++ b/src/room/data-track/depacketizer.ts
@@ -9,8 +9,6 @@ import { U16_MAX_SIZE, WrapAroundUnsignedInt } from './utils';
 const log = getLogger(LoggerNames.DataTracks);
 
 type PartialFrame = {
-  /** Frame number from the start packet. */
-  frameNumber: number;
   /** Sequence of the start packet. */
   startSequence: WrapAroundUnsignedInt<typeof U16_MAX_SIZE>;
   /** Extensions from the start packet. */
@@ -83,13 +81,18 @@ type PushOptions = {
   /** If true, throws an error instead of logging a warning when a new frame is encountered half way
    * through processing a pre-existing frame. */
   errorOnPartialFrames: boolean;
+
+  maximumConcurrentPartialFrames?: number
 };
 
 export default class DataTrackDepacketizer {
   /** Maximum number of packets to buffer per frame before dropping. */
   static MAX_BUFFER_PACKETS = 128;
 
-  private partial: PartialFrame | null = null;
+  private partials: Map<
+    number, /* Frame number from the start packet. */
+    { frame: PartialFrame, startedAt: Date }
+  > = new Map();
 
   /** Should be repeatedly called with received {@link DataTrackPacket}s - intermediate calls
    * aggregate the packet's state internally, and return null.
@@ -112,13 +115,21 @@ export default class DataTrackDepacketizer {
   }
 
   reset() {
-    this.partial = null;
+    this.partials.clear();
   }
 
-  private frameFromSingle(
-    packet: DataTrackPacket,
-    options?: PushOptions,
-  ): Throws<
+  private peekOldestPartialFrameNumber() {
+    const orderedPartialEntries = Array.from(this.partials.entries()).sort((a, b) => {
+      return a[1].startedAt.getTime() - b[1].startedAt.getTime()
+    });
+    if (orderedPartialEntries.length > 0) {
+      return orderedPartialEntries[0][0];
+    } else {
+      return null;
+    }
+  }
+
+  private frameFromSingle(packet: DataTrackPacket, options?: PushOptions): Throws<
     DataTrackFrameInternal | null,
     DataTrackDepacketizerDropError<DataTrackDepacketizerDropReason.Interrupted>
   > {
@@ -129,21 +140,30 @@ export default class DataTrackDepacketizer {
       );
     }
 
-    if (this.partial) {
+    // const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
+    // if (this.partials.size < maximumConcurrentPartialFrames) {
+
+    if (this.partials.size > 0 && options?.maximumConcurrentPartialFrames === 1) {
+      const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
+      if (!oldestPartialFrameNumber) {
+        // @throws-transformer ignore - this should be treated as a "panic" and not be caught
+        throw new Error(
+          `Depacketizer.frameFromSingle: no oldest frame number found, but partials.size is ${this.partials.size}`,
+        );
+      }
+
       if (options?.errorOnPartialFrames) {
-        const frameNumber = this.partial.frameNumber;
-        this.reset();
+        this.partials.delete(oldestPartialFrameNumber);
         throw DataTrackDepacketizerDropError.interrupted(
-          frameNumber,
+          oldestPartialFrameNumber,
           packet.header.frameNumber.value,
         );
       } else {
         log.warn(
-          `Data track frame ${this.partial.frameNumber} was interrupted by the start of a new frame, dropping.`,
+          `Data track frame ${oldestPartialFrameNumber} was interrupted by the start of a new frame, dropping.`,
         );
       }
     }
-    this.reset();
 
     return { payload: packet.payload, extensions: packet.header.extensions };
   }
@@ -160,30 +180,35 @@ export default class DataTrackDepacketizer {
       );
     }
 
-    if (this.partial) {
-      if (options?.errorOnPartialFrames) {
-        const frameNumber = this.partial.frameNumber;
-        this.reset();
-        throw DataTrackDepacketizerDropError.interrupted(
-          frameNumber,
-          packet.header.frameNumber.value,
-        );
-      } else {
-        log.warn(
-          `Data track frame ${this.partial.frameNumber} was interrupted by the start of a new frame ${packet.header.frameNumber.value}, dropping.`,
-        );
-      }
-    }
-    this.reset();
-
     const startSequence = packet.header.sequence;
-
-    this.partial = {
-      frameNumber: packet.header.frameNumber.value,
+    const frameNumber = packet.header.frameNumber.value;
+    const partial: PartialFrame = {
       startSequence,
       extensions: packet.header.extensions,
       payloads: new Map([[startSequence.value, packet.payload]]),
     };
+
+    const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
+    if (this.partials.size > maximumConcurrentPartialFrames) {
+      const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber()!;
+      this.partials.delete(oldestPartialFrameNumber);
+
+      if (options?.errorOnPartialFrames) {
+        const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
+        if (!oldestPartialFrameNumber) {
+          // @throws-transformer ignore - this should be treated as a "panic" and not be caught
+          throw new Error(
+            `Depacketizer.beginPartial: no oldest frame number found, but partials.size is ${this.partials.size}`,
+          );
+        }
+        throw DataTrackDepacketizerDropError.interrupted(oldestPartialFrameNumber, frameNumber);
+      } else {
+        log.warn(
+          `Data track partials (size of ${maximumConcurrentPartialFrames}) didn't have enough room for a new frame ${frameNumber}, dropping.`,
+        );
+      }
+    }
+    this.partials.set(frameNumber, { frame: partial, startedAt: new Date() });
 
     return null;
   }
@@ -199,40 +224,32 @@ export default class DataTrackDepacketizer {
       );
     }
 
-    if (!this.partial) {
-      this.reset();
+    const packetFrameNumber = packet.header.frameNumber.value;
+    const matchingPartial = this.partials.get(packetFrameNumber);
+    if (!matchingPartial) {
+      this.partials.delete(packetFrameNumber);
       throw DataTrackDepacketizerDropError.unknownFrame(packet.header.frameNumber.value);
-    }
-
-    if (packet.header.frameNumber.value !== this.partial.frameNumber) {
-      const frameNumber = this.partial.frameNumber;
-      this.reset();
-      throw DataTrackDepacketizerDropError.interrupted(
-        frameNumber,
-        packet.header.frameNumber.value,
-      );
     }
 
     // NOTE: this check will block reprocessing packets with duplicate sequence values if the
     // buffer is full already, which could maybe be problematic for very large frames.
-    if (this.partial.payloads.size >= DataTrackDepacketizer.MAX_BUFFER_PACKETS) {
-      const frameNumber = this.partial.frameNumber;
-      this.reset();
-      throw DataTrackDepacketizerDropError.bufferFull(frameNumber);
+    if (matchingPartial.frame.payloads.size >= DataTrackDepacketizer.MAX_BUFFER_PACKETS) {
+      this.partials.delete(packetFrameNumber);
+      throw DataTrackDepacketizerDropError.bufferFull(packetFrameNumber);
     }
 
     // Note: receiving a packet with a duplicate `sequence` value is something that likely won't
     // happen in actual use, but even if it does (maybe a low level network retransmission?) the
     // last packet with a given sequence received should always win.
-    if (this.partial.payloads.has(packet.header.sequence.value)) {
+    if (matchingPartial.frame.payloads.has(packet.header.sequence.value)) {
       log.warn(
-        `Data track frame ${this.partial.frameNumber} received duplicate packet for sequence ${packet.header.sequence.value}, so replacing with newly received packet.`,
+        `Data track frame ${packetFrameNumber} received duplicate packet for sequence ${packet.header.sequence.value}, so replacing with newly received packet.`,
       );
     }
-    this.partial.payloads.set(packet.header.sequence.value, packet.payload);
+    matchingPartial.frame.payloads.set(packet.header.sequence.value, packet.payload);
 
     if (packet.header.marker === FrameMarker.Final) {
-      return this.finalize(this.partial, packet.header.sequence.value);
+      return this.finalize(packetFrameNumber, matchingPartial.frame, packet.header.sequence.value);
     }
 
     return null;
@@ -240,6 +257,7 @@ export default class DataTrackDepacketizer {
 
   /** Try to reassemble the complete frame. */
   private finalize(
+    partialFrameNumber: number,
     partial: PartialFrame,
     endSequence: number,
   ): Throws<
@@ -281,13 +299,13 @@ export default class DataTrackDepacketizer {
       }
 
       // The packet is done processing, reset the state so another frame can be processed next.
-      this.reset();
+      this.partials.delete(partialFrameNumber);
       return { payload, extensions: partial.extensions };
     }
 
-    this.reset();
+    this.partials.delete(partialFrameNumber);
     throw DataTrackDepacketizerDropError.incomplete(
-      partial.frameNumber,
+      partialFrameNumber,
       received,
       endSequence - partial.startSequence.value + 1,
     );

--- a/src/room/data-track/depacketizer.ts
+++ b/src/room/data-track/depacketizer.ts
@@ -78,21 +78,22 @@ export enum DataTrackDepacketizerDropReason {
 }
 
 type PushOptions = {
-  /** If true, throws an error instead of logging a warning when a new frame is encountered half way
-   * through processing a pre-existing frame. */
+  /** If true, throws an error instead of logging a warning when a new frame would evict a
+   * pre-existing partial frame. */
   errorOnPartialFrames: boolean;
 
-  maximumConcurrentPartialFrames?: number
+  /** Maximum number of partial frames the depacketizer will track concurrently. When a new
+   * `Start` packet arrives at capacity, the oldest partial frame is evicted. Defaults to 1. */
+  maximumConcurrentPartialFrames?: number;
 };
 
 export default class DataTrackDepacketizer {
   /** Maximum number of packets to buffer per frame before dropping. */
   static MAX_BUFFER_PACKETS = 128;
 
-  private partials: Map<
-    number, /* Frame number from the start packet. */
-    { frame: PartialFrame, startedAt: Date }
-  > = new Map();
+  /** Partial frames currently being assembled, keyed by frame number. `Map` preserves insertion
+   * order, so the oldest entry is the first key. */
+  private partials: Map<number, PartialFrame> = new Map();
 
   /** Should be repeatedly called with received {@link DataTrackPacket}s - intermediate calls
    * aggregate the packet's state internally, and return null.
@@ -118,19 +119,16 @@ export default class DataTrackDepacketizer {
     this.partials.clear();
   }
 
-  private peekOldestPartialFrameNumber() {
-    const orderedPartialEntries = Array.from(this.partials.entries()).sort((a, b) => {
-      return a[1].startedAt.getTime() - b[1].startedAt.getTime()
-    });
-    if (orderedPartialEntries.length > 0) {
-      return orderedPartialEntries[0][0];
-    } else {
-      return null;
-    }
+  private peekOldestPartialFrameNumber(): number | null {
+    const first = this.partials.keys().next();
+    return first.done ? null : first.value;
   }
 
-  private frameFromSingle(packet: DataTrackPacket, options?: PushOptions): Throws<
-    DataTrackFrameInternal | null,
+  private frameFromSingle(
+    packet: DataTrackPacket,
+    options?: PushOptions,
+  ): Throws<
+    DataTrackFrameInternal,
     DataTrackDepacketizerDropError<DataTrackDepacketizerDropReason.Interrupted>
   > {
     if (packet.header.marker !== FrameMarker.Single) {
@@ -140,29 +138,29 @@ export default class DataTrackDepacketizer {
       );
     }
 
-    // const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
-    // if (this.partials.size < maximumConcurrentPartialFrames) {
-
-    if (this.partials.size > 0 && options?.maximumConcurrentPartialFrames === 1) {
+    // A `Single` packet is a self-contained frame and doesn't reserve a partials slot, but if
+    // the partials map is at capacity, treat it as a signal that the oldest in-flight partial
+    // is stale and evict it (matches `main`'s behavior when `maximumConcurrentPartialFrames`
+    // defaults to 1).
+    const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
+    if (this.partials.size >= maximumConcurrentPartialFrames) {
       const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
-      if (!oldestPartialFrameNumber) {
+      if (typeof oldestPartialFrameNumber !== 'number') {
         // @throws-transformer ignore - this should be treated as a "panic" and not be caught
         throw new Error(
-          `Depacketizer.frameFromSingle: no oldest frame number found, but partials.size is ${this.partials.size}`,
+          `Depacketizer.frameFromSingle: no oldest frame number found, but partials.size is ${this.partials.size}.`,
         );
       }
-
       if (options?.errorOnPartialFrames) {
         this.partials.delete(oldestPartialFrameNumber);
         throw DataTrackDepacketizerDropError.interrupted(
           oldestPartialFrameNumber,
           packet.header.frameNumber.value,
         );
-      } else {
-        log.warn(
-          `Data track frame ${oldestPartialFrameNumber} was interrupted by the start of a new frame, dropping.`,
-        );
       }
+      log.warn(
+        `Data track frame ${oldestPartialFrameNumber} was interrupted by single-packet frame ${packet.header.frameNumber.value}, dropping.`,
+      );
     }
 
     return { payload: packet.payload, extensions: packet.header.extensions };
@@ -190,25 +188,23 @@ export default class DataTrackDepacketizer {
 
     const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
     if (this.partials.size >= maximumConcurrentPartialFrames) {
-      const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber()!;
+      const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
+      if (typeof oldestPartialFrameNumber !== 'number') {
+        // @throws-transformer ignore - this should be treated as a "panic" and not be caught
+        throw new Error(
+          `Depacketizer.beginPartial: no oldest frame number found, but partials.size is ${this.partials.size}.`,
+        );
+      }
       this.partials.delete(oldestPartialFrameNumber);
 
       if (options?.errorOnPartialFrames) {
-        const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
-        if (!oldestPartialFrameNumber) {
-          // @throws-transformer ignore - this should be treated as a "panic" and not be caught
-          throw new Error(
-            `Depacketizer.beginPartial: no oldest frame number found, but partials.size is ${this.partials.size}`,
-          );
-        }
         throw DataTrackDepacketizerDropError.interrupted(oldestPartialFrameNumber, frameNumber);
-      } else {
-        log.warn(
-          `Data track partials (size of ${maximumConcurrentPartialFrames}) didn't have enough room for a new frame ${frameNumber}, dropping.`,
-        );
       }
+      log.warn(
+        `Data track partials full (max ${maximumConcurrentPartialFrames}), evicted oldest frame ${oldestPartialFrameNumber} to make room for new frame ${frameNumber}.`,
+      );
     }
-    this.partials.set(frameNumber, { frame: partial, startedAt: new Date() });
+    this.partials.set(frameNumber, partial);
 
     return null;
   }
@@ -228,12 +224,12 @@ export default class DataTrackDepacketizer {
     const matchingPartial = this.partials.get(packetFrameNumber);
     if (!matchingPartial) {
       this.partials.delete(packetFrameNumber);
-      throw DataTrackDepacketizerDropError.unknownFrame(packet.header.frameNumber.value);
+      throw DataTrackDepacketizerDropError.unknownFrame(packetFrameNumber);
     }
 
     // NOTE: this check will block reprocessing packets with duplicate sequence values if the
     // buffer is full already, which could maybe be problematic for very large frames.
-    if (matchingPartial.frame.payloads.size >= DataTrackDepacketizer.MAX_BUFFER_PACKETS) {
+    if (matchingPartial.payloads.size >= DataTrackDepacketizer.MAX_BUFFER_PACKETS) {
       this.partials.delete(packetFrameNumber);
       throw DataTrackDepacketizerDropError.bufferFull(packetFrameNumber);
     }
@@ -241,15 +237,15 @@ export default class DataTrackDepacketizer {
     // Note: receiving a packet with a duplicate `sequence` value is something that likely won't
     // happen in actual use, but even if it does (maybe a low level network retransmission?) the
     // last packet with a given sequence received should always win.
-    if (matchingPartial.frame.payloads.has(packet.header.sequence.value)) {
+    if (matchingPartial.payloads.has(packet.header.sequence.value)) {
       log.warn(
         `Data track frame ${packetFrameNumber} received duplicate packet for sequence ${packet.header.sequence.value}, so replacing with newly received packet.`,
       );
     }
-    matchingPartial.frame.payloads.set(packet.header.sequence.value, packet.payload);
+    matchingPartial.payloads.set(packet.header.sequence.value, packet.payload);
 
     if (packet.header.marker === FrameMarker.Final) {
-      return this.finalize(packetFrameNumber, matchingPartial.frame, packet.header.sequence.value);
+      return this.finalize(packetFrameNumber, matchingPartial, packet.header.sequence.value);
     }
 
     return null;

--- a/src/room/data-track/depacketizer.ts
+++ b/src/room/data-track/depacketizer.ts
@@ -189,7 +189,7 @@ export default class DataTrackDepacketizer {
     };
 
     const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
-    if (this.partials.size > maximumConcurrentPartialFrames) {
+    if (this.partials.size >= maximumConcurrentPartialFrames) {
       const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber()!;
       this.partials.delete(oldestPartialFrameNumber);
 

--- a/src/room/data-track/depacketizer.ts
+++ b/src/room/data-track/depacketizer.ts
@@ -78,13 +78,15 @@ export enum DataTrackDepacketizerDropReason {
 }
 
 type PushOptions = {
-  /** If true, throws an error instead of logging a warning when a new frame would evict a
-   * pre-existing partial frame. */
-  errorOnPartialFrames: boolean;
+  /** If true, throws `DataTrackDepacketizerDropError.interrupted` instead of logging a warning
+   * when a new frame arrives while the partials map is at capacity. */
+  throwOnInterruption: boolean;
 
   /** Maximum number of partial frames the depacketizer will track concurrently. When a new
-   * `Start` packet arrives at capacity, the oldest partial frame is evicted. Defaults to 1. */
-  maximumConcurrentPartialFrames?: number;
+   * frame arrives while the partials map is at capacity, the oldest partial is evicted (or
+   * `DataTrackDepacketizerDropError.interrupted` is thrown when `throwOnInterruption` is set).
+   * Defaults to 1. */
+  maxPartialFrames?: number;
 };
 
 export default class DataTrackDepacketizer {
@@ -140,10 +142,10 @@ export default class DataTrackDepacketizer {
 
     // A `Single` packet is a self-contained frame and doesn't reserve a partials slot, but if
     // the partials map is at capacity, treat it as a signal that the oldest in-flight partial
-    // is stale and evict it (matches `main`'s behavior when `maximumConcurrentPartialFrames`
+    // is stale and evict it (matches `main`'s behavior when `maxPartialFrames`
     // defaults to 1).
-    const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
-    if (this.partials.size >= maximumConcurrentPartialFrames) {
+    const maxPartialFrames = options?.maxPartialFrames ?? 1;
+    if (this.partials.size >= maxPartialFrames) {
       const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
       if (typeof oldestPartialFrameNumber !== 'number') {
         // @throws-transformer ignore - this should be treated as a "panic" and not be caught
@@ -151,7 +153,7 @@ export default class DataTrackDepacketizer {
           `Depacketizer.frameFromSingle: no oldest frame number found, but partials.size is ${this.partials.size}.`,
         );
       }
-      if (options?.errorOnPartialFrames) {
+      if (options?.throwOnInterruption) {
         this.partials.delete(oldestPartialFrameNumber);
         throw DataTrackDepacketizerDropError.interrupted(
           oldestPartialFrameNumber,
@@ -186,8 +188,8 @@ export default class DataTrackDepacketizer {
       payloads: new Map([[startSequence.value, packet.payload]]),
     };
 
-    const maximumConcurrentPartialFrames = options?.maximumConcurrentPartialFrames ?? 1;
-    if (this.partials.size >= maximumConcurrentPartialFrames) {
+    const maxPartialFrames = options?.maxPartialFrames ?? 1;
+    if (this.partials.size >= maxPartialFrames) {
       const oldestPartialFrameNumber = this.peekOldestPartialFrameNumber();
       if (typeof oldestPartialFrameNumber !== 'number') {
         // @throws-transformer ignore - this should be treated as a "panic" and not be caught
@@ -197,11 +199,11 @@ export default class DataTrackDepacketizer {
       }
       this.partials.delete(oldestPartialFrameNumber);
 
-      if (options?.errorOnPartialFrames) {
+      if (options?.throwOnInterruption) {
         throw DataTrackDepacketizerDropError.interrupted(oldestPartialFrameNumber, frameNumber);
       }
       log.warn(
-        `Data track partials full (max ${maximumConcurrentPartialFrames}), evicted oldest frame ${oldestPartialFrameNumber} to make room for new frame ${frameNumber}.`,
+        `Data track partials full (max ${maxPartialFrames}), evicted oldest frame ${oldestPartialFrameNumber} to make room for new frame ${frameNumber}.`,
       );
     }
     this.partials.set(frameNumber, partial);

--- a/src/room/data-track/depacketizer.ts
+++ b/src/room/data-track/depacketizer.ts
@@ -153,8 +153,8 @@ export default class DataTrackDepacketizer {
           `Depacketizer.frameFromSingle: no oldest frame number found, but partials.size is ${this.partials.size}.`,
         );
       }
+      this.partials.delete(oldestPartialFrameNumber);
       if (options?.throwOnInterruption) {
-        this.partials.delete(oldestPartialFrameNumber);
         throw DataTrackDepacketizerDropError.interrupted(
           oldestPartialFrameNumber,
           packet.header.frameNumber.value,

--- a/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
@@ -936,5 +936,199 @@ describe('DataTrackIncomingManager', () => {
         process.off('unhandledRejection', onUnhandled);
       }
     });
+
+    it('should depacketize multiple interleaved partial frames when setMaxPartialFrames is called before subscribe', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      const trackPublishedEvent = await managerEvents.waitFor('trackPublished');
+
+      // Configure the track BEFORE any subscribe.
+      trackPublishedEvent.track.setMaxPartialFrames(3);
+
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid);
+      const reader = stream.getReader();
+
+      await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+      await sfuSubscriptionComplete;
+
+      // Two interleaved partial frames: Start(1), Start(2), Final(1), Final(2). With the default
+      // maxPartialFrames=1 frame 1 would be evicted by frame 2; with maxPartialFrames=3 both
+      // frames coexist and emerge.
+      pushInterleavedTwoFramePair(manager, handle, {
+        frameOneNumber: 1,
+        frameOneStartSequence: 0,
+        frameOnePayloads: [new Uint8Array([0xa1]), new Uint8Array([0xa2])],
+        frameTwoNumber: 2,
+        frameTwoStartSequence: 100,
+        frameTwoPayloads: [new Uint8Array([0xb1]), new Uint8Array([0xb2])],
+      });
+
+      const first = await reader.read();
+      expect(first.done).toStrictEqual(false);
+      expect(first.value?.payload).toStrictEqual(new Uint8Array([0xa1, 0xa2]));
+
+      const second = await reader.read();
+      expect(second.done).toStrictEqual(false);
+      expect(second.value?.payload).toStrictEqual(new Uint8Array([0xb1, 0xb2]));
+    });
+
+    it('should pick up setMaxPartialFrames live on an already-active subscription', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      const trackPublishedEvent = await managerEvents.waitFor('trackPublished');
+
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid);
+      const reader = stream.getReader();
+
+      await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+      await sfuSubscriptionComplete;
+
+      // Subscription is now active; flip the cap on the live pipeline.
+      trackPublishedEvent.track.setMaxPartialFrames(3);
+
+      pushInterleavedTwoFramePair(manager, handle, {
+        frameOneNumber: 1,
+        frameOneStartSequence: 0,
+        frameOnePayloads: [new Uint8Array([0xa1]), new Uint8Array([0xa2])],
+        frameTwoNumber: 2,
+        frameTwoStartSequence: 100,
+        frameTwoPayloads: [new Uint8Array([0xb1]), new Uint8Array([0xb2])],
+      });
+
+      const first = await reader.read();
+      expect(first.value?.payload).toStrictEqual(new Uint8Array([0xa1, 0xa2]));
+
+      const second = await reader.read();
+      expect(second.value?.payload).toStrictEqual(new Uint8Array([0xb1, 0xb2]));
+    });
+
+    it('should drop the older partial frame by default (no setMaxPartialFrames call)', async () => {
+      const manager = new IncomingDataTrackManager();
+      const managerEvents = subscribeToEvents<DataTrackIncomingManagerCallbacks>(manager, [
+        'sfuUpdateSubscription',
+        'trackPublished',
+      ]);
+
+      const senderIdentity = 'identity';
+      const sid = 'data track sid';
+      const handle = DataTrackHandle.fromNumber(5);
+
+      await manager.receiveSfuPublicationUpdates(
+        new Map([[senderIdentity, [{ sid, pubHandle: handle, name: 'test', usesE2ee: false }]]]),
+      );
+      await managerEvents.waitFor('trackPublished');
+
+      const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid);
+      const reader = stream.getReader();
+
+      await managerEvents.waitFor('sfuUpdateSubscription');
+      manager.receivedSfuSubscriberHandles(new Map([[handle, sid]]));
+      await sfuSubscriptionComplete;
+
+      // Default cap of 1: Start(2) evicts Start(1), so Final(1) is unknown and only frame 2
+      // makes it through.
+      pushInterleavedTwoFramePair(manager, handle, {
+        frameOneNumber: 1,
+        frameOneStartSequence: 0,
+        frameOnePayloads: [new Uint8Array([0xa1]), new Uint8Array([0xa2])],
+        frameTwoNumber: 2,
+        frameTwoStartSequence: 100,
+        frameTwoPayloads: [new Uint8Array([0xb1]), new Uint8Array([0xb2])],
+      });
+
+      const onlyFrame = await reader.read();
+      expect(onlyFrame.done).toStrictEqual(false);
+      expect(onlyFrame.value?.payload).toStrictEqual(new Uint8Array([0xb1, 0xb2]));
+    });
   });
 });
+
+/** Pushes Start(frame1), Start(frame2), Final(frame1), Final(frame2) packets through the manager
+ * to exercise the depacketizer's concurrent-partial-frame handling. */
+function pushInterleavedTwoFramePair(
+  manager: IncomingDataTrackManager,
+  trackHandle: DataTrackHandle,
+  args: {
+    frameOneNumber: number;
+    frameOneStartSequence: number;
+    frameOnePayloads: [Uint8Array, Uint8Array];
+    frameTwoNumber: number;
+    frameTwoStartSequence: number;
+    frameTwoPayloads: [Uint8Array, Uint8Array];
+  },
+) {
+  const buildPacket = (
+    frameNumber: number,
+    sequence: number,
+    marker: FrameMarker,
+    payload: Uint8Array,
+  ) =>
+    new DataTrackPacket(
+      new DataTrackPacketHeader({
+        extensions: new DataTrackExtensions(),
+        frameNumber: WrapAroundUnsignedInt.u16(frameNumber),
+        marker,
+        sequence: WrapAroundUnsignedInt.u16(sequence),
+        timestamp: DataTrackTimestamp.fromRtpTicks(0),
+        trackHandle,
+      }),
+      payload,
+    ).toBinary();
+
+  manager.packetReceived(
+    buildPacket(
+      args.frameOneNumber,
+      args.frameOneStartSequence,
+      FrameMarker.Start,
+      args.frameOnePayloads[0],
+    ),
+  );
+  manager.packetReceived(
+    buildPacket(
+      args.frameTwoNumber,
+      args.frameTwoStartSequence,
+      FrameMarker.Start,
+      args.frameTwoPayloads[0],
+    ),
+  );
+  manager.packetReceived(
+    buildPacket(
+      args.frameOneNumber,
+      args.frameOneStartSequence + 1,
+      FrameMarker.Final,
+      args.frameOnePayloads[1],
+    ),
+  );
+  manager.packetReceived(
+    buildPacket(
+      args.frameTwoNumber,
+      args.frameTwoStartSequence + 1,
+      FrameMarker.Final,
+      args.frameTwoPayloads[1],
+    ),
+  );
+}

--- a/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.test.ts
@@ -954,7 +954,7 @@ describe('DataTrackIncomingManager', () => {
       const trackPublishedEvent = await managerEvents.waitFor('trackPublished');
 
       // Configure the track BEFORE any subscribe.
-      trackPublishedEvent.track.setMaxPartialFrames(3);
+      trackPublishedEvent.track.setPipelineOptions({ maxPartialFrames: 3 });
 
       const [stream, sfuSubscriptionComplete] = manager.openSubscriptionStream(sid);
       const reader = stream.getReader();
@@ -1008,7 +1008,7 @@ describe('DataTrackIncomingManager', () => {
       await sfuSubscriptionComplete;
 
       // Subscription is now active; flip the cap on the live pipeline.
-      trackPublishedEvent.track.setMaxPartialFrames(3);
+      trackPublishedEvent.track.setPipelineOptions({ maxPartialFrames: 3 });
 
       pushInterleavedTwoFramePair(manager, handle, {
         frameOneNumber: 1,

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -65,6 +65,10 @@ type Descriptor<S extends SubscriptionState> = {
   info: DataTrackInfo;
   publisherIdentity: Participant['identity'];
   subscription: S;
+  /** Per-track override for the depacketizer's `maxPartialFrames`. Set via
+   * {@link RemoteDataTrack.setMaxPartialFrames}. Read at pipeline construction time and pushed
+   * live to an active pipeline if changed afterwards. */
+  maxPartialFrames?: number;
 };
 
 type IncomingDataTrackManagerOptions = {
@@ -110,6 +114,23 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       if (descriptor.subscription.type === 'active') {
         descriptor.subscription.pipeline.updateE2eeManager(e2eeManager);
       }
+    }
+  }
+
+  /** Set the per-track `maxPartialFrames` value used by the depacketizer. Stored on the
+   * descriptor so it survives subscription teardown/recreation, and forwarded immediately to
+   * an active pipeline if there is one.
+   *
+   * @internal */
+  setTrackMaxPartialFrames(sid: DataTrackSid, n: number): void {
+    const descriptor = this.descriptors.get(sid);
+    if (!descriptor) {
+      log.warn(`Unknown track ${sid}, cannot set maxPartialFrames.`);
+      return;
+    }
+    descriptor.maxPartialFrames = n;
+    if (descriptor.subscription.type === 'active') {
+      descriptor.subscription.pipeline.setMaxPartialFrames(n);
     }
   }
 
@@ -530,6 +551,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
           info: descriptor.info,
           publisherIdentity: descriptor.publisherIdentity,
           e2eeManager: this.e2eeManager,
+          maxPartialFrames: descriptor.maxPartialFrames,
         });
 
         const previousDescriptorSubscription = descriptor.subscription;

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -13,7 +13,11 @@ import { DataTrackDepacketizerDropError } from '../depacketizer';
 import { type DataTrackFrame, DataTrackFrameInternal } from '../frame';
 import { DataTrackHandle } from '../handle';
 import { DataTrackPacket } from '../packet';
-import { type DataTrackInfo, type DataTrackSid } from '../types';
+import {
+  type DataTrackInfo,
+  type DataTrackSid,
+  type RemoteDataTrackPipelineOptions,
+} from '../types';
 import { DataTrackSubscribeError } from './errors';
 import IncomingDataTrackPipeline from './pipeline';
 import {
@@ -65,10 +69,7 @@ type Descriptor<S extends SubscriptionState> = {
   info: DataTrackInfo;
   publisherIdentity: Participant['identity'];
   subscription: S;
-  /** Per-track override for the depacketizer's `maxPartialFrames`. Set via
-   * {@link RemoteDataTrack.setMaxPartialFrames}. Read at pipeline construction time and pushed
-   * live to an active pipeline if changed afterwards. */
-  maxPartialFrames: number | null;
+  pipelineOptions: RemoteDataTrackPipelineOptions;
 };
 
 type IncomingDataTrackManagerOptions = {
@@ -117,20 +118,16 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
     }
   }
 
-  /** Set the per-track `maxPartialFrames` value used by the depacketizer. Stored on the
-   * descriptor so it survives subscription teardown/recreation, and forwarded immediately to
-   * an active pipeline if there is one.
-   *
-   * @internal */
-  setTrackMaxPartialFrames(sid: DataTrackSid, n: number | null): void {
+  /** @internal */
+  setPipelineOptions(sid: DataTrackSid, options: RemoteDataTrackPipelineOptions): void {
     const descriptor = this.descriptors.get(sid);
     if (!descriptor) {
-      log.warn(`Unknown track ${sid}, cannot set maxPartialFrames.`);
+      log.warn(`Unknown track ${sid}, cannot set pipeline options.`);
       return;
     }
-    descriptor.maxPartialFrames = n;
+    descriptor.pipelineOptions = options;
     if (descriptor.subscription.type === 'active') {
-      descriptor.subscription.pipeline.setMaxPartialFrames(n);
+      descriptor.subscription.pipeline.setOptions(options);
     }
   }
 
@@ -494,7 +491,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       info,
       publisherIdentity,
       subscription: { type: 'none' },
-      maxPartialFrames: null,
+      pipelineOptions: {},
     };
     this.descriptors.set(descriptor.info.sid, descriptor);
 
@@ -552,7 +549,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
           info: descriptor.info,
           publisherIdentity: descriptor.publisherIdentity,
           e2eeManager: this.e2eeManager,
-          maxPartialFrames: descriptor.maxPartialFrames ?? undefined,
+          pipelineOptions: descriptor.pipelineOptions,
         });
 
         const previousDescriptorSubscription = descriptor.subscription;

--- a/src/room/data-track/incoming/IncomingDataTrackManager.ts
+++ b/src/room/data-track/incoming/IncomingDataTrackManager.ts
@@ -68,7 +68,7 @@ type Descriptor<S extends SubscriptionState> = {
   /** Per-track override for the depacketizer's `maxPartialFrames`. Set via
    * {@link RemoteDataTrack.setMaxPartialFrames}. Read at pipeline construction time and pushed
    * live to an active pipeline if changed afterwards. */
-  maxPartialFrames?: number;
+  maxPartialFrames: number | null;
 };
 
 type IncomingDataTrackManagerOptions = {
@@ -122,7 +122,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
    * an active pipeline if there is one.
    *
    * @internal */
-  setTrackMaxPartialFrames(sid: DataTrackSid, n: number): void {
+  setTrackMaxPartialFrames(sid: DataTrackSid, n: number | null): void {
     const descriptor = this.descriptors.get(sid);
     if (!descriptor) {
       log.warn(`Unknown track ${sid}, cannot set maxPartialFrames.`);
@@ -494,6 +494,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
       info,
       publisherIdentity,
       subscription: { type: 'none' },
+      maxPartialFrames: null,
     };
     this.descriptors.set(descriptor.info.sid, descriptor);
 
@@ -551,7 +552,7 @@ export default class IncomingDataTrackManager extends (EventEmitter as new () =>
           info: descriptor.info,
           publisherIdentity: descriptor.publisherIdentity,
           e2eeManager: this.e2eeManager,
-          maxPartialFrames: descriptor.maxPartialFrames,
+          maxPartialFrames: descriptor.maxPartialFrames ?? undefined,
         });
 
         const previousDescriptorSubscription = descriptor.subscription;

--- a/src/room/data-track/incoming/pipeline.ts
+++ b/src/room/data-track/incoming/pipeline.ts
@@ -15,6 +15,7 @@ type Options = {
   info: DataTrackInfo;
   publisherIdentity: string;
   e2eeManager: BaseE2EEManager | null;
+  maxPartialFrames?: number;
 };
 
 /**
@@ -26,6 +27,8 @@ export default class IncomingDataTrackPipeline {
   private e2eeManager: BaseE2EEManager | null;
 
   private depacketizer: DataTrackDepacketizer;
+
+  private maxPartialFrames?: number;
 
   /**
    * Creates a new pipeline with the given options.
@@ -44,10 +47,15 @@ export default class IncomingDataTrackPipeline {
     this.publisherIdentity = options.publisherIdentity;
     this.e2eeManager = options.e2eeManager ?? null;
     this.depacketizer = depacketizer;
+    this.maxPartialFrames = options.maxPartialFrames;
   }
 
   updateE2eeManager(e2eeManager: BaseE2EEManager | null) {
     this.e2eeManager = e2eeManager;
+  }
+
+  setMaxPartialFrames(n: number): void {
+    this.maxPartialFrames = n;
   }
 
   async processPacket(
@@ -74,7 +82,10 @@ export default class IncomingDataTrackPipeline {
   ): Throws<DataTrackFrameInternal | null, DataTrackDepacketizerDropError> {
     let frame: DataTrackFrameInternal | null;
     try {
-      frame = this.depacketizer.push(packet);
+      frame = this.depacketizer.push(packet, {
+        throwOnInterruption: false,
+        maxPartialFrames: this.maxPartialFrames,
+      });
     } catch (err) {
       // In a future version, use this to maintain drop statistics.
       // FIXME: is this a good idea?

--- a/src/room/data-track/incoming/pipeline.ts
+++ b/src/room/data-track/incoming/pipeline.ts
@@ -4,7 +4,7 @@ import { LoggerNames, getLogger } from '../../../logger';
 import DataTrackDepacketizer, { DataTrackDepacketizerDropError } from '../depacketizer';
 import type { DataTrackFrameInternal } from '../frame';
 import { DataTrackPacket } from '../packet';
-import { type DataTrackInfo } from '../types';
+import { type DataTrackInfo, type RemoteDataTrackPipelineOptions } from '../types';
 
 const log = getLogger(LoggerNames.DataTracks);
 
@@ -15,7 +15,7 @@ type Options = {
   info: DataTrackInfo;
   publisherIdentity: string;
   e2eeManager: BaseE2EEManager | null;
-  maxPartialFrames?: number;
+  pipelineOptions?: RemoteDataTrackPipelineOptions;
 };
 
 /**
@@ -28,7 +28,7 @@ export default class IncomingDataTrackPipeline {
 
   private depacketizer: DataTrackDepacketizer;
 
-  private maxPartialFrames: number | null;
+  private options: RemoteDataTrackPipelineOptions;
 
   /**
    * Creates a new pipeline with the given options.
@@ -47,15 +47,15 @@ export default class IncomingDataTrackPipeline {
     this.publisherIdentity = options.publisherIdentity;
     this.e2eeManager = options.e2eeManager ?? null;
     this.depacketizer = depacketizer;
-    this.maxPartialFrames = options.maxPartialFrames ?? null;
+    this.options = options.pipelineOptions ?? {};
   }
 
   updateE2eeManager(e2eeManager: BaseE2EEManager | null) {
     this.e2eeManager = e2eeManager;
   }
 
-  setMaxPartialFrames(n: number | null): void {
-    this.maxPartialFrames = n;
+  setOptions(options: RemoteDataTrackPipelineOptions): void {
+    this.options = options;
   }
 
   async processPacket(
@@ -84,7 +84,7 @@ export default class IncomingDataTrackPipeline {
     try {
       frame = this.depacketizer.push(packet, {
         throwOnInterruption: false,
-        maxPartialFrames: this.maxPartialFrames ?? undefined,
+        maxPartialFrames: this.options.maxPartialFrames,
       });
     } catch (err) {
       // In a future version, use this to maintain drop statistics.

--- a/src/room/data-track/incoming/pipeline.ts
+++ b/src/room/data-track/incoming/pipeline.ts
@@ -28,7 +28,7 @@ export default class IncomingDataTrackPipeline {
 
   private depacketizer: DataTrackDepacketizer;
 
-  private maxPartialFrames?: number;
+  private maxPartialFrames: number | null;
 
   /**
    * Creates a new pipeline with the given options.
@@ -47,14 +47,14 @@ export default class IncomingDataTrackPipeline {
     this.publisherIdentity = options.publisherIdentity;
     this.e2eeManager = options.e2eeManager ?? null;
     this.depacketizer = depacketizer;
-    this.maxPartialFrames = options.maxPartialFrames;
+    this.maxPartialFrames = options.maxPartialFrames ?? null;
   }
 
   updateE2eeManager(e2eeManager: BaseE2EEManager | null) {
     this.e2eeManager = e2eeManager;
   }
 
-  setMaxPartialFrames(n: number): void {
+  setMaxPartialFrames(n: number | null): void {
     this.maxPartialFrames = n;
   }
 
@@ -84,7 +84,7 @@ export default class IncomingDataTrackPipeline {
     try {
       frame = this.depacketizer.push(packet, {
         throwOnInterruption: false,
-        maxPartialFrames: this.maxPartialFrames,
+        maxPartialFrames: this.maxPartialFrames ?? undefined,
       });
     } catch (err) {
       // In a future version, use this to maintain drop statistics.

--- a/src/room/data-track/types.ts
+++ b/src/room/data-track/types.ts
@@ -11,6 +11,14 @@ export type DataTrackInfo = {
   usesE2ee: boolean;
 };
 
+export type RemoteDataTrackPipelineOptions = {
+  /** Set the maximum number of in-flight partial frames the depacketizer will track
+   * concurrently for this track. Higher values give more out-of-order tolerance for
+   * high-frequency senders. Defaults to 1.
+   */
+  maxPartialFrames?: number;
+};
+
 export const DataTrackInfo = {
   from(protocolInfo: ProtocolDataTrackInfo): DataTrackInfo {
     return {


### PR DESCRIPTION
- Updates the depacketizer to take a `maxPartialFrames` which controls how many frames are being stored at once.
- Exposes this as a `RemoteDataTrack` level setting - there is one pipeline per track, not one pipeline per subscription, so this is where it makes most sense (also given that you won't really need to configure it differently by subscription since this is fully dependant on the data being received from the sender).

Code example:
```tsx
const remoteDataTrack: RemoteDataTrack = /* ... */;

// The new bit:
remoteDataTrack.setPipelineOptions({ maxPartialFrames: 10 }); // Defaults to 1 to maintain backwards compatibility.

for await (const frame of remoteDataTrack.subscribe()) {
  // ...
}
```

## Todo
- [x] Add changeset