### PR TITLE
Implement negotiation tracking based on offerId

### DIFF
--- a/.changeset/eight-eggs-obey.md
+++ b/.changeset/eight-eggs-obey.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Implement negotiation tracking based on offerId

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -1,7 +1,8 @@
 import { Mutex } from '@livekit/mutex';
 import { EventEmitter } from 'events';
 import { parse, write } from 'sdp-transform';
-import type { MediaDescription, SessionDescription } from 'sdp-transform';
+import type { MediaAttributes, MediaDescription, SessionDescription } from 'sdp-transform';
+import type TypedEmitter from 'typed-emitter';
 import log, { LoggerNames, getLogger } from '../logger';
 import { debounce } from './debounce';
 import { NegotiationError, UnexpectedConnectionState } from './errors';
@@ -38,7 +39,7 @@ export const PCEvents = {
 } as const;
 
 /** @internal */
-export default class PCTransport extends EventEmitter {
+export default class PCTransport extends (EventEmitter as new () => TypedEmitter<PCTransportEventCallbacks>) {
   private _pc: RTCPeerConnection | null;
 
   private get pc() {
@@ -752,3 +753,10 @@ function ensureIPAddrMatchVersion(media: MediaDescription) {
 function getMidString(mid: string | number) {
   return typeof mid === 'number' ? mid.toFixed(0) : mid;
 }
+
+type PCTransportEventCallbacks = {
+  negotiationStarted: () => void;
+  negotiationComplete: () => void;
+  offerAnswered: (offerId: number) => void;
+  rtpVideoPayloadTypes: (attributes: MediaAttributes['rtp']) => void;
+};

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -29,6 +29,11 @@ const debounceInterval = 20;
 export const PCEvents = {
   NegotiationStarted: 'negotiationStarted',
   NegotiationComplete: 'negotiationComplete',
+  // Fired with the offerId for every successful publisher answer application,
+  // including answers that immediately recurse into another offer via
+  // `renegotiate`. Use this rather than NegotiationComplete to know that a
+  // specific offer has been negotiated end-to-end.
+  OfferAnswered: 'offerAnswered',
   RTPVideoPayloadTypes: 'rtpVideoPayloadTypes',
 } as const;
 
@@ -51,7 +56,9 @@ export default class PCTransport extends EventEmitter {
 
   private ddExtID = 0;
 
-  private latestOfferId: number = 0;
+  latestOfferId: number = 0;
+
+  latestAcknowledgedOfferId: number = 0;
 
   private offerLock: Mutex;
 
@@ -235,6 +242,14 @@ export default class PCTransport extends EventEmitter {
     });
     this.pendingCandidates = [];
     this.restartingIce = false;
+
+    // Fire OfferAnswered for every successfully applied answer, including the
+    // ones that recurse into another offer via `renegotiate`. Callers waiting
+    // on a specific offerId can resolve as soon as their offer's answer is in.
+    if (sd.type === 'answer') {
+      this.latestAcknowledgedOfferId = offerId;
+      this.emit(PCEvents.OfferAnswered, offerId);
+    }
 
     if (this.renegotiate) {
       this.renegotiate = false;

--- a/src/room/PCTransportManager.test.ts
+++ b/src/room/PCTransportManager.test.ts
@@ -38,7 +38,23 @@ class StubPC {
 }
 
 class FakePublisher extends EventEmitter {
+  latestOfferId = 0;
+
+  latestAcknowledgedOfferId = 0;
+
   negotiate = vi.fn(async (_onError?: (e: Error) => void) => {});
+
+  /** Simulate a publisher offer cycle: bump latestOfferId. */
+  startOffer() {
+    this.latestOfferId += 1;
+    return this.latestOfferId;
+  }
+
+  /** Simulate a successful answer for the given offerId. */
+  answer(offerId: number) {
+    this.latestAcknowledgedOfferId = offerId;
+    this.emit(PCEvents.OfferAnswered, offerId);
+  }
 }
 
 describe('PCTransportManager.negotiate', () => {
@@ -58,22 +74,106 @@ describe('PCTransportManager.negotiate', () => {
   function makeManager() {
     const manager = new PCTransportManager('publisher-only', {});
     const fake = new FakePublisher();
-    // swap in the fake publisher so we control the event surface and avoid
-    // exercising any real PeerConnection plumbing
     (manager as unknown as { publisher: FakePublisher }).publisher = fake;
     manager.peerConnectionTimeout = 200;
     return { manager, pub: fake };
   }
 
-  it('resolves when NegotiationComplete fires', async () => {
+  it('resolves when an offer past the checkpoint is answered', async () => {
     const { manager, pub } = makeManager();
-    const ac = new AbortController();
-    const p = manager.negotiate(ac);
-    setTimeout(() => pub.emit(PCEvents.NegotiationComplete), 10);
+    const p = manager.negotiate(new AbortController());
+    setTimeout(() => {
+      const id = pub.startOffer();
+      pub.answer(id);
+    }, 10);
     await expect(p).resolves.toBeUndefined();
   });
 
-  it('rejects when the initial timeout elapses', async () => {
+  it('does not resolve on answers for offers at or before the checkpoint', async () => {
+    const { manager, pub } = makeManager();
+    // Some prior cycle is in flight with id=5 at the moment we capture our
+    // checkpoint. Its answer must NOT satisfy our request — our changes
+    // weren't in offer 5.
+    pub.latestOfferId = 5;
+    const ac = new AbortController();
+    const p = manager.negotiate(ac);
+
+    let settled = false;
+    p.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    pub.answer(5);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(settled).toBe(false);
+
+    ac.abort();
+    await expect(p).rejects.toThrow(/aborted/);
+  });
+
+  it('resolves through the renegotiate-recursion path', async () => {
+    // Reproduces the field shape: we capture checkpoint=N while an offer N is
+    // in flight. The answer for N arrives (renegotiate=true on the publisher,
+    // so it doesn't satisfy us), then a follow-up offer N+1 is created and
+    // answered. We resolve on the second answer.
+    const { manager, pub } = makeManager();
+    pub.latestOfferId = 1;
+    const p = manager.negotiate(new AbortController());
+
+    setTimeout(() => pub.answer(1), 10); // does not satisfy checkpoint=1
+    setTimeout(() => {
+      const id = pub.startOffer(); // 2
+      pub.answer(id);
+    }, 30);
+
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('resolves immediately when an answer past the checkpoint already arrived', async () => {
+    const { manager, pub } = makeManager();
+    pub.latestOfferId = 3;
+    pub.latestAcknowledgedOfferId = 4;
+    await expect(manager.negotiate(new AbortController())).resolves.toBeUndefined();
+  });
+
+  it('resolves concurrent callers independently at their own checkpoints', async () => {
+    const { manager, pub } = makeManager();
+
+    // A captures checkpoint=0
+    const a = manager.negotiate(new AbortController());
+    let aResolved = false;
+    a.then(() => {
+      aResolved = true;
+    });
+
+    // First cycle starts and answers — A is satisfied (1 > 0)
+    const id1 = pub.startOffer();
+
+    // B captures checkpoint=1 (an offer is now in flight)
+    const b = manager.negotiate(new AbortController());
+    let bResolved = false;
+    b.then(() => {
+      bResolved = true;
+    });
+
+    pub.answer(id1);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(aResolved).toBe(true);
+    expect(bResolved).toBe(false);
+
+    // B should resolve only on the next cycle
+    const id2 = pub.startOffer();
+    pub.answer(id2);
+    await b;
+    expect(bResolved).toBe(true);
+  });
+
+  it('rejects when the deadline elapses', async () => {
     const { manager } = makeManager();
     await expect(manager.negotiate(new AbortController())).rejects.toThrow(/timed out/);
   });
@@ -93,89 +193,90 @@ describe('PCTransportManager.negotiate', () => {
     await expect(manager.negotiate(new AbortController())).rejects.toThrow(/publisher boom/);
   });
 
-  it('removes all listeners after NegotiationComplete resolves the promise', async () => {
-    const { manager, pub } = makeManager();
-    const p = manager.negotiate(new AbortController());
-    pub.emit(PCEvents.NegotiationComplete);
-    await p;
-    expect(pub.listenerCount(PCEvents.NegotiationStarted)).toBe(0);
-    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
-  });
-
-  // BUG: the initial setTimeout at PCTransportManager.ts:232-234 rejects without
-  // calling cleanup(), so the NegotiationStarted handler, the abort handler,
-  // and the once(NegotiationComplete) handler all leak after the first timeout.
-  it('removes all listeners after the initial timeout rejects', async () => {
-    const { manager, pub } = makeManager();
-    await expect(manager.negotiate(new AbortController())).rejects.toThrow(/timed out/);
-    expect(pub.listenerCount(PCEvents.NegotiationStarted)).toBe(0);
-    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
-  });
-
-  // BUG: cleanup() at PCTransportManager.ts:236-240 never offs the
-  // once(NegotiationComplete) handler. After abort/cycle-reset timeout/
-  // publisher error, that listener accumulates over repeated negotiate() calls
-  // (matching the "11 negotiationComplete listeners added" warning seen in
-  // production sessions that hit this hang).
-  it('removes the NegotiationComplete listener after the cycle-reset timeout rejects', async () => {
-    const { manager, pub } = makeManager();
-    const p = manager.negotiate(new AbortController());
-    // switch onto the resettable timer path
-    pub.emit(PCEvents.NegotiationStarted);
-    await expect(p).rejects.toThrow(/timed out/);
-    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
-  });
-
-  it('removes the NegotiationComplete listener after abort rejects', async () => {
-    const { manager, pub } = makeManager();
-    const ac = new AbortController();
-    const p = manager.negotiate(ac);
-    setTimeout(() => ac.abort(), 10);
-    await expect(p).rejects.toThrow(/aborted/);
-    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
-  });
-
-  it('removes the NegotiationComplete listener after publisher.negotiate errors', async () => {
-    const { manager, pub } = makeManager();
-    pub.negotiate.mockImplementationOnce(async (onError?: (e: Error) => void) => {
-      onError?.(new Error('publisher boom'));
+  describe('listener cleanup', () => {
+    it('after success', async () => {
+      const { manager, pub } = makeManager();
+      const p = manager.negotiate(new AbortController());
+      const id = pub.startOffer();
+      pub.answer(id);
+      await p;
+      expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(0);
     });
-    await expect(manager.negotiate(new AbortController())).rejects.toThrow(/publisher boom/);
-    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
+
+    it('after non-matching answer (still pending), then abort', async () => {
+      const { manager, pub } = makeManager();
+      pub.latestOfferId = 5;
+      const ac = new AbortController();
+      const p = manager.negotiate(ac);
+      pub.answer(5); // does not satisfy checkpoint=5
+      expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(1);
+      ac.abort();
+      await expect(p).rejects.toThrow(/aborted/);
+      expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(0);
+    });
+
+    it('after deadline', async () => {
+      const { manager, pub } = makeManager();
+      await expect(manager.negotiate(new AbortController())).rejects.toThrow(/timed out/);
+      expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(0);
+    });
+
+    it('after abort', async () => {
+      const { manager, pub } = makeManager();
+      const ac = new AbortController();
+      const p = manager.negotiate(ac);
+      setTimeout(() => ac.abort(), 10);
+      await expect(p).rejects.toThrow(/aborted/);
+      expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(0);
+    });
+
+    it('after publisher.negotiate errors', async () => {
+      const { manager, pub } = makeManager();
+      pub.negotiate.mockImplementationOnce(async (onError?: (e: Error) => void) => {
+        onError?.(new Error('publisher boom'));
+      });
+      await expect(manager.negotiate(new AbortController())).rejects.toThrow(/publisher boom/);
+      expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(0);
+    });
+
+    it('does not leak across many sequential negotiate() calls', async () => {
+      const { manager, pub } = makeManager();
+      for (let i = 0; i < 12; i += 1) {
+        const p = manager.negotiate(new AbortController());
+        const id = pub.startOffer();
+        pub.answer(id);
+        await p;
+      }
+      expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(0);
+    });
   });
 
-  // ROOT-CAUSE TEST: reproduces the field hang reported on Windows 11 with a
-  // slow Camera Frame Server. Every NegotiationStarted resets the timer
-  // (PCTransportManager.ts:252-261, introduced in PR #1813). If something keeps
-  // emitting NegotiationStarted faster than peerConnectionTimeout — e.g.
-  // ensureDataTransportConnected calling publisher.negotiate() while ICE isn't
-  // up, or repeated server-driven MediaSectionsRequirement updates — the
-  // outer Promise neither resolves nor rejects. publishTrack's
-  // Promise.all([addTrackPromise, negotiate()]) is then wedged forever even
-  // though the underlying PC has already finished offer/answer. The fix is to
-  // bound the resettable cycle with a non-resettable max deadline.
-  it('does not hang when NegotiationStarted keeps resetting the timer', async () => {
+  // Regression test for the field hang on Windows 11 with slow Camera Frame
+  // Server. With the old design, NegotiationStarted firing faster than
+  // peerConnectionTimeout kept resetting the timer indefinitely while
+  // NegotiationComplete was suppressed by an unconverging `renegotiate` cycle,
+  // wedging the publishTrack Promise. The offerId-checkpoint design resolves
+  // on the first answer past the checkpoint, regardless of how many cycles
+  // start in between.
+  it('does not hang when many spurious cycles start without converging on the checkpoint', async () => {
     const { manager, pub } = makeManager();
-    manager.peerConnectionTimeout = 100;
-    const ac = new AbortController();
-    const p = manager.negotiate(ac);
-    // swallow whichever way it eventually settles (or doesn't)
-    p.catch(() => {});
+    manager.peerConnectionTimeout = 1500;
+    pub.latestOfferId = 1; // an unrelated cycle is in flight
+    const p = manager.negotiate(new AbortController());
 
-    const interval = setInterval(() => pub.emit(PCEvents.NegotiationStarted), 30);
+    // Lots of NegotiationStarted noise (not listened to anymore) and a few
+    // answers that don't satisfy the checkpoint.
+    const noise = setInterval(() => pub.emit(PCEvents.NegotiationStarted), 30);
+    setTimeout(() => pub.answer(1), 50); // doesn't satisfy
+    setTimeout(() => {
+      const id = pub.startOffer(); // 2
+      pub.answer(id);
+    }, 200);
 
     try {
-      const settled = await Promise.race([
-        p.then(
-          () => 'resolved' as const,
-          () => 'rejected' as const,
-        ),
-        new Promise<'hung'>((res) => setTimeout(() => res('hung'), 1500)),
-      ]);
-      expect(settled, 'negotiate() never settled — timer keeps resetting').not.toBe('hung');
+      await expect(p).resolves.toBeUndefined();
     } finally {
-      clearInterval(interval);
-      ac.abort();
+      clearInterval(noise);
     }
   });
 });

--- a/src/room/PCTransportManager.test.ts
+++ b/src/room/PCTransportManager.test.ts
@@ -251,8 +251,8 @@ describe('PCTransportManager.negotiate', () => {
     });
   });
 
-  // Regression test for the field hang on Windows 11 with slow Camera Frame
-  // Server. With the old design, NegotiationStarted firing faster than
+  // Regression test for publishing call getting stuck
+  // With the old design, NegotiationStarted firing faster than
   // peerConnectionTimeout kept resetting the timer indefinitely while
   // NegotiationComplete was suppressed by an unconverging `renegotiate` cycle,
   // wedging the publishTrack Promise. The offerId-checkpoint design resolves

--- a/src/room/PCTransportManager.test.ts
+++ b/src/room/PCTransportManager.test.ts
@@ -3,6 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PCEvents } from './PCTransport';
 import { PCTransportManager } from './PCTransportManager';
 
+/**
+ * Yield to the microtask queue so any then/catch handlers chained to a promise
+ * have a chance to run. Sufficient for "is this promise still pending right
+ * now?" assertions; nothing in these tests depends on real elapsed time.
+ */
+const flushMicrotasks = () => Promise.resolve();
+
 class StubPC {
   iceConnectionState: RTCIceConnectionState = 'new';
 
@@ -82,10 +89,10 @@ describe('PCTransportManager.negotiate', () => {
   it('resolves when an offer past the checkpoint is answered', async () => {
     const { manager, pub } = makeManager();
     const p = manager.negotiate(new AbortController());
-    setTimeout(() => {
-      const id = pub.startOffer();
-      pub.answer(id);
-    }, 10);
+
+    const id = pub.startOffer();
+    pub.answer(id);
+
     await expect(p).resolves.toBeUndefined();
   });
 
@@ -109,7 +116,7 @@ describe('PCTransportManager.negotiate', () => {
     );
 
     pub.answer(5);
-    await new Promise((r) => setTimeout(r, 50));
+    await flushMicrotasks();
     expect(settled).toBe(false);
 
     ac.abort();
@@ -125,11 +132,10 @@ describe('PCTransportManager.negotiate', () => {
     pub.latestOfferId = 1;
     const p = manager.negotiate(new AbortController());
 
-    setTimeout(() => pub.answer(1), 10); // does not satisfy checkpoint=1
-    setTimeout(() => {
-      const id = pub.startOffer(); // 2
-      pub.answer(id);
-    }, 30);
+    pub.answer(1); // does not satisfy checkpoint=1
+
+    const id = pub.startOffer(); // 2
+    pub.answer(id);
 
     await expect(p).resolves.toBeUndefined();
   });
@@ -146,27 +152,22 @@ describe('PCTransportManager.negotiate', () => {
 
     // A captures checkpoint=0
     const a = manager.negotiate(new AbortController());
-    let aResolved = false;
-    a.then(() => {
-      aResolved = true;
-    });
 
-    // First cycle starts and answers — A is satisfied (1 > 0)
+    // First cycle starts; B captures checkpoint=1 (offer now in flight)
     const id1 = pub.startOffer();
-
-    // B captures checkpoint=1 (an offer is now in flight)
     const b = manager.negotiate(new AbortController());
+
     let bResolved = false;
     b.then(() => {
       bResolved = true;
     });
 
+    // The first answer satisfies A (1 > 0) but not B (1 > 1 is false).
     pub.answer(id1);
-    await new Promise((r) => setTimeout(r, 0));
-    expect(aResolved).toBe(true);
+    await a;
     expect(bResolved).toBe(false);
 
-    // B should resolve only on the next cycle
+    // The next cycle's answer satisfies B.
     const id2 = pub.startOffer();
     pub.answer(id2);
     await b;
@@ -181,8 +182,9 @@ describe('PCTransportManager.negotiate', () => {
   it('rejects when the abort signal fires', async () => {
     const { manager } = makeManager();
     const ac = new AbortController();
-    setTimeout(() => ac.abort(), 10);
-    await expect(manager.negotiate(ac)).rejects.toThrow(/aborted/);
+    const p = manager.negotiate(ac);
+    ac.abort();
+    await expect(p).rejects.toThrow(/aborted/);
   });
 
   it('rejects when publisher.negotiate invokes its error callback', async () => {
@@ -225,7 +227,7 @@ describe('PCTransportManager.negotiate', () => {
       const { manager, pub } = makeManager();
       const ac = new AbortController();
       const p = manager.negotiate(ac);
-      setTimeout(() => ac.abort(), 10);
+      ac.abort();
       await expect(p).rejects.toThrow(/aborted/);
       expect(pub.listenerCount(PCEvents.OfferAnswered)).toBe(0);
     });
@@ -260,23 +262,20 @@ describe('PCTransportManager.negotiate', () => {
   // start in between.
   it('does not hang when many spurious cycles start without converging on the checkpoint', async () => {
     const { manager, pub } = makeManager();
-    manager.peerConnectionTimeout = 1500;
     pub.latestOfferId = 1; // an unrelated cycle is in flight
     const p = manager.negotiate(new AbortController());
 
-    // Lots of NegotiationStarted noise (not listened to anymore) and a few
-    // answers that don't satisfy the checkpoint.
-    const noise = setInterval(() => pub.emit(PCEvents.NegotiationStarted), 30);
-    setTimeout(() => pub.answer(1), 50); // doesn't satisfy
-    setTimeout(() => {
-      const id = pub.startOffer(); // 2
-      pub.answer(id);
-    }, 200);
+    // NegotiationStarted noise (not listened to anymore) interleaved with an
+    // answer for the in-flight offer that doesn't satisfy our checkpoint.
+    pub.emit(PCEvents.NegotiationStarted);
+    pub.emit(PCEvents.NegotiationStarted);
+    pub.answer(1); // doesn't satisfy checkpoint=1
+    pub.emit(PCEvents.NegotiationStarted);
 
-    try {
-      await expect(p).resolves.toBeUndefined();
-    } finally {
-      clearInterval(noise);
-    }
+    // Eventually a fresh offer is created and answered.
+    const id = pub.startOffer(); // 2
+    pub.answer(id);
+
+    await expect(p).resolves.toBeUndefined();
   });
 });

--- a/src/room/PCTransportManager.test.ts
+++ b/src/room/PCTransportManager.test.ts
@@ -1,0 +1,181 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PCEvents } from './PCTransport';
+import { PCTransportManager } from './PCTransportManager';
+
+class StubPC {
+  iceConnectionState: RTCIceConnectionState = 'new';
+
+  signalingState: RTCSignalingState = 'stable';
+
+  connectionState: RTCPeerConnectionState = 'new';
+
+  onicecandidate: ((ev: RTCPeerConnectionIceEvent) => void) | null = null;
+
+  onicecandidateerror: ((ev: Event) => void) | null = null;
+
+  oniceconnectionstatechange: (() => void) | null = null;
+
+  onsignalingstatechange: (() => void) | null = null;
+
+  onconnectionstatechange: (() => void) | null = null;
+
+  ondatachannel: ((ev: RTCDataChannelEvent) => void) | null = null;
+
+  ontrack: ((ev: RTCTrackEvent) => void) | null = null;
+
+  getTransceivers() {
+    return [];
+  }
+
+  getSenders() {
+    return [];
+  }
+
+  close() {}
+
+  setConfiguration() {}
+}
+
+class FakePublisher extends EventEmitter {
+  negotiate = vi.fn(async (_onError?: (e: Error) => void) => {});
+}
+
+describe('PCTransportManager.negotiate', () => {
+  let originalRTCPeerConnection: unknown;
+
+  beforeEach(() => {
+    originalRTCPeerConnection = (globalThis as unknown as { RTCPeerConnection?: unknown })
+      .RTCPeerConnection;
+    (globalThis as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection = StubPC;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      originalRTCPeerConnection;
+  });
+
+  function makeManager() {
+    const manager = new PCTransportManager('publisher-only', {});
+    const fake = new FakePublisher();
+    // swap in the fake publisher so we control the event surface and avoid
+    // exercising any real PeerConnection plumbing
+    (manager as unknown as { publisher: FakePublisher }).publisher = fake;
+    manager.peerConnectionTimeout = 200;
+    return { manager, pub: fake };
+  }
+
+  it('resolves when NegotiationComplete fires', async () => {
+    const { manager, pub } = makeManager();
+    const ac = new AbortController();
+    const p = manager.negotiate(ac);
+    setTimeout(() => pub.emit(PCEvents.NegotiationComplete), 10);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('rejects when the initial timeout elapses', async () => {
+    const { manager } = makeManager();
+    await expect(manager.negotiate(new AbortController())).rejects.toThrow(/timed out/);
+  });
+
+  it('rejects when the abort signal fires', async () => {
+    const { manager } = makeManager();
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(), 10);
+    await expect(manager.negotiate(ac)).rejects.toThrow(/aborted/);
+  });
+
+  it('rejects when publisher.negotiate invokes its error callback', async () => {
+    const { manager, pub } = makeManager();
+    pub.negotiate.mockImplementationOnce(async (onError?: (e: Error) => void) => {
+      onError?.(new Error('publisher boom'));
+    });
+    await expect(manager.negotiate(new AbortController())).rejects.toThrow(/publisher boom/);
+  });
+
+  it('removes all listeners after NegotiationComplete resolves the promise', async () => {
+    const { manager, pub } = makeManager();
+    const p = manager.negotiate(new AbortController());
+    pub.emit(PCEvents.NegotiationComplete);
+    await p;
+    expect(pub.listenerCount(PCEvents.NegotiationStarted)).toBe(0);
+    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
+  });
+
+  // BUG: the initial setTimeout at PCTransportManager.ts:232-234 rejects without
+  // calling cleanup(), so the NegotiationStarted handler, the abort handler,
+  // and the once(NegotiationComplete) handler all leak after the first timeout.
+  it('removes all listeners after the initial timeout rejects', async () => {
+    const { manager, pub } = makeManager();
+    await expect(manager.negotiate(new AbortController())).rejects.toThrow(/timed out/);
+    expect(pub.listenerCount(PCEvents.NegotiationStarted)).toBe(0);
+    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
+  });
+
+  // BUG: cleanup() at PCTransportManager.ts:236-240 never offs the
+  // once(NegotiationComplete) handler. After abort/cycle-reset timeout/
+  // publisher error, that listener accumulates over repeated negotiate() calls
+  // (matching the "11 negotiationComplete listeners added" warning seen in
+  // production sessions that hit this hang).
+  it('removes the NegotiationComplete listener after the cycle-reset timeout rejects', async () => {
+    const { manager, pub } = makeManager();
+    const p = manager.negotiate(new AbortController());
+    // switch onto the resettable timer path
+    pub.emit(PCEvents.NegotiationStarted);
+    await expect(p).rejects.toThrow(/timed out/);
+    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
+  });
+
+  it('removes the NegotiationComplete listener after abort rejects', async () => {
+    const { manager, pub } = makeManager();
+    const ac = new AbortController();
+    const p = manager.negotiate(ac);
+    setTimeout(() => ac.abort(), 10);
+    await expect(p).rejects.toThrow(/aborted/);
+    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
+  });
+
+  it('removes the NegotiationComplete listener after publisher.negotiate errors', async () => {
+    const { manager, pub } = makeManager();
+    pub.negotiate.mockImplementationOnce(async (onError?: (e: Error) => void) => {
+      onError?.(new Error('publisher boom'));
+    });
+    await expect(manager.negotiate(new AbortController())).rejects.toThrow(/publisher boom/);
+    expect(pub.listenerCount(PCEvents.NegotiationComplete)).toBe(0);
+  });
+
+  // ROOT-CAUSE TEST: reproduces the field hang reported on Windows 11 with a
+  // slow Camera Frame Server. Every NegotiationStarted resets the timer
+  // (PCTransportManager.ts:252-261, introduced in PR #1813). If something keeps
+  // emitting NegotiationStarted faster than peerConnectionTimeout — e.g.
+  // ensureDataTransportConnected calling publisher.negotiate() while ICE isn't
+  // up, or repeated server-driven MediaSectionsRequirement updates — the
+  // outer Promise neither resolves nor rejects. publishTrack's
+  // Promise.all([addTrackPromise, negotiate()]) is then wedged forever even
+  // though the underlying PC has already finished offer/answer. The fix is to
+  // bound the resettable cycle with a non-resettable max deadline.
+  it('does not hang when NegotiationStarted keeps resetting the timer', async () => {
+    const { manager, pub } = makeManager();
+    manager.peerConnectionTimeout = 100;
+    const ac = new AbortController();
+    const p = manager.negotiate(ac);
+    // swallow whichever way it eventually settles (or doesn't)
+    p.catch(() => {});
+
+    const interval = setInterval(() => pub.emit(PCEvents.NegotiationStarted), 30);
+
+    try {
+      const settled = await Promise.race([
+        p.then(
+          () => 'resolved' as const,
+          () => 'rejected' as const,
+        ),
+        new Promise<'hung'>((res) => setTimeout(() => res('hung'), 1500)),
+      ]);
+      expect(settled, 'negotiate() never settled — timer keeps resetting').not.toBe('hung');
+    } finally {
+      clearInterval(interval);
+      ac.abort();
+    }
+  });
+});

--- a/src/room/PCTransportManager.ts
+++ b/src/room/PCTransportManager.ts
@@ -242,6 +242,10 @@ export class PCTransportManager {
       // Race: an answer past our checkpoint already arrived before we had a
       // chance to subscribe.
       if (this.publisher.latestAcknowledgedOfferId > checkpoint) {
+        this.log.debug(
+          `negotiation already handled in more recent acknowledged offer`,
+          this.logContext,
+        );
         resolve();
         return;
       }

--- a/src/room/PCTransportManager.ts
+++ b/src/room/PCTransportManager.ts
@@ -228,46 +228,53 @@ export class PCTransportManager {
   }
 
   async negotiate(abortController: AbortController) {
-    return new TypedPromise<void, NegotiationError | Error>(async (resolve, reject) => {
-      let negotiationTimeout = setTimeout(() => {
-        reject(new NegotiationError('negotiation timed out'));
-      }, this.peerConnectionTimeout);
+    return new TypedPromise<void, NegotiationError | Error>((resolve, reject) => {
+      // Capture the publisher's latest offer id at request time. We are done
+      // when an offer with a higher id has had its answer successfully
+      // applied — that offer is the one that includes any transceiver/SDP
+      // changes that motivated this negotiate call. Concurrent callers each
+      // get their own checkpoint and resolve independently.
+      const checkpoint = this.publisher.latestOfferId;
 
+      // Race: an answer past our checkpoint already arrived before we had a
+      // chance to subscribe.
+      if (this.publisher.latestAcknowledgedOfferId > checkpoint) {
+        resolve();
+        return;
+      }
+
+      let cleanedUp = false;
       const cleanup = () => {
-        clearTimeout(negotiationTimeout);
-        this.publisher.off(PCEvents.NegotiationStarted, onNegotiationStarted);
-        abortController.signal.removeEventListener('abort', abortHandler);
+        if (cleanedUp) return;
+        cleanedUp = true;
+        clearTimeout(deadlineTimer);
+        this.publisher.off(PCEvents.OfferAnswered, onAnswered);
+        abortController.signal.removeEventListener('abort', onAbort);
       };
 
-      const abortHandler = () => {
+      const onAnswered = (offerId: number) => {
+        if (offerId > checkpoint) {
+          cleanup();
+          resolve();
+        }
+      };
+
+      const onAbort = () => {
         cleanup();
         reject(new NegotiationError('negotiation aborted'));
       };
 
-      // Reset the timeout each time a renegotiation cycle starts. This
-      // prevents premature timeouts when the negotiation machinery is
-      // actively renegotiating (offers going out, answers coming back) but
-      // NegotiationComplete hasn't fired yet because new requirements keep
-      // arriving between offer/answer round-trips.
-      const onNegotiationStarted = () => {
-        if (abortController.signal.aborted) {
-          return;
-        }
-        clearTimeout(negotiationTimeout);
-        negotiationTimeout = setTimeout(() => {
-          cleanup();
-          reject(new NegotiationError('negotiation timed out'));
-        }, this.peerConnectionTimeout);
-      };
-
-      abortController.signal.addEventListener('abort', abortHandler);
-      this.publisher.on(PCEvents.NegotiationStarted, onNegotiationStarted);
-      this.publisher.once(PCEvents.NegotiationComplete, () => {
+      // Single hard deadline as a backstop. Not reset on cycle progress —
+      // progress is tracked via OfferAnswered, not NegotiationStarted.
+      const deadlineTimer = setTimeout(() => {
         cleanup();
-        resolve();
-      });
+        reject(new NegotiationError('negotiation timed out'));
+      }, this.peerConnectionTimeout);
 
-      await this.publisher.negotiate((e) => {
+      abortController.signal.addEventListener('abort', onAbort);
+      this.publisher.on(PCEvents.OfferAnswered, onAnswered);
+
+      this.publisher.negotiate((e) => {
         cleanup();
         if (e instanceof Error) {
           reject(e);

--- a/src/room/PCTransportManager.ts
+++ b/src/room/PCTransportManager.ts
@@ -1,5 +1,6 @@
 import { Mutex } from '@livekit/mutex';
 import { SignalTarget } from '@livekit/protocol';
+import type { Throws } from '@livekit/throws-transformer/throws';
 import log, { LoggerNames, getLogger } from '../logger';
 import TypedPromise from '../utils/TypedPromise';
 import PCTransport, { PCEvents } from './PCTransport';
@@ -227,7 +228,9 @@ export class PCTransportManager {
     }
   }
 
-  async negotiate(abortController: AbortController) {
+  async negotiate(
+    abortController: AbortController,
+  ): Promise<Throws<void, NegotiationError | Error>> {
     return new TypedPromise<void, NegotiationError | Error>((resolve, reject) => {
       // Capture the publisher's latest offer id at request time. We are done
       // when an offer with a higher id has had its answer successfully


### PR DESCRIPTION
## Fix publisher negotiation hang under stacked offer cycles
Under specific conditions the Promise returned by `setCameraEnabled(true)` could neither resolve nor reject, even though the track was successfully published from the server's perspective. Sessions hitting this also showed MaxListenersExceededWarning for negotiationComplete/negotiationStarted on the publisher within seconds of connecting.

### Root cause
`PCTransportManager.negotiate()` resolved on the next NegotiationComplete event from the publisher. That event only fires when an answer is processed and `renegotiate === false`. If a new `publisher.negotiate() `lands while an offer is in flight, the next answer recurses into another offer instead of emitting NegotiationComplete (PCTransport.ts:239-243). With enough cycle starts (data-channel sends, server-driven MediaSectionsRequirement, concurrent track publishes) the cycle never converges, the resettable timeout from #1813 keeps firing, and the Promise wedges. cleanup() also never offed the `once(NegotiationComplete)` listener, which is why the warning surfaced.

### Change
Switch from an event-cycle-based wait to an offerId checkpoint:

- Capture `checkpoint = publisher.latestOfferId `at the moment `negotiate()` is called.
- Resolve when any offer with offerId > checkpoint has had its answer applied — that offer necessarily contains the changes that motivated the call.
- New `PCEvents.OfferAnswered` fires for every successful answer, including ones that recurse via renegotiate=true (which the existing NegotiationComplete deliberately suppresses).
- Single non-resettable deadline as a backstop. No NegotiationStarted reset path.
- Single listener type, idempotent `cleanup()` — no leaks across abort/timeout/error paths.
- Concurrent callers each get their own checkpoint and resolve independently when their changes are negotiated.
- NegotiationComplete and RTPVideoPayloadTypes are kept intact for existing consumers.

### Tests
PCTransportManager.test.ts covers:

- Resolution on offer past checkpoint, including via the renegotiate-recursion path.
- Non-resolution on answers at or before the checkpoint.
- Concurrent callers resolving independently.
- Race where an answer past the checkpoint already arrived at entry.
- Abort, deadline, and publisher.negotiate error paths.
- Listener cleanup across all paths plus a 12-iteration leak guard.
- Regression test for the field hang: spurious cycle noise + non-matching answers no longer wedge the promise.

### Risk
Behavior change is contained to the publisher negotiation handshake. `latestOfferId` is exposed publicly (was private) and latestAcknowledgedOfferId is added — both internal SDK fields. No public API surface changes.