### PR TITLE
Address race condition in rpc timeout logic

### DIFF
--- a/.changeset/neat-pianos-wink.md
+++ b/.changeset/neat-pianos-wink.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ensure clearTimeout(responseTimeoutId) is skipped when timeout isn't set yet

--- a/src/room/rpc/client/RpcClientManager.ts
+++ b/src/room/rpc/client/RpcClientManager.ts
@@ -86,11 +86,14 @@ export default class RpcClientManager extends (EventEmitter as new () => TypedEm
 
     const completionFuture = new Future<string, RpcError>();
 
+    let responseTimeoutId: ReturnType<typeof setTimeout> | null = null;
     const ackTimeoutId = setTimeout(() => {
       this.pendingAcks.delete(id);
       completionFuture.reject?.(RpcError.builtIn('CONNECTION_TIMEOUT'));
       this.pendingResponses.delete(id);
-      clearTimeout(responseTimeoutId);
+      if (responseTimeoutId !== null) {
+        clearTimeout(responseTimeoutId);
+      }
     }, maxRoundTripLatencyMs);
 
     this.pendingAcks.set(id, {
@@ -114,7 +117,7 @@ export default class RpcClientManager extends (EventEmitter as new () => TypedEm
       remoteClientProtocol,
     );
 
-    const responseTimeoutId = setTimeout(() => {
+    responseTimeoutId = setTimeout(() => {
       this.pendingResponses.delete(id);
       completionFuture.reject?.(RpcError.builtIn('RESPONSE_TIMEOUT'));
     }, responseTimeoutMs);


### PR DESCRIPTION
In `RpcClientManager`'s `performRpc` method, there was some code roughly like this:

```ts
setTimeout(() => {
  clearTimeout(id);
}, /* arbitrary delay a */);

await variableDurationAsyncFunction();

const id = setTimeout(() => { /* ... */ }, /* arbitrary delay b */);
```

If `variableDurationAsyncFunction` takes longer to run than `arbitrary delay a`, then it's possible that `clearTimeout(id)` could run before `id` gets assigned. Fix this so that `id` is explictly hoisted and set to `null`, and then only actually cleared if it is non-null.