### PR TITLE
Add `restrictOwnAudio` experimental param to `AudioCaptureOptions`

### DIFF
--- a/.changeset/eighty-pears-cheat.md
+++ b/.changeset/eighty-pears-cheat.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add restrictOwnAudio experimental param to AudioCaptureOptions

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -293,6 +293,15 @@ export interface AudioCaptureOptions {
   voiceIsolation?: ConstrainBoolean;
 
   /**
+   * @experimental
+   * when capturing system/screen-share audio, excludes the local participant's own audio
+   * from the captured stream to prevent echo. Browser support is not widespread yet
+   * (as of mid 2026, Chromium-based browsers only).
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints/restrictOwnAudio
+   */
+  restrictOwnAudio?: ConstrainBoolean;
+
+  /**
    * the sample rate or range of sample rates which are acceptable and/or required.
    */
   sampleRate?: ConstrainULong;


### PR DESCRIPTION
Works around an issue reported by a customer.

Note that this `restrictOwnAudio` param is only supported by chrome / chrome-derived browsers. I think the better long term move rather than hardcoding individual settings in here would be to somebow derive `AudioCaptureOptions` from `MediaTrackSettings` ([link](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings)) so that any globally configured values per the user's `tsconfig.json` `lib` setting would automatically cascade through this api.