### PR TITLE
ensure release workflow runs on regular pushes to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.event.inputs.snapshot == 'false' }}
+    if: ${{ github.event.inputs.snapshot != 'true' }}
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,9 @@ jobs:
     
     - name: Prettier
       run: pnpm format:check
+    
+    - name: Type check
+      run: pnpm type:check
 
     - name: Throws check
       run: pnpm throws:check

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "format": "prettier --write src examples/**/*.ts",
     "format:check": "prettier --check src examples/**/*.ts",
     "throws:check": "pnpm --package=@livekit/throws-transformer dlx throws-check 'src/!(*.test).ts' 'src/**/!(*.test).ts'",
-    "ci:publish": "pnpm build:clean && pnpm compat && changeset publish",
+    "type:check": "tsc --noEmit",
+    "ci:publish": "pnpm type:check && pnpm build && pnpm compat && changeset publish",
     "downlevel-dts": "downlevel-dts ./dist/src ./dist/ts4.2 --to=4.2",
     "compat": "eslint --config ./eslint.config.dist.mjs --no-inline-config  ./dist/livekit-client.esm.mjs",
     "size-limit": "size-limit"


### PR DESCRIPTION
two things: 
- the release workflow didn't run on main, so fixing this
- the new build uses oxc transform but doesn't perform any type checking anymore, just transforming code (hence the speedup). So adding a type:check step do ensure we're still catching those