### PR TITLE
Fix demo icons

### DIFF
--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -967,19 +967,19 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
       micPub?.audioTrack?.attach(audioElm);
     }
     micElm.className = 'mic-on';
-    micElm.innerHTML = '<i class="fas fa-microphone"></i>';
+    micElm.innerHTML = '<i class="ph-fill ph-microphone"></i>';
   } else {
     micElm.className = 'mic-off';
-    micElm.innerHTML = '<i class="fas fa-microphone-slash"></i>';
+    micElm.innerHTML = '<i class="ph-fill ph-microphone-slash"></i>';
   }
 
   const e2eeElm = container.querySelector(`#e2ee-${identity}`)!;
   if (participant.isEncrypted) {
     e2eeElm.className = 'e2ee-on';
-    e2eeElm.innerHTML = '<i class="fas fa-lock"></i>';
+    e2eeElm.innerHTML = '<i class="ph-fill ph-lock-simple"></i>';
   } else {
     e2eeElm.className = 'e2ee-off';
-    e2eeElm.innerHTML = '<i class="fas fa-unlock"></i>';
+    e2eeElm.innerHTML = '';
   }
 
   switch (participant.connectionQuality) {
@@ -987,7 +987,7 @@ function renderParticipant(participant: Participant, remove: boolean = false) {
     case ConnectionQuality.Good:
     case ConnectionQuality.Poor:
       signalElm.className = `connection-${participant.connectionQuality}`;
-      signalElm.innerHTML = '<i class="fas fa-circle"></i>';
+      signalElm.innerHTML = '<i class="ph-fill ph-circle"></i>';
       break;
     default:
       signalElm.innerHTML = '';

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -11,6 +11,11 @@
       integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2"
       crossorigin="anonymous"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.1/src/fill/style.css"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>


### PR DESCRIPTION
We had removed font awesome icons last year but never updated usage to a different icon library for the demo. 

This PR switches icons to @rektdeckard's phosphor icons