### PR TITLE
Ensure that flush called when there are no in flight data track packets works

### DIFF
--- a/.changeset/cool-lands-smile.md
+++ b/.changeset/cool-lands-smile.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ensure that flush called when there are no in flight data track packets works

--- a/src/room/data-track/LocalDataTrack.ts
+++ b/src/room/data-track/LocalDataTrack.ts
@@ -4,7 +4,7 @@ import { type DataTrackFrame, DataTrackFrameInternal } from './frame';
 import type { DataTrackHandle } from './handle';
 import type OutgoingDataTrackManager from './outgoing/OutgoingDataTrackManager';
 import { DataTrackPushFrameError } from './outgoing/errors';
-import type { DataTrackOptions } from './outgoing/types';
+import type { DataTrackOptions, EventPacketsFlushedChange } from './outgoing/types';
 import {
   DataTrackSymbol,
   type IDataTrack,
@@ -32,6 +32,8 @@ export default class LocalDataTrack implements ILocalTrack, IDataTrack {
   /** Resolves once the data track has sent all pending packets the rtc data channel buffer. */
   protected flushedFuture = new Future<void, never>();
 
+  protected isFlushed = true;
+
   /** @internal */
   constructor(options: DataTrackOptions, manager: OutgoingDataTrackManager) {
     this.options = options;
@@ -39,7 +41,7 @@ export default class LocalDataTrack implements ILocalTrack, IDataTrack {
 
     this.log = getLogger(LoggerNames.DataTracks);
 
-    this.manager.on('packetsFlushed', this.handleManagerPacketsFlushed);
+    this.manager.on('packetsFlushedChange', this.handleManagerPacketsFlushedChange);
     this.manager.on('reset', this.handleManagerReset);
   }
 
@@ -47,15 +49,18 @@ export default class LocalDataTrack implements ILocalTrack, IDataTrack {
     // When the associated manager resets, mark any in flight flushes as complete
     // There's nothing actionable a user can do to get these to complete so no
     // error is being thrown.
-    this.handleManagerPacketsFlushed();
+    this.flushedFuture.resolve?.();
 
-    this.manager.off('packetsFlushed', this.handleManagerReset);
+    this.manager.off('packetsFlushedChange', this.handleManagerPacketsFlushedChange);
     this.manager.off('reset', this.handleManagerReset);
   };
 
-  private handleManagerPacketsFlushed = () => {
-    this.flushedFuture.resolve?.();
-    this.flushedFuture = new Future();
+  private handleManagerPacketsFlushedChange = (event: EventPacketsFlushedChange) => {
+    this.isFlushed = event.isFlushed;
+    if (event.isFlushed) {
+      this.flushedFuture.resolve?.();
+      this.flushedFuture = new Future();
+    }
   };
 
   /** @internal */
@@ -152,6 +157,9 @@ export default class LocalDataTrack implements ILocalTrack, IDataTrack {
    * ```
    **/
   async flush(): Promise<void> {
+    if (this.isFlushed) {
+      return;
+    }
     return this.flushedFuture.promise;
   }
 

--- a/src/room/data-track/outgoing/OutgoingDataTrackManager.test.ts
+++ b/src/room/data-track/outgoing/OutgoingDataTrackManager.test.ts
@@ -603,237 +603,389 @@ describe('DataTrackOutgoingManager', () => {
     await shutdownPromise;
   });
 
-  it('should resolve flush() after a single tryPush once the packet is acknowledged', async () => {
-    const pubHandle = 5;
-    const manager = OutgoingDataTrackManager.withDescriptors(
-      new Map([
-        [
-          DataTrackHandle.fromNumber(pubHandle),
-          Descriptor.active(
-            {
-              sid: 'bogus-sid',
-              pubHandle,
-              name: 'test',
-              usesE2ee: false,
-            },
-            null,
-          ),
-        ],
-      ]),
-    );
-    const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
-      'packetAvailable',
-      'packetsFlushed',
-    ]);
-    const localDataTrack = LocalDataTrack.withExplicitHandle(
-      { name: 'track name' },
-      manager,
-      pubHandle,
-    );
+  describe('localDataTrack.flush()', () => {
+    it('should resolve flush() after a single tryPush once the packet is acknowledged', async () => {
+      const pubHandle = 5;
+      const manager = OutgoingDataTrackManager.withDescriptors(
+        new Map([
+          [
+            DataTrackHandle.fromNumber(pubHandle),
+            Descriptor.active(
+              {
+                sid: 'bogus-sid',
+                pubHandle,
+                name: 'test',
+                usesE2ee: false,
+              },
+              null,
+            ),
+          ],
+        ]),
+      );
+      const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
+        'packetAvailable',
+        'packetsFlushedChange',
+      ]);
+      const localDataTrack = LocalDataTrack.withExplicitHandle(
+        { name: 'track name' },
+        manager,
+        pubHandle,
+      );
 
-    // 1. Push a single-packet payload
-    await localDataTrack.tryPush({ payload: new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]) });
+      // 1. Push a single-packet payload
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]) });
 
-    // 2. The packet should have been emitted to be sent over the data channel
-    const packetEvent = await managerEvents.waitFor('packetAvailable');
-    expect(packetEvent.handle).toStrictEqual(pubHandle);
+      // 2. The packet should have been emitted to be sent over the data channel
+      const packetEvent = await managerEvents.waitFor('packetAvailable');
+      expect(packetEvent.handle).toStrictEqual(pubHandle);
 
-    // 3. Calling flush() right after tryPush() should not resolve until the packet
-    // is acknowledged via handlePacketSendComplete
-    let flushed = false;
-    const flushPromise = localDataTrack.flush().then(() => {
-      flushed = true;
+      // 3. A event should be sent indicating that the data track is no longer "flushed"
+      const noLongerFlushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(noLongerFlushedEvent.handle).toStrictEqual(pubHandle);
+      expect(noLongerFlushedEvent.isFlushed).toStrictEqual(false);
+
+      // 3. Calling flush() right after tryPush() should not resolve until the packet
+      // is acknowledged via handlePacketSendComplete
+      let flushed = false;
+      const flushPromise = localDataTrack.flush().then(() => {
+        flushed = true;
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(flushed).toStrictEqual(false);
+      expect(managerEvents.areThereBufferedEvents('packetsFlushedChange')).toBe(false);
+
+      // 4. Acknowledge that the packet has been sent over the data channel
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+
+      // 5. The packetsFlushed event fires once the in-flight packet counter reaches 0
+      const flushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(flushedEvent.handle).toStrictEqual(pubHandle);
+      expect(flushedEvent.isFlushed).toStrictEqual(true);
+
+      // 6. The flush() promise resolves
+      await flushPromise;
+      expect(flushed).toStrictEqual(true);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(flushed).toStrictEqual(false);
-    expect(managerEvents.areThereBufferedEvents('packetsFlushed')).toBe(false);
+    it('should resolve flush() only after all packets in a multi-packet payload are acknowledged', async () => {
+      const pubHandle = 5;
+      const manager = OutgoingDataTrackManager.withDescriptors(
+        new Map([
+          [
+            DataTrackHandle.fromNumber(pubHandle),
+            Descriptor.active(
+              {
+                sid: 'bogus-sid',
+                pubHandle,
+                name: 'test',
+                usesE2ee: false,
+              },
+              null,
+            ),
+          ],
+        ]),
+      );
+      const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
+        'packetAvailable',
+        'packetsFlushedChange',
+      ]);
+      const localDataTrack = LocalDataTrack.withExplicitHandle(
+        { name: 'track name' },
+        manager,
+        pubHandle,
+      );
 
-    // 4. Acknowledge that the packet has been sent over the data channel
-    manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      // 1. Push a payload large enough to span multiple packets (24k > single packet mtu)
+      await localDataTrack.tryPush({ payload: new Uint8Array(24_000).fill(0xbe) });
 
-    // 5. The packetsFlushed event fires once the in-flight packet counter reaches 0
-    const flushedEvent = await managerEvents.waitFor('packetsFlushed');
-    expect(flushedEvent.handle).toStrictEqual(pubHandle);
+      // 2. A event should be sent indicating that the data track is no longer "flushed"
+      const noLongerFlushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(noLongerFlushedEvent.handle).toStrictEqual(pubHandle);
+      expect(noLongerFlushedEvent.isFlushed).toStrictEqual(false);
 
-    // 6. The flush() promise resolves
-    await flushPromise;
-    expect(flushed).toStrictEqual(true);
-  });
+      // 3. Two packetAvailable events should be emitted for this payload
+      await managerEvents.waitFor('packetAvailable');
+      await managerEvents.waitFor('packetAvailable');
 
-  it('should resolve flush() only after all packets in a multi-packet payload are acknowledged', async () => {
-    const pubHandle = 5;
-    const manager = OutgoingDataTrackManager.withDescriptors(
-      new Map([
-        [
-          DataTrackHandle.fromNumber(pubHandle),
-          Descriptor.active(
-            {
-              sid: 'bogus-sid',
-              pubHandle,
-              name: 'test',
-              usesE2ee: false,
-            },
-            null,
-          ),
-        ],
-      ]),
-    );
-    const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
-      'packetAvailable',
-      'packetsFlushed',
-    ]);
-    const localDataTrack = LocalDataTrack.withExplicitHandle(
-      { name: 'track name' },
-      manager,
-      pubHandle,
-    );
+      // 4. Call flush() before any of the packets have been acknowledged
+      let flushed = false;
+      const flushPromise = localDataTrack.flush().then(() => {
+        flushed = true;
+      });
 
-    // 1. Push a payload large enough to span multiple packets (24k > single packet mtu)
-    await localDataTrack.tryPush({ payload: new Uint8Array(24_000).fill(0xbe) });
+      // 5. Acknowledge the first packet -- flush should not resolve yet, in-flight counter still > 0
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(flushed).toStrictEqual(false);
+      expect(managerEvents.areThereBufferedEvents('packetsFlushedChange')).toBe(false);
 
-    // 2. Two packetAvailable events should be emitted for this payload
-    await managerEvents.waitFor('packetAvailable');
-    await managerEvents.waitFor('packetAvailable');
+      // 6. Acknowledge the second packet -- flush resolves once the counter reaches 0
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
 
-    // 3. Call flush() before any of the packets have been acknowledged
-    let flushed = false;
-    const flushPromise = localDataTrack.flush().then(() => {
-      flushed = true;
+      const flushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(flushedEvent.handle).toStrictEqual(pubHandle);
+      expect(flushedEvent.isFlushed).toStrictEqual(true);
+
+      await flushPromise;
+      expect(flushed).toStrictEqual(true);
     });
 
-    // 4. Acknowledge the first packet -- flush should not resolve yet, in-flight counter still > 0
-    manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(flushed).toStrictEqual(false);
-    expect(managerEvents.areThereBufferedEvents('packetsFlushed')).toBe(false);
+    it('should resolve any pending flush() calls when the manager is reset', async () => {
+      const pubHandle = 5;
+      const manager = OutgoingDataTrackManager.withDescriptors(
+        new Map([
+          [
+            DataTrackHandle.fromNumber(pubHandle),
+            Descriptor.active(
+              {
+                sid: 'bogus-sid',
+                pubHandle,
+                name: 'test',
+                usesE2ee: false,
+              },
+              null,
+            ),
+          ],
+        ]),
+      );
+      const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
+        'packetAvailable',
+        'packetsFlushedChange',
+        'reset',
+      ]);
+      const localDataTrack = LocalDataTrack.withExplicitHandle(
+        { name: 'track name' },
+        manager,
+        pubHandle,
+      );
 
-    // 5. Acknowledge the second packet -- flush resolves once the counter reaches 0
-    manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      // 1. Push a single-packet payload
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]) });
 
-    const flushedEvent = await managerEvents.waitFor('packetsFlushed');
-    expect(flushedEvent.handle).toStrictEqual(pubHandle);
+      // 2. A event should be sent indicating that the data track is no longer "flushed"
+      const noLongerFlushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(noLongerFlushedEvent.handle).toStrictEqual(pubHandle);
+      expect(noLongerFlushedEvent.isFlushed).toStrictEqual(false);
 
-    await flushPromise;
-    expect(flushed).toStrictEqual(true);
-  });
+      await managerEvents.waitFor('packetAvailable');
 
-  it('should resolve any pending flush() calls when the manager is reset', async () => {
-    const pubHandle = 5;
-    const manager = OutgoingDataTrackManager.withDescriptors(
-      new Map([
-        [
-          DataTrackHandle.fromNumber(pubHandle),
-          Descriptor.active(
-            {
-              sid: 'bogus-sid',
-              pubHandle,
-              name: 'test',
-              usesE2ee: false,
-            },
-            null,
-          ),
-        ],
-      ]),
-    );
-    const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
-      'packetAvailable',
-      'packetsFlushed',
-      'reset',
-    ]);
-    const localDataTrack = LocalDataTrack.withExplicitHandle(
-      { name: 'track name' },
-      manager,
-      pubHandle,
-    );
+      // 3. Call flush() before the in-flight packet is acknowledged -- it should remain
+      // pending because the in-flight counter is still > 0
+      let flushed = false;
+      const flushPromise = localDataTrack.flush().then(() => {
+        flushed = true;
+      });
 
-    // 1. Push a single-packet payload
-    await localDataTrack.tryPush({ payload: new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]) });
-    await managerEvents.waitFor('packetAvailable');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(flushed).toStrictEqual(false);
+      expect(managerEvents.areThereBufferedEvents('packetsFlushedChange')).toBe(false);
 
-    // 2. Call flush() before the in-flight packet is acknowledged -- it should remain
-    // pending because the in-flight counter is still > 0
-    let flushed = false;
-    const flushPromise = localDataTrack.flush().then(() => {
-      flushed = true;
+      // 4. Reset the manager. This simulates a RTCEngine disconnect and should resolve
+      // the pending flush() even though the packet was never acknowledged.
+      await manager.reset();
+      await managerEvents.waitFor('reset');
+
+      // 5. The flush() promise resolves
+      await flushPromise;
+      expect(flushed).toStrictEqual(true);
+
+      // 6. No packetsFlushed event was emitted -- reset short-circuits the flush directly
+      // on the LocalDataTrack rather than going through the in-flight counter.
+      expect(managerEvents.areThereBufferedEvents('packetsFlushedChange')).toBe(false);
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(flushed).toStrictEqual(false);
-    expect(managerEvents.areThereBufferedEvents('packetsFlushed')).toBe(false);
+    it('should resolve flush() at the end of a batch of tryPush calls after all packets are later acknowledged as "sent"', async () => {
+      const pubHandle = 5;
+      const manager = OutgoingDataTrackManager.withDescriptors(
+        new Map([
+          [
+            DataTrackHandle.fromNumber(pubHandle),
+            Descriptor.active(
+              {
+                sid: 'bogus-sid',
+                pubHandle,
+                name: 'test',
+                usesE2ee: false,
+              },
+              null,
+            ),
+          ],
+        ]),
+      );
+      const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
+        'packetAvailable',
+        'packetsFlushedChange',
+      ]);
+      const localDataTrack = LocalDataTrack.withExplicitHandle(
+        { name: 'track name' },
+        manager,
+        pubHandle,
+      );
 
-    // 3. Reset the manager. This simulates a RTCEngine disconnect and should resolve
-    // the pending flush() even though the packet was never acknowledged.
-    await manager.reset();
-    await managerEvents.waitFor('reset');
+      // 1. Run a batch of tryPush calls
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x01]) });
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x02]) });
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x03]) });
 
-    // 4. The flush() promise resolves
-    await flushPromise;
-    expect(flushed).toStrictEqual(true);
+      // 2. A event should have been sent indicating that the data track is no longer "flushed"
+      const noLongerFlushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(noLongerFlushedEvent.handle).toStrictEqual(pubHandle);
+      expect(noLongerFlushedEvent.isFlushed).toStrictEqual(false);
 
-    // 5. No packetsFlushed event was emitted -- reset short-circuits the flush directly
-    // on the LocalDataTrack rather than going through the in-flight counter.
-    expect(managerEvents.areThereBufferedEvents('packetsFlushed')).toBe(false);
-  });
+      // 3. Three packetAvailable events should be emitted, one per pushed frame
+      await managerEvents.waitFor('packetAvailable');
+      await managerEvents.waitFor('packetAvailable');
+      await managerEvents.waitFor('packetAvailable');
 
-  it('should resolve flush() at the end of a batch of tryPush calls once all packets are acknowledged', async () => {
-    const pubHandle = 5;
-    const manager = OutgoingDataTrackManager.withDescriptors(
-      new Map([
-        [
-          DataTrackHandle.fromNumber(pubHandle),
-          Descriptor.active(
-            {
-              sid: 'bogus-sid',
-              pubHandle,
-              name: 'test',
-              usesE2ee: false,
-            },
-            null,
-          ),
-        ],
-      ]),
-    );
-    const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
-      'packetAvailable',
-      'packetsFlushed',
-    ]);
-    const localDataTrack = LocalDataTrack.withExplicitHandle(
-      { name: 'track name' },
-      manager,
-      pubHandle,
-    );
+      // 4. After the batch is enqueued, call flush() to wait for the SFU to drain them
+      let flushed = false;
+      const flushPromise = localDataTrack.flush().then(() => {
+        flushed = true;
+      });
 
-    // 1. Run a batch of tryPush calls
-    await localDataTrack.tryPush({ payload: new Uint8Array([0x01]) });
-    await localDataTrack.tryPush({ payload: new Uint8Array([0x02]) });
-    await localDataTrack.tryPush({ payload: new Uint8Array([0x03]) });
+      // 5. Acknowledge two of the three packets -- flush should not resolve yet
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(flushed).toStrictEqual(false);
+      expect(managerEvents.areThereBufferedEvents('packetsFlushedChange')).toBe(false);
 
-    // 2. Three packetAvailable events should be emitted, one per pushed frame
-    await managerEvents.waitFor('packetAvailable');
-    await managerEvents.waitFor('packetAvailable');
-    await managerEvents.waitFor('packetAvailable');
+      // 6. Acknowledge the last packet -- flush resolves once the counter reaches 0
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
 
-    // 3. After the batch is enqueued, call flush() to wait for the SFU to drain them
-    let flushed = false;
-    const flushPromise = localDataTrack.flush().then(() => {
-      flushed = true;
+      const flushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(flushedEvent.handle).toStrictEqual(pubHandle);
+
+      await flushPromise;
+      expect(flushed).toStrictEqual(true);
     });
 
-    // 4. Acknowledge two of the three packets -- flush should not resolve yet
-    manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
-    manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(flushed).toStrictEqual(false);
-    expect(managerEvents.areThereBufferedEvents('packetsFlushed')).toBe(false);
+    it('should resolve flush() if there are no tryPush calls in flight', async () => {
+      const pubHandle = 5;
+      const manager = OutgoingDataTrackManager.withDescriptors(
+        new Map([
+          [
+            DataTrackHandle.fromNumber(pubHandle),
+            Descriptor.active(
+              {
+                sid: 'bogus-sid',
+                pubHandle,
+                name: 'test',
+                usesE2ee: false,
+              },
+              null,
+            ),
+          ],
+        ]),
+      );
+      const localDataTrack = LocalDataTrack.withExplicitHandle(
+        { name: 'track name' },
+        manager,
+        pubHandle,
+      );
 
-    // 5. Acknowledge the last packet -- flush resolves once the counter reaches 0
-    manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      // Call flush, make sure it resolves on its own
+      await localDataTrack.flush();
+    });
 
-    const flushedEvent = await managerEvents.waitFor('packetsFlushed');
-    expect(flushedEvent.handle).toStrictEqual(pubHandle);
+    it('should resolve flush() at the end of a batch of tryPush calls which have all fully sent their data', async () => {
+      const pubHandle = 5;
+      const manager = OutgoingDataTrackManager.withDescriptors(
+        new Map([
+          [
+            DataTrackHandle.fromNumber(pubHandle),
+            Descriptor.active(
+              {
+                sid: 'bogus-sid',
+                pubHandle,
+                name: 'test',
+                usesE2ee: false,
+              },
+              null,
+            ),
+          ],
+        ]),
+      );
+      const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
+        'packetAvailable',
+      ]);
+      const localDataTrack = LocalDataTrack.withExplicitHandle(
+        { name: 'track name' },
+        manager,
+        pubHandle,
+      );
 
-    await flushPromise;
-    expect(flushed).toStrictEqual(true);
+      // 1. Run a batch of tryPush calls
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x01]) });
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x02]) });
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x03]) });
+
+      // 2. Three packetAvailable events should be emitted, one per pushed frame
+      await managerEvents.waitFor('packetAvailable');
+      await managerEvents.waitFor('packetAvailable');
+      await managerEvents.waitFor('packetAvailable');
+
+      // 3. Acknowledge all three packets
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+
+      // 4. Call flush and ensure that it resolves immediately
+      await localDataTrack.flush();
+    });
+
+    it('should send packetsFlushedChange events in between tryPush / handlePacketSendComplete calls', async () => {
+      const pubHandle = 5;
+      const manager = OutgoingDataTrackManager.withDescriptors(
+        new Map([
+          [
+            DataTrackHandle.fromNumber(pubHandle),
+            Descriptor.active(
+              {
+                sid: 'bogus-sid',
+                pubHandle,
+                name: 'test',
+                usesE2ee: false,
+              },
+              null,
+            ),
+          ],
+        ]),
+      );
+      const managerEvents = subscribeToEvents<DataTrackOutgoingManagerCallbacks>(manager, [
+        'packetsFlushedChange',
+      ]);
+      const localDataTrack = LocalDataTrack.withExplicitHandle(
+        { name: 'track name' },
+        manager,
+        pubHandle,
+      );
+
+      // 1. Send a single packet frame
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x01]) });
+
+      // 2. Ensure the data track is no longer "flushed"
+      const noLongerFlushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(noLongerFlushedEvent.handle).toStrictEqual(pubHandle);
+      expect(noLongerFlushedEvent.isFlushed).toStrictEqual(false);
+
+      // 3. Send more single packet frames
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x02]) });
+      await localDataTrack.tryPush({ payload: new Uint8Array([0x03]) });
+
+      // 3. Acknowledge the first two packets
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+      expect(managerEvents.areThereBufferedEvents('packetsFlushedChange')).toBe(false);
+
+      // 4. Acknowledge the last packet
+      manager.handlePacketSendComplete(DataTrackHandle.fromNumber(pubHandle));
+
+      // 4. The data track should now be "flushed" again
+      const isFlushedEvent = await managerEvents.waitFor('packetsFlushedChange');
+      expect(isFlushedEvent.handle).toStrictEqual(pubHandle);
+      expect(isFlushedEvent.isFlushed).toStrictEqual(true);
+    });
   });
 });

--- a/src/room/data-track/outgoing/OutgoingDataTrackManager.ts
+++ b/src/room/data-track/outgoing/OutgoingDataTrackManager.ts
@@ -18,7 +18,7 @@ import DataTrackOutgoingPipeline from './pipeline';
 import {
   type DataTrackOptions,
   type EventPacketAvailable,
-  type EventPacketsFlushed,
+  type EventPacketsFlushedChange,
   type EventSfuPublishRequest,
   type EventSfuUnpublishRequest,
   type EventTrackPublished,
@@ -76,7 +76,7 @@ export type DataTrackOutgoingManagerCallbacks = {
   /** A {@link LocalDataTrack} has been unpublished */
   trackUnpublished: (event: EventTrackUnpublished) => void;
   /** A {@link LocalDataTrack} has had all of its in flight packets sent via the rtc data channel. */
-  packetsFlushed: (event: EventPacketsFlushed) => void;
+  packetsFlushedChange: (event: EventPacketsFlushedChange) => void;
   /** The manager has been reset and all state has been cleared in preparation for the next room
    * connection. */
   reset: () => void;
@@ -167,6 +167,12 @@ export default class OutgoingDataTrackManager extends (EventEmitter as new () =>
       for await (const packet of descriptor.pipeline.processFrame(frame)) {
         const prev = this.inFlightPacketCounter.get(handle) ?? 0;
         this.inFlightPacketCounter.set(handle, prev + 1);
+        if (prev === 0) {
+          // A new packet has been sent, so there are now packets in the rtc data channel buffer for
+          // this data track frame
+          this.emit('packetsFlushedChange', { handle, isFlushed: false });
+        }
+
         this.emit('packetAvailable', { handle, bytes: packet.toBinary() });
       }
     } catch (err) {
@@ -193,7 +199,7 @@ export default class OutgoingDataTrackManager extends (EventEmitter as new () =>
     this.inFlightPacketCounter.set(handle, counter);
 
     if (counter === 0) {
-      this.emit('packetsFlushed', { handle });
+      this.emit('packetsFlushedChange', { handle, isFlushed: true });
     }
   }
 

--- a/src/room/data-track/outgoing/types.ts
+++ b/src/room/data-track/outgoing/types.ts
@@ -47,4 +47,4 @@ export type EventTrackPublished = { track: LocalDataTrack };
 export type EventTrackUnpublished = { sid: DataTrackSid };
 
 /** A track has had all of its in flight packets sent via the rtc data channel. */
-export type EventPacketsFlushed = { handle: DataTrackHandle };
+export type EventPacketsFlushedChange = { handle: DataTrackHandle; isFlushed: boolean };


### PR DESCRIPTION
Previously, if flush was called on a freshly created `LocalDataTrack` or on a `LocalDataTrack` which had properly sent all of its packets, it would return a promise which if no more data were sent on the local data track, would never resolve.

Fixes this issue and also adds a few more tests around this and some other flush related edge cases.

Follow up to https://github.com/livekit/client-sdk-js/pull/1925