### PR TITLE
fix: rtpMap event listener leak on multiple negotiations without video tracks

### DIFF
--- a/.changeset/famous-ends-guess.md
+++ b/.changeset/famous-ends-guess.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: rtpMap event leak on multiple negotiations without video tracks

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -8,7 +8,8 @@ import {
 } from '../../packetTrailer/packetTrailer';
 import type { PacketTrailerPublishOptions } from '../../packetTrailer/types';
 import { hasPacketTrailerPublishOptions } from '../../packetTrailer/utils';
-import type { VideoCodec } from '../../room/track/options';
+import { type VideoCodec, videoCodecs } from '../../room/track/options';
+import { mimeTypeToVideoCodecString } from '../../room/track/utils';
 import { ENCRYPTION_ALGORITHM, IV_LENGTH, UNENCRYPTED_BYTES } from '../constants';
 import { CryptorError, CryptorErrorReason } from '../errors';
 import { type CryptorCallbacks, CryptorEvent } from '../events';
@@ -818,13 +819,20 @@ export class FrameCryptor extends BaseFrameCryptor {
   }
 
   /**
-   * inspects frame payloadtype if available and maps it to the codec specified in rtpMap
+   * inspects frame mimetype if available. falls back to payloadtype and maps it to the codec specified in rtpMap
    */
   private getVideoCodec(frame: RTCEncodedVideoFrame): VideoCodec | undefined {
+    const metadata = frame.getMetadata();
+    if (metadata.mimeType) {
+      const maybeKnownCodec = mimeTypeToVideoCodecString(metadata.mimeType);
+      if (videoCodecs.includes(maybeKnownCodec)) {
+        return maybeKnownCodec;
+      }
+    }
     if (this.rtpMap.size === 0) {
       return undefined;
     }
-    const payloadType = frame.getMetadata().payloadType;
+    const payloadType = metadata.payloadType;
     const codec = payloadType ? this.rtpMap.get(payloadType) : undefined;
     return codec;
   }

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -818,18 +818,31 @@ export class FrameCryptor extends BaseFrameCryptor {
         };
       }
     } catch (e) {
-      if (!this.loggedNALUFallbacks.has(fallbackKey)) {
-        this.loggedNALUFallbacks.add(fallbackKey);
-        workerLogger.warn('NALU processing failed, falling back to VP8 handling', {
-          error: e,
-          payloadType,
-          ...this.logContext,
-        });
-      }
+      this.logNALUFallbackOnce(fallbackKey, payloadType, e);
     }
 
     // Fallback to VP8 handling
     return { unencryptedBytes: UNENCRYPTED_BYTES[frame.type], requiresNALUProcessing: false };
+  }
+
+  /**
+   * Logs a NALU processing fallback at most once per (participant, trackId, payloadType) tuple,
+   * so a persistent bad state doesn't flood the console (Firefox doesn't filter debug).
+   */
+  private logNALUFallbackOnce(
+    fallbackKey: string,
+    payloadType: number | undefined,
+    error: unknown,
+  ) {
+    if (this.loggedNALUFallbacks.has(fallbackKey)) {
+      return;
+    }
+    this.loggedNALUFallbacks.add(fallbackKey);
+    workerLogger.warn('NALU processing failed, falling back to VP8 handling', {
+      error,
+      payloadType,
+      ...this.logContext,
+    });
   }
 
   /**

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -107,6 +107,12 @@ export class FrameCryptor extends BaseFrameCryptor {
 
   private readonly ERROR_WINDOW_MS = 60000; // 1 minute window
 
+  /**
+   * Tracks (participant, trackId, payloadType) tuples for which we've already logged a NALU
+   * fallback, so a persistent bad state doesn't flood the console (Firefox doesn't filter debug).
+   */
+  private loggedNALUFallbacks: Set<string> = new Set();
+
   constructor(opts: {
     keys: ParticipantKeyHandler;
     participantIdentity: string;
@@ -796,22 +802,30 @@ export class FrameCryptor extends BaseFrameCryptor {
     }
 
     // Try NALU processing for H.264/H.265 codecs
+    const payloadType = frame.getMetadata().payloadType;
+    const fallbackKey = `${this.participantIdentity}-${this.trackId}-${payloadType}`;
     try {
       const knownCodec =
         detectedCodec === 'h264' || detectedCodec === 'h265' ? detectedCodec : undefined;
       const naluResult = processNALUsForEncryption(new Uint8Array(frame.data), knownCodec);
 
       if (naluResult.requiresNALUProcessing) {
+        // Recovered for this tuple, allow a future failure to log again.
+        this.loggedNALUFallbacks.delete(fallbackKey);
         return {
           unencryptedBytes: naluResult.unencryptedBytes,
           requiresNALUProcessing: true,
         };
       }
     } catch (e) {
-      workerLogger.debug('NALU processing failed, falling back to VP8 handling', {
-        error: e,
-        ...this.logContext,
-      });
+      if (!this.loggedNALUFallbacks.has(fallbackKey)) {
+        this.loggedNALUFallbacks.add(fallbackKey);
+        workerLogger.warn('NALU processing failed, falling back to VP8 handling', {
+          error: e,
+          payloadType,
+          ...this.logContext,
+        });
+      }
     }
 
     // Fallback to VP8 handling

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1746,20 +1746,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
       this.on(EngineEvent.Closing, handleClosed);
       this.on(EngineEvent.Restarting, handleClosed);
-
-      this.pcManager.publisher.once(
-        PCEvents.RTPVideoPayloadTypes,
-        (rtpTypes: MediaAttributes['rtp']) => {
-          const rtpMap = new Map<number, VideoCodec>();
-          rtpTypes.forEach((rtp) => {
-            const codec = rtp.codec.toLowerCase();
-            if (isVideoCodec(codec)) {
-              rtpMap.set(rtp.payload, codec);
-            }
-          });
-          this.emit(EngineEvent.RTPVideoMapUpdate, rtpMap);
-        },
-      );
+      this.pcManager.publisher.off(PCEvents.RTPVideoPayloadTypes, this.onRtpMapAvailable);
+      this.pcManager.publisher.once(PCEvents.RTPVideoPayloadTypes, this.onRtpMapAvailable);
 
       try {
         await this.pcManager.negotiate(abortController);
@@ -1905,6 +1893,17 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     // debugging method to fail the next connection attempt for /rtc/v1 to trigger the fallback version
     this.shouldFailOnV1Path = true;
   }
+
+  private onRtpMapAvailable = (rtpTypes: MediaAttributes['rtp']) => {
+    const rtpMap = new Map<number, VideoCodec>();
+    rtpTypes.forEach((rtp) => {
+      const codec = rtp.codec.toLowerCase();
+      if (isVideoCodec(codec)) {
+        rtpMap.set(rtp.payload, codec);
+      }
+    });
+    this.emit(EngineEvent.RTPVideoMapUpdate, rtpMap);
+  };
 
   private dataChannelsInfo(): DataChannelInfo[] {
     const infos: DataChannelInfo[] = [];


### PR DESCRIPTION
addresses https://community.livekit.io/t/rtpvideopayloadtypes-listener-leak-on-publisher-pctransport-during-audio-only-renegotiations/1320

Additionally hardens codec detection in e2ee path by inspecting frame metadata's `mimeType` field if available without relying on codec mapping. 