### PR TITLE
Ensure that client protocol is set in the dual peer connection case

### DIFF
--- a/.changeset/floppy-radios-invent.md
+++ b/.changeset/floppy-radios-invent.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ensure that client protocol is set in the dual peer connection case

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -1157,6 +1157,7 @@ function createConnectionParams(
   params.set('sdk', isReactNative() ? 'reactnative' : 'js');
   params.set('version', info.version!);
   params.set('protocol', info.protocol!.toString());
+  params.set('client_protocol', info.clientProtocol!.toString());
   if (info.deviceModel) {
     params.set('device_model', info.deviceModel);
   }


### PR DESCRIPTION
When the `useV0Path` value is set right now in `SignalClient`, `createConnectionParams` is called to create connection parameters instead of `createJoinRequestConnectionParams`. `createJoinRequestConnectionParams` includes `clientProtocol` as part of the `ClientInfo` in the join request, but it was recently discovered that `createConnectionParams` does NOT include `client_protocol` - so what this means is that currently, for clients using dual peer connections, rpc v2 is not active. This pull request fixes this.