### PR TITLE
fix(room): restore Firefox compatibility regressed in 2.18.1

### DIFF
--- a/.changeset/firefox-prejoin-publisher-offer-regression-1919.md
+++ b/.changeset/firefox-prejoin-publisher-offer-regression-1919.md
@@ -1,0 +1,8 @@
+---
+'livekit-client': patch
+---
+
+Restore Firefox compatibility regressed in 2.18.1 by skipping the prejoin
+publisher offer optimization (#1846) on Firefox, where the deferred
+setLocalDescription left publisher data channels stuck in `'connecting'`.
+Fixes #1919.

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -90,10 +90,10 @@ import { getTrackPublicationInfo } from './track/utils';
 import type { LoggerOptions } from './types';
 import {
   Future,
-  isCompressionStreamSupported,
   isVideoCodec,
   isVideoTrack,
   isWeb,
+  shouldUsePrejoinPublisherOffer,
   sleep,
   supportsAddTrack,
   supportsTransceiver,
@@ -324,8 +324,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.joinAttempts += 1;
 
       this.setupSignalClientCallbacks();
+      // #1919: Firefox can't open data channels when the initial offer's
+      // setLocalDescription is deferred until the join answer arrives, so
+      // skip the prejoin-offer fast path there.
+      const usePrejoinOffer = shouldUsePrejoinPublisherOffer(useV0Path);
       let offerProto: SessionDescription | undefined;
-      if (!useV0Path && isCompressionStreamSupported()) {
+      if (usePrejoinOffer) {
         if (!this.pcManager) {
           await this.configure();
           this.createDataChannels();
@@ -358,7 +362,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.participantSid = joinResponse.participant?.sid;
 
       this.subscriberPrimary = joinResponse.subscriberPrimary;
-      if (!useV0Path && isCompressionStreamSupported()) {
+      if (usePrejoinOffer) {
         this.pcManager?.updateConfiguration(this.makeRTCConfiguration(joinResponse));
       } else {
         if (!this.pcManager) {

--- a/src/room/utils.test.ts
+++ b/src/room/utils.test.ts
@@ -1,6 +1,12 @@
 import { ClientInfo_Capability } from '@livekit/protocol';
-import { describe, expect, it } from 'vitest';
-import { extractMaxAgeFromRequestHeaders, getClientInfo, splitUtf8, toWebsocketUrl } from './utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  extractMaxAgeFromRequestHeaders,
+  getClientInfo,
+  shouldUsePrejoinPublisherOffer,
+  splitUtf8,
+  toWebsocketUrl,
+} from './utils';
 
 describe('toWebsocketUrl', () => {
   it('leaves wss urls alone', () => {
@@ -186,5 +192,100 @@ describe('extractMaxAgeFromRequestHeaders', () => {
     const headers = new Headers();
     headers.set('Cache-Control', 'custom-max-age=7200,max-age=3600');
     expect(extractMaxAgeFromRequestHeaders(headers)).toBe(3600);
+  });
+});
+
+// Regression coverage for #1919: Firefox cannot connect after upgrading from
+// 2.18.0 to 2.18.1 because the publisher data channel never opens when the
+// initial offer is created before setLocalDescription. The fast-publisher-offer
+// path must therefore be skipped on Firefox.
+describe('shouldUsePrejoinPublisherOffer', () => {
+  const originalUserAgent = navigator.userAgent;
+  const originalCompressionStream = (globalThis as unknown as { CompressionStream?: unknown })
+    .CompressionStream;
+
+  function setUserAgent(ua: string) {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      configurable: true,
+      value: ua,
+    });
+  }
+
+  function setCompressionStreamSupported(supported: boolean) {
+    if (supported) {
+      Object.defineProperty(globalThis, 'CompressionStream', {
+        configurable: true,
+        value: class CompressionStreamStub {},
+        writable: true,
+      });
+    } else {
+      // Removing the global is the most faithful way to model older browsers.
+      delete (globalThis as unknown as { CompressionStream?: unknown }).CompressionStream;
+    }
+  }
+
+  beforeEach(() => {
+    // happy-dom ships CompressionStream by default; pin known state per test.
+    setCompressionStreamSupported(true);
+  });
+
+  afterEach(() => {
+    setUserAgent(originalUserAgent);
+    if (typeof originalCompressionStream === 'undefined') {
+      delete (globalThis as unknown as { CompressionStream?: unknown }).CompressionStream;
+    } else {
+      Object.defineProperty(globalThis, 'CompressionStream', {
+        configurable: true,
+        value: originalCompressionStream,
+        writable: true,
+      });
+    }
+  });
+
+  it('is false on Firefox even when CompressionStream is supported (#1919)', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0');
+    expect(shouldUsePrejoinPublisherOffer(false)).toBe(false);
+  });
+
+  it('is true on Chrome when CompressionStream is supported', () => {
+    setUserAgent(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    );
+    expect(shouldUsePrejoinPublisherOffer(false)).toBe(true);
+  });
+
+  it('is true on Safari (desktop) when CompressionStream is supported', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    );
+    expect(shouldUsePrejoinPublisherOffer(false)).toBe(true);
+  });
+
+  it('is false on any browser when CompressionStream is not supported', () => {
+    setUserAgent(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    );
+    setCompressionStreamSupported(false);
+    expect(shouldUsePrejoinPublisherOffer(false)).toBe(false);
+  });
+
+  it('is false when useV0Path is true (legacy dual peer connection path)', () => {
+    setUserAgent(
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    );
+    expect(shouldUsePrejoinPublisherOffer(true)).toBe(false);
+  });
+
+  it('is false when useV0Path is true on Firefox too', () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0');
+    expect(shouldUsePrejoinPublisherOffer(true)).toBe(false);
+  });
+
+  it('is true on Firefox-on-iOS (FxiOS) only if CompressionStream is present — FxiOS uses WebKit, not Gecko, so the Firefox SCTP timing quirk does not apply, and the browser parser reports name=Firefox os=iOS. We intentionally keep this conservative and still bypass for any Firefox UA.', () => {
+    setUserAgent(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/120.0 Mobile/15E148 Safari/605.1.15',
+    );
+    // FxiOS still gets detected as Firefox by the parser; we keep it conservative.
+    expect(shouldUsePrejoinPublisherOffer(false)).toBe(false);
   });
 });

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -794,3 +794,19 @@ export function extractMaxAgeFromRequestHeaders(headers: Headers): number | unde
 export function isCompressionStreamSupported() {
   return typeof CompressionStream !== 'undefined';
 }
+
+/**
+ * Whether the "send publisher offer with join request" optimization (PR #1846)
+ * should be used. Firefox is excluded because deferring setLocalDescription
+ * until the answer arrives leaves Firefox's publisher SCTP transport in a
+ * state where data channels never reach `'open'` (see #1919).
+ */
+export function shouldUsePrejoinPublisherOffer(useV0Path: boolean): boolean {
+  if (useV0Path) {
+    return false;
+  }
+  if (!isCompressionStreamSupported()) {
+    return false;
+  }
+  return !isFireFox();
+}


### PR DESCRIPTION
Closes #1919.

## Summary

Firefox can't connect after upgrading `livekit-client` from 2.18.0 to 2.18.1 (also reproduced on 2.18.6 and 2.19.0). The publisher data channel never opens, `ensureDataTransportConnected` eventually times out with `ConnectionError: could not establish Publisher connection, state: connected`, and the room disconnects.

This PR guards the "send publisher offer with join request" optimization (PR #1846) behind a Firefox check so Firefox falls back to the legacy v2.17.x negotiate-after-join flow. Chromium / Safari keep the optimization.

## Bisect

`git log v2.18.0..v2.18.1 --oneline`:

```
120e3328 Version Packages (#1848)
c872e328 Data track integration (#1820)
c70276bf Emit TrackSubscribed event only when room is connected (#1860)
5470632e Fix e2ee configuration error (#1857)
89d012da Send publisher offer with join request to accelerate connection (#1846)   <-- regressor
3e7f5dc5 Pin workflows and add minimum release age (#1854)
e51cf4c4 chore(deps): update dependency happy-dom to v20.8.9 [security] (#1853)
79f0c169 Enable E2EE key-size configuration via ExternalE2EEKeyProvider options (#1841)
```

`89d012da` (PR #1846) is the regressor.

## Root cause

`RTCEngine.join` previously created the publisher PC and negotiated *after* the JoinResponse arrived. PR #1846 added a fast path that, when `isCompressionStreamSupported()` is true (every modern browser, including Firefox 113+), creates the publisher PC, pre-allocates 3 audio + 3 video transceivers and three data channels, then calls `publisher.createInitialOffer()` *before* the JoinRequest is sent. The offer is stashed in `pendingInitialOffer` and `setLocalDescription` is **not** called until the server's answer arrives over the signal channel.

```
src/room/PCTransport.ts:286
  async createInitialOffer() {
    ...
    const offer = await this.pc.createOffer();
    this.pendingInitialOffer = { sdp: offer.sdp, type: offer.type }; // not applied yet
    ...
  }
```

Chromium tolerates this delay. Firefox does not: once `createDataChannel` runs and `createOffer` returns without a subsequent `setLocalDescription`, Firefox's publisher SCTP transport gets stuck. ICE and DTLS both reach `connected`, but `lossyDC` / `reliableDC` / `dataTrackDC` stay `'connecting'` forever.

Reporter's debug log (`client2.txt` on the issue) confirms it on Firefox 147 with `singlePeerConnection: true`:

```
pc state change: from NEW to CONNECTING
original offer { sdp: "v=0\r\no=mozilla...THIS_IS_SDPARTA-99.0 ..." }
setting munged local description
pc state change: from CONNECTING to CONNECTED
received server answer { sdp: "...m=application 9 UDP/DTLS/SCTP webrtc-datachannel...a=mid:6..." }
setting munged remote description
connection state changed: connecting -> connected
... 15s later ...
ConnectionError: could not establish Publisher connection, state: connected
    ensureDataTransportConnected RTCEngine.ts:1683
```

The SDP exchange completes (server's answer has the full `m=application` section), the PC reports `connected`, but no data channel ever opens.

cnderrauber on the issue: *"Looks like a publisher data channel(or sctp) connection issue."* — confirmed.

## Fix

New helper in `src/room/utils.ts`:

```ts
export function shouldUsePrejoinPublisherOffer(useV0Path: boolean): boolean {
  if (useV0Path) return false;
  if (!isCompressionStreamSupported()) return false;
  return !isFireFox();
}
```

`RTCEngine.join` swaps the inline `!useV0Path && isCompressionStreamSupported()` checks (2 sites) for this helper. Firefox falls back to the v2.17.x flow (`configure(joinResponse, ...)` + `negotiate()` after JoinResponse). Chromium / Safari keep the optimization.

### Diff

```diff
diff --git a/src/room/RTCEngine.ts b/src/room/RTCEngine.ts
@@ -90,10 +90,10 @@
 import {
   Future,
-  isCompressionStreamSupported,
   isVideoCodec,
   isVideoTrack,
   isWeb,
+  shouldUsePrejoinPublisherOffer,
   sleep,
   supportsAddTrack,
   supportsTransceiver,
@@ -324,8 +324,12 @@
       this.setupSignalClientCallbacks();
+      // #1919: Firefox can't open data channels when the initial offer's
+      // setLocalDescription is deferred until the join answer arrives, so
+      // skip the prejoin-offer fast path there.
+      const usePrejoinOffer = shouldUsePrejoinPublisherOffer(useV0Path);
       let offerProto: SessionDescription | undefined;
-      if (!useV0Path && isCompressionStreamSupported()) {
+      if (usePrejoinOffer) {
         if (!this.pcManager) {
           await this.configure();
           this.createDataChannels();
@@ -358,7 +362,7 @@
       this.subscriberPrimary = joinResponse.subscriberPrimary;
-      if (!useV0Path && isCompressionStreamSupported()) {
+      if (usePrejoinOffer) {
         this.pcManager?.updateConfiguration(this.makeRTCConfiguration(joinResponse));
       } else {
         if (!this.pcManager) {

diff --git a/src/room/utils.ts b/src/room/utils.ts
@@ -794,3 +794,19 @@
 export function isCompressionStreamSupported() {
   return typeof CompressionStream !== 'undefined';
 }
+
+/**
+ * Whether the "send publisher offer with join request" optimization (PR #1846)
+ * should be used. Firefox is excluded because deferring setLocalDescription
+ * until the answer arrives leaves Firefox's publisher SCTP transport in a
+ * state where data channels never reach `'open'` (see #1919).
+ */
+export function shouldUsePrejoinPublisherOffer(useV0Path: boolean): boolean {
+  if (useV0Path) {
+    return false;
+  }
+  if (!isCompressionStreamSupported()) {
+    return false;
+  }
+  return !isFireFox();
+}
```

## Tests

Co-located in `src/room/utils.test.ts`. 7 new tests covering the routing-decision matrix:

```
 ✓ src/room/utils.test.ts > shouldUsePrejoinPublisherOffer > is false on Firefox even when CompressionStream is supported (#1919) 0ms
 ✓ src/room/utils.test.ts > shouldUsePrejoinPublisherOffer > is true on Chrome when CompressionStream is supported 0ms
 ✓ src/room/utils.test.ts > shouldUsePrejoinPublisherOffer > is true on Safari (desktop) when CompressionStream is supported 0ms
 ✓ src/room/utils.test.ts > shouldUsePrejoinPublisherOffer > is false on any browser when CompressionStream is not supported 0ms
 ✓ src/room/utils.test.ts > shouldUsePrejoinPublisherOffer > is false when useV0Path is true (legacy dual peer connection path) 0ms
 ✓ src/room/utils.test.ts > shouldUsePrejoinPublisherOffer > is false when useV0Path is true on Firefox too 0ms
 ✓ src/room/utils.test.ts > shouldUsePrejoinPublisherOffer > is true on Firefox-on-iOS (FxiOS) only if CompressionStream is present — FxiOS uses WebKit, not Gecko, so the Firefox SCTP timing quirk does not apply, and the browser parser reports name=Firefox os=iOS. We intentionally keep this conservative and still bypass for any Firefox UA. 0ms
```

Full `src/` suite:

```
 Test Files  38 passed (38)
      Tests  522 passed (522)
   Duration  3.72s
```

The Firefox-specific test fails before the fix (`shouldUsePrejoinPublisherOffer is not a function`) and passes after, confirming the test-first ordering.

## Risk

- Firefox no longer benefits from the "prejoin publisher offer" RTT-saving optimization. It gets the prior (working) v2.17.x flow. No regression.
- Chromium / Safari / Edge: code path unchanged. Tests 2 and 3 above pin this.
- `useV0Path` (dual peer connection) is unchanged. Tests 5 and 6 pin this.
- The `isFireFox()` helper has been in `src/room/utils.ts:174` for years and is used by E2EE, PCTransport, and track-publication paths, so no new dependency surface.

## #1875 cross-reference

I checked whether issue #1875 ("Intermittent join/signal failures") shares this root cause. **It does not.** #1875 is on Chromium with 350-400 subscribers per room and points to scale-related reconnect storms (DTLS timeouts, paired `_lossy`/`_reliable` data-channel aborts). #1919 is Firefox-specific and reproduces on the very first connection at any scale. This PR does not close #1875.

## Out of scope

- Investigating whether Firefox could be made to tolerate the deferred `setLocalDescription` (would require a deeper rework of `pendingInitialOffer` handling or upstream Firefox investigation).
- Reconnection storms in large rooms (#1875).
- Other Firefox-specific WebRTC quirks unrelated to data channel timing.

CC @lukasIO
