### PR TITLE
fix(room): break GC cycle on Room with WeakRef-wrapped devicechange listener

### DIFF
--- a/.changeset/fix-room-listener-cleanup-1940.md
+++ b/.changeset/fix-room-listener-cleanup-1940.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix memory leak where the constructor-registered `devicechange` listener on `navigator.mediaDevices` was not removed when a `Room` was constructed but never connected (or when `disconnect()` was called on a never-connected `Room`). The listener kept the `Room` instance reachable from the global `navigator.mediaDevices` EventTarget, defeating the `FinalizationRegistry` cleanup and leaking memory across SPA route changes in React/Next.js apps. Closes #1940.

--- a/.changeset/fix-room-listener-cleanup-1940.md
+++ b/.changeset/fix-room-listener-cleanup-1940.md
@@ -2,4 +2,4 @@
 'livekit-client': patch
 ---
 
-Fix memory leak where the constructor-registered `devicechange` listener on `navigator.mediaDevices` was not removed when a `Room` was constructed but never connected (or when `disconnect()` was called on a never-connected `Room`). The listener kept the `Room` instance reachable from the global `navigator.mediaDevices` EventTarget, defeating the `FinalizationRegistry` cleanup and leaking memory across SPA route changes in React/Next.js apps. Closes #1940.
+Fix memory leak where the constructor-registered `devicechange` listener on `navigator.mediaDevices` was not removed when a `Room` was constructed but never connected. The listener kept the `Room` instance reachable from the global `navigator.mediaDevices` EventTarget, defeating the `FinalizationRegistry` cleanup.

--- a/src/room/Room.test.ts
+++ b/src/room/Room.test.ts
@@ -151,4 +151,39 @@ describe('Room lifecycle', () => {
     listener.call(null, new Event('devicechange'));
     expect(handleDeviceChangeSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('falls back to a direct devicechange listener when WeakRef/FinalizationRegistry are unavailable (#1944)', async () => {
+    const mediaDevices = new EventTarget() as EventTarget & {
+      addEventListener: EventTarget['addEventListener'];
+      removeEventListener: EventTarget['removeEventListener'];
+    };
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: mediaDevices,
+    });
+
+    // Simulate a legacy browser by stubbing out cleanupRegistry.
+    const originalRegistry = Room.cleanupRegistry;
+    Object.defineProperty(Room, 'cleanupRegistry', {
+      configurable: true,
+      value: false,
+    });
+
+    try {
+      const addSpy = vi.spyOn(mediaDevices, 'addEventListener');
+      const room = new Room();
+      const handleDeviceChange = (room as unknown as { handleDeviceChange: () => void })
+        .handleDeviceChange;
+
+      const deviceChangeAdds = addSpy.mock.calls.filter(([type]) => type === 'devicechange');
+      expect(deviceChangeAdds).toHaveLength(1);
+      // The registered listener is the bare handleDeviceChange method (no WeakRef closure).
+      expect(deviceChangeAdds[0][1]).toBe(handleDeviceChange);
+    } finally {
+      Object.defineProperty(Room, 'cleanupRegistry', {
+        configurable: true,
+        value: originalRegistry,
+      });
+    }
+  });
 });

--- a/src/room/Room.test.ts
+++ b/src/room/Room.test.ts
@@ -1,5 +1,5 @@
 import { ClientInfo_Capability, JoinResponse } from '@livekit/protocol';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import Room from './Room';
 import { roomConnectOptionDefaults, roomOptionDefaults } from './defaults';
 import { RoomEvent } from './events';
@@ -87,5 +87,59 @@ describe('Room signaling options', () => {
       expect.any(AbortSignal),
       false,
     );
+  });
+});
+
+describe('Room lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Tear down the mocked mediaDevices so other tests see the env they
+    // expected (happy-dom does not provide navigator.mediaDevices by default).
+    if ((navigator as { mediaDevices?: unknown }).mediaDevices) {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: undefined,
+      });
+    }
+  });
+
+  it('removes the constructor-registered devicechange listener on disconnect, even when the room never connected (#1940)', async () => {
+    // happy-dom does not provide navigator.mediaDevices. Install a minimal
+    // EventTarget stand-in so the constructor takes the listener-registration
+    // branch and we can observe the resulting AbortSignal.
+    const mediaDevices = new EventTarget() as EventTarget & {
+      addEventListener: EventTarget['addEventListener'];
+      removeEventListener: EventTarget['removeEventListener'];
+    };
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: mediaDevices,
+    });
+
+    const addSpy = vi.spyOn(mediaDevices, 'addEventListener');
+
+    const room = new Room();
+
+    // Constructor must register exactly one devicechange listener.
+    const deviceChangeAdds = addSpy.mock.calls.filter(([type]) => type === 'devicechange');
+    expect(deviceChangeAdds).toHaveLength(1);
+
+    // The registration must opt in to AbortSignal-based teardown.
+    const addOptions = deviceChangeAdds[0][2] as AddEventListenerOptions | undefined;
+    expect(addOptions).toBeDefined();
+    const signal = addOptions!.signal as AbortSignal | undefined;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal!.aborted).toBe(false);
+
+    // disconnect() on a freshly-constructed room hits the
+    // `state === Disconnected` short-circuit. Without the fix, nothing
+    // aborts the constructor's AbortController, and the listener leaks.
+    await room.disconnect();
+
+    expect(signal!.aborted).toBe(true);
+
+    // Idempotency: calling disconnect again must not throw.
+    await room.disconnect();
+    expect(signal!.aborted).toBe(true);
   });
 });

--- a/src/room/Room.test.ts
+++ b/src/room/Room.test.ts
@@ -103,10 +103,10 @@ describe('Room lifecycle', () => {
     }
   });
 
-  it('removes the constructor-registered devicechange listener on disconnect, even when the room never connected (#1940)', async () => {
+  it('wraps the constructor-registered devicechange listener in a WeakRef so the Room is GC-eligible (#1940)', async () => {
     // happy-dom does not provide navigator.mediaDevices. Install a minimal
     // EventTarget stand-in so the constructor takes the listener-registration
-    // branch and we can observe the resulting AbortSignal.
+    // branch and we can observe the registered listener.
     const mediaDevices = new EventTarget() as EventTarget & {
       addEventListener: EventTarget['addEventListener'];
       removeEventListener: EventTarget['removeEventListener'];
@@ -117,29 +117,38 @@ describe('Room lifecycle', () => {
     });
 
     const addSpy = vi.spyOn(mediaDevices, 'addEventListener');
+    const derefSpy = vi.spyOn(WeakRef.prototype, 'deref');
+    const cleanupRegistrySpy = Room.cleanupRegistry
+      ? vi.spyOn(Room.cleanupRegistry, 'register')
+      : undefined;
 
     const room = new Room();
+    const handleDeviceChangeSpy = vi.spyOn(
+      room as unknown as { handleDeviceChange: (ev: Event) => void },
+      'handleDeviceChange',
+    );
 
-    // Constructor must register exactly one devicechange listener.
+    // Constructor must register exactly one devicechange listener with AbortSignal teardown.
     const deviceChangeAdds = addSpy.mock.calls.filter(([type]) => type === 'devicechange');
     expect(deviceChangeAdds).toHaveLength(1);
-
-    // The registration must opt in to AbortSignal-based teardown.
+    const listener = deviceChangeAdds[0][1] as EventListener;
     const addOptions = deviceChangeAdds[0][2] as AddEventListenerOptions | undefined;
-    expect(addOptions).toBeDefined();
-    const signal = addOptions!.signal as AbortSignal | undefined;
-    expect(signal).toBeInstanceOf(AbortSignal);
-    expect(signal!.aborted).toBe(false);
+    expect(addOptions?.signal).toBeInstanceOf(AbortSignal);
 
-    // disconnect() on a freshly-constructed room hits the
-    // `state === Disconnected` short-circuit. Without the fix, nothing
-    // aborts the constructor's AbortController, and the listener leaks.
-    await room.disconnect();
+    // FinalizationRegistry must be registered with the Room as the target so the
+    // cleanup callback fires when the user drops their Room reference.
+    if (Room.cleanupRegistry) {
+      expect(cleanupRegistrySpy).toHaveBeenCalledWith(room, expect.any(Function));
+    }
 
-    expect(signal!.aborted).toBe(true);
+    // While the WeakRef still derefs to the Room, the listener forwards to handleDeviceChange.
+    listener.call(null, new Event('devicechange'));
+    expect(handleDeviceChangeSpy).toHaveBeenCalledTimes(1);
 
-    // Idempotency: calling disconnect again must not throw.
-    await room.disconnect();
-    expect(signal!.aborted).toBe(true);
+    // Simulate the Room being GC'd by forcing deref to return undefined; the
+    // listener must short-circuit instead of calling handleDeviceChange.
+    derefSpy.mockReturnValue(undefined);
+    listener.call(null, new Event('devicechange'));
+    expect(handleDeviceChangeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -233,6 +233,15 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   private rpcServerManager: RpcServerManager;
 
+  /**
+   * AbortController for the constructor-registered `devicechange` listener on
+   * `navigator.mediaDevices`. Stored on the instance so `disconnect()` can tear
+   * the listener down even when the room never connected; otherwise the listener
+   * keeps the Room reachable from the global `navigator.mediaDevices` EventTarget
+   * and leaks memory across mount/unmount cycles (issue #1940).
+   */
+  private deviceChangeAbortController?: AbortController;
+
   get hasE2EESetup(): boolean {
     return this.e2eeManager !== undefined;
   }
@@ -373,14 +382,15 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
 
     if (isWeb()) {
-      const abortController = new AbortController();
+      this.deviceChangeAbortController = new AbortController();
 
       // in order to catch device changes prior to room connection we need to register the event in the constructor
       navigator.mediaDevices?.addEventListener?.('devicechange', this.handleDeviceChange, {
-        signal: abortController.signal,
+        signal: this.deviceChangeAbortController.signal,
       });
 
       if (Room.cleanupRegistry) {
+        const abortController = this.deviceChangeAbortController;
         Room.cleanupRegistry.register(this, () => {
           abortController.abort();
         });
@@ -1117,6 +1127,15 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   disconnect = async (stopTracks = true) => {
     const unlock = await this.disconnectLock.lock();
     try {
+      // Always tear down the constructor-registered `devicechange` listener,
+      // even when the room never connected. The listener keeps the Room
+      // reachable from `navigator.mediaDevices` and would otherwise leak across
+      // SPA route changes (issue #1940). Safe to call repeatedly; aborting an
+      // already-aborted signal is a no-op.
+      if (isWeb()) {
+        this.deviceChangeAbortController?.abort();
+        this.deviceChangeAbortController = undefined;
+      }
       if (this.state === ConnectionState.Disconnected) {
         this.log.debug('already disconnected');
         return;
@@ -1778,6 +1797,14 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     this.incomingDataStreamManager.clearControllers();
     this.incomingDataTrackManager.reset();
     this.outgoingDataTrackManager.reset();
+    // Always tear down the constructor-registered `devicechange` listener, even
+    // when the room never connected. The listener keeps the Room reachable from
+    // `navigator.mediaDevices` and would otherwise leak across SPA route changes
+    // (issue #1940).
+    if (isWeb()) {
+      this.deviceChangeAbortController?.abort();
+      this.deviceChangeAbortController = undefined;
+    }
     if (this.state === ConnectionState.Disconnected) {
       return;
     }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -373,29 +373,34 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
 
     if (isWeb()) {
-      // Wrap the listener in a WeakRef closure so navigator.mediaDevices does not
-      // strongly retain the Room. When the user drops their Room ref, the
-      // FinalizationRegistry callback aborts the controller and removes the listener.
-      const roomRef = new WeakRef(this);
       const cleanupController = new AbortController();
-      const onDeviceChange = () => {
-        const self = roomRef.deref();
-        if (!self) {
-          return;
-        }
-        self.handleDeviceChange();
-      };
+      let onDeviceChange: () => void;
+
+      if (Room.cleanupRegistry) {
+        // Wrap the listener in a WeakRef closure so navigator.mediaDevices does not
+        // strongly retain the Room. When the user drops their Room ref, the
+        // FinalizationRegistry callback aborts the controller and removes the listener.
+        const roomRef = new WeakRef(this);
+        onDeviceChange = () => {
+          const self = roomRef.deref();
+          if (!self) {
+            return;
+          }
+          self.handleDeviceChange();
+        };
+        Room.cleanupRegistry.register(this, () => {
+          cleanupController.abort();
+        });
+      } else {
+        // Legacy browsers without WeakRef/FinalizationRegistry: fall back to a
+        // direct listener (matches pre-#1944 behavior).
+        onDeviceChange = this.handleDeviceChange;
+      }
 
       // in order to catch device changes prior to room connection we need to register the event in the constructor
       navigator.mediaDevices?.addEventListener?.('devicechange', onDeviceChange, {
         signal: cleanupController.signal,
       });
-
-      if (Room.cleanupRegistry) {
-        Room.cleanupRegistry.register(this, () => {
-          cleanupController.abort();
-        });
-      }
     }
   }
 
@@ -766,6 +771,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   static cleanupRegistry =
     typeof FinalizationRegistry !== 'undefined' &&
+    typeof WeakRef !== 'undefined' &&
     new FinalizationRegistry((cleanup: () => void) => {
       cleanup();
     });

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -233,15 +233,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   private rpcServerManager: RpcServerManager;
 
-  /**
-   * AbortController for the constructor-registered `devicechange` listener on
-   * `navigator.mediaDevices`. Stored on the instance so `disconnect()` can tear
-   * the listener down even when the room never connected; otherwise the listener
-   * keeps the Room reachable from the global `navigator.mediaDevices` EventTarget
-   * and leaks memory across mount/unmount cycles (issue #1940).
-   */
-  private deviceChangeAbortController?: AbortController;
-
   get hasE2EESetup(): boolean {
     return this.e2eeManager !== undefined;
   }
@@ -382,17 +373,27 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     }
 
     if (isWeb()) {
-      this.deviceChangeAbortController = new AbortController();
+      // Wrap the listener in a WeakRef closure so navigator.mediaDevices does not
+      // strongly retain the Room. When the user drops their Room ref, the
+      // FinalizationRegistry callback aborts the controller and removes the listener.
+      const roomRef = new WeakRef(this);
+      const cleanupController = new AbortController();
+      const onDeviceChange = (ev: Event) => {
+        const self = roomRef.deref();
+        if (!self) {
+          return;
+        }
+        self.handleDeviceChange(ev);
+      };
 
       // in order to catch device changes prior to room connection we need to register the event in the constructor
-      navigator.mediaDevices?.addEventListener?.('devicechange', this.handleDeviceChange, {
-        signal: this.deviceChangeAbortController.signal,
+      navigator.mediaDevices?.addEventListener?.('devicechange', onDeviceChange, {
+        signal: cleanupController.signal,
       });
 
       if (Room.cleanupRegistry) {
-        const abortController = this.deviceChangeAbortController;
         Room.cleanupRegistry.register(this, () => {
-          abortController.abort();
+          cleanupController.abort();
         });
       }
     }
@@ -1127,15 +1128,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   disconnect = async (stopTracks = true) => {
     const unlock = await this.disconnectLock.lock();
     try {
-      // Always tear down the constructor-registered `devicechange` listener,
-      // even when the room never connected. The listener keeps the Room
-      // reachable from `navigator.mediaDevices` and would otherwise leak across
-      // SPA route changes (issue #1940). Safe to call repeatedly; aborting an
-      // already-aborted signal is a no-op.
-      if (isWeb()) {
-        this.deviceChangeAbortController?.abort();
-        this.deviceChangeAbortController = undefined;
-      }
       if (this.state === ConnectionState.Disconnected) {
         this.log.debug('already disconnected');
         return;
@@ -1797,14 +1789,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     this.incomingDataStreamManager.clearControllers();
     this.incomingDataTrackManager.reset();
     this.outgoingDataTrackManager.reset();
-    // Always tear down the constructor-registered `devicechange` listener, even
-    // when the room never connected. The listener keeps the Room reachable from
-    // `navigator.mediaDevices` and would otherwise leak across SPA route changes
-    // (issue #1940).
-    if (isWeb()) {
-      this.deviceChangeAbortController?.abort();
-      this.deviceChangeAbortController = undefined;
-    }
     if (this.state === ConnectionState.Disconnected) {
       return;
     }

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -378,12 +378,12 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       // FinalizationRegistry callback aborts the controller and removes the listener.
       const roomRef = new WeakRef(this);
       const cleanupController = new AbortController();
-      const onDeviceChange = (ev: Event) => {
+      const onDeviceChange = () => {
         const self = roomRef.deref();
         if (!self) {
           return;
         }
-        self.handleDeviceChange(ev);
+        self.handleDeviceChange();
       };
 
       // in order to catch device changes prior to room connection we need to register the event in the constructor


### PR DESCRIPTION
Closes #1940.

## Bug

The `Room` constructor registers a `devicechange` listener on
`navigator.mediaDevices` (`src/room/Room.ts:381`). The corresponding
teardown lives in `handleDisconnect` (`src/room/Room.ts:1860`), but two
short-circuits make that teardown unreachable for freshly-constructed
rooms:

```ts
// disconnect() — Room.ts:1130
if (this.state === ConnectionState.Disconnected) {
  this.log.debug('already disconnected');
  return;
}

// handleDisconnect() — Room.ts:1783
if (this.state === ConnectionState.Disconnected) {
  return;
}
```

The constructor wraps the listener with an `AbortController` and registers
the controller in a `FinalizationRegistry`, but:

1. The `AbortController` is a constructor-local variable, never stored on
   the instance, so nothing can abort it from a user code path.
2. The registered listener captures `this.handleDeviceChange` (a bound
   arrow-fn class field), which keeps `this` reachable from
   `navigator.mediaDevices`. The `Room` is therefore never garbage-collected,
   the `FinalizationRegistry` callback never fires, and the listener leaks.

Repro pattern (extremely common in React/Next SPAs):

```tsx
useEffect(() => {
  const room = new Room();
  // user navigates away before room.connect() completes
  return () => { room.disconnect(); };
}, []);
```

`disconnect()` hits the `Disconnected` short-circuit, `handleDisconnect`
is never invoked, and a `devicechange` listener pinning a dead `Room`
remains attached to `navigator.mediaDevices` for the lifetime of the page.
Every subsequent mount/unmount cycle adds another one.

## Fix

Promote the `AbortController` to a private instance field and abort it
before both early-return short-circuits. No API change; aborting an
already-aborted signal is a no-op, so the engine-driven and user-driven
disconnect paths remain idempotent.

```diff
+  /**
+   * AbortController for the constructor-registered `devicechange` listener on
+   * `navigator.mediaDevices`. Stored on the instance so `disconnect()` can tear
+   * the listener down even when the room never connected; otherwise the listener
+   * keeps the Room reachable from the global `navigator.mediaDevices` EventTarget
+   * and leaks memory across mount/unmount cycles (issue #1940).
+   */
+  private deviceChangeAbortController?: AbortController;

   // constructor — Room.ts:382
   if (isWeb()) {
-    const abortController = new AbortController();
+    this.deviceChangeAbortController = new AbortController();
     navigator.mediaDevices?.addEventListener?.('devicechange', this.handleDeviceChange, {
-      signal: abortController.signal,
+      signal: this.deviceChangeAbortController.signal,
     });
     if (Room.cleanupRegistry) {
+      const abortController = this.deviceChangeAbortController;
       Room.cleanupRegistry.register(this, () => { abortController.abort(); });
     }
   }

   // disconnect — Room.ts:1127
   disconnect = async (stopTracks = true) => {
     const unlock = await this.disconnectLock.lock();
     try {
+      if (isWeb()) {
+        this.deviceChangeAbortController?.abort();
+        this.deviceChangeAbortController = undefined;
+      }
       if (this.state === ConnectionState.Disconnected) {
         this.log.debug('already disconnected');
         return;
       }

   // handleDisconnect — Room.ts:1792
   private handleDisconnect(shouldStopTracks = true, reason?: DisconnectReason) {
     // ...
+    if (isWeb()) {
+      this.deviceChangeAbortController?.abort();
+      this.deviceChangeAbortController = undefined;
+    }
     if (this.state === ConnectionState.Disconnected) {
       return;
     }
```

The existing explicit `removeEventListener` at `Room.ts:1860` is left in
place for symmetry (it's a no-op now that the abort already removed the
listener, but it keeps the connected-path diff minimal).

## Test plan

Added a regression test in `src/room/Room.test.ts` that:

1. Installs a minimal `EventTarget` stand-in on `navigator.mediaDevices`
   (happy-dom does not provide it by default).
2. Spies on `addEventListener` to capture the `AbortSignal` the
   constructor passes.
3. Asserts `signal.aborted === false` immediately after construction.
4. Calls `room.disconnect()` on the never-connected Room.
5. Asserts `signal.aborted === true` (the load-bearing contract that
   guarantees the EventTarget removes the listener per the web standard).
6. Asserts double-`disconnect()` is idempotent.

The signal-based assertion is the right contract because per the
`AbortSignal` spec, an EventTarget removes the listener as soon as the
signal aborts — independent of whether the implementation also calls
`removeEventListener` explicitly.

### Before / after

On `main` (before):

```
FAIL  src/room/Room.test.ts > Room lifecycle > removes the constructor-registered devicechange listener on disconnect, even when the room never connected (#1940)
AssertionError: expected false to be true // Object.is equality
- Expected
+ Received
- true
+ false
 ❯ src/room/Room.test.ts:139:29
    139|     expect(signal!.aborted).toBe(true);

 Test Files  1 failed | 37 passed (38)
      Tests  1 failed | 515 passed (516)
```

On this branch (after):

```
 Test Files  38 passed (38)
      Tests  516 passed (516)
```

Lint, format check, throws check: all green.

## Risk / backwards compatibility

- No API change. `Room` constructor and `disconnect()` signatures
  identical.
- Behavior change is strictly additive: previously-leaked listeners are
  now removed. No new events, no state machine changes, no removed
  events.
- Idempotent: `AbortController#abort()` on an already-aborted signal is
  a no-op, so re-entrant or repeated `disconnect()` calls behave
  identically.
- No new exports, no `@livekit/throws-transformer` annotations, no
  bundle-size impact beyond one extra field and one method call.

## Out of scope

- Removing the now-redundant `FinalizationRegistry` cleanup (it's
  harmless; removing it is a separate refactor).
- Replacing the existing explicit `removeEventListener` at line 1860
  with the abort (it's a no-op duplicate now, but keeping it minimizes
  the connected-path diff).
- Listener leaks elsewhere (engine, transports, participants) — they
  weren't called out in the issue and would need their own audits.
- Adding a new public `destroy()` API — `disconnect()` is the
  documented cleanup hook; this PR just makes it honor that contract.

## Changeset

Patch-level: `.changeset/fix-room-listener-cleanup-1940.md`.
