### PR TITLE
Explicitly initialize enum field with constant value

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -122,7 +122,7 @@ enum PCState {
 export enum DataChannelKind {
   RELIABLE = DataPacket_Kind.RELIABLE,
   LOSSY = DataPacket_Kind.LOSSY,
-  DATA_TRACK_LOSSY,
+  DATA_TRACK_LOSSY = 2,
 }
 
 /** @internal */


### PR DESCRIPTION
tsc correctly auto increments the next enum field without an initializer. 
After switching to rolldown as a bundler it silently set `DataChannelKind.DATA_TRACK_LOSSY` to `0` for all call sites. 

The fix here is a safety measure and added for clarity. Somewhat inclined to revert the bundler change as the change in behaviour here shows there's still a risk with adopting the fairly recent rolldown bundler.