### PR TITLE
Fix data channel close race condition

### DIFF
--- a/.changeset/gold-candies-switch.md
+++ b/.changeset/gold-candies-switch.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix data channel close race condition

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -456,33 +456,24 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   }
 
   async cleanupPeerConnections() {
-    // Detach the data channel handlers before closing the peer connections. Closing a peer
-    // connection tears down the SCTP transport, which can dispatch `error`/`close` events on
-    // the still-open data channels; if our handlers are still attached at that point,
-    // handleDataError logs a spurious "Unknown DataChannel error" during an otherwise graceful
-    // disconnect. Detaching first makes this deterministic regardless of how/when the browser
-    // dispatches those teardown events. See livekit/client-sdk-js#1953.
-    const detachHandlers = (dc: RTCDataChannel | undefined) => {
-      if (!dc) return;
+    const dcCleanup = (dc: RTCDataChannel | undefined) => {
+      if (!dc) {
+        return;
+      }
+
+      // Detach the data channel handlers before closing anything. Closing a peer connection tears
+      // down the SCTP transport, which can dispatch `error`/`close` events on the still-open data
+      // channels; if our handlers are still attached at that point, handleDataError logs a spurious
+      // "Unknown DataChannel error" during an otherwise graceful disconnect. Removing the handlers
+      // before dc.close()/pcManager.close() makes this deterministic regardless of how/when the
+      // browser dispatches those teardown events. See livekit/client-sdk-js#1953.
       dc.onbufferedamountlow = null;
       dc.onclose = null;
       dc.onclosing = null;
       dc.onerror = null;
       dc.onmessage = null;
       dc.onopen = null;
-    };
-    detachHandlers(this.lossyDC);
-    detachHandlers(this.lossyDCSub);
-    detachHandlers(this.reliableDC);
-    detachHandlers(this.reliableDCSub);
-    detachHandlers(this.dataTrackDC);
-    detachHandlers(this.dataTrackDCSub);
 
-    await this.pcManager?.close();
-    this.pcManager = undefined;
-
-    const dcCleanup = (dc: RTCDataChannel | undefined) => {
-      if (!dc) return;
       dc.close();
     };
     dcCleanup(this.lossyDC);
@@ -491,6 +482,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     dcCleanup(this.reliableDCSub);
     dcCleanup(this.dataTrackDC);
     dcCleanup(this.dataTrackDCSub);
+
+    await this.pcManager?.close();
+    this.pcManager = undefined;
 
     this.lossyDC = undefined;
     this.lossyDCSub = undefined;

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -456,18 +456,34 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   }
 
   async cleanupPeerConnections() {
-    await this.pcManager?.close();
-    this.pcManager = undefined;
-
-    const dcCleanup = (dc: RTCDataChannel | undefined) => {
+    // Detach the data channel handlers before closing the peer connections. Closing a peer
+    // connection tears down the SCTP transport, which can dispatch `error`/`close` events on
+    // the still-open data channels; if our handlers are still attached at that point,
+    // handleDataError logs a spurious "Unknown DataChannel error" during an otherwise graceful
+    // disconnect. Detaching first makes this deterministic regardless of how/when the browser
+    // dispatches those teardown events. See livekit/client-sdk-js#1953.
+    const detachHandlers = (dc: RTCDataChannel | undefined) => {
       if (!dc) return;
-      dc.close();
       dc.onbufferedamountlow = null;
       dc.onclose = null;
       dc.onclosing = null;
       dc.onerror = null;
       dc.onmessage = null;
       dc.onopen = null;
+    };
+    detachHandlers(this.lossyDC);
+    detachHandlers(this.lossyDCSub);
+    detachHandlers(this.reliableDC);
+    detachHandlers(this.reliableDCSub);
+    detachHandlers(this.dataTrackDC);
+    detachHandlers(this.dataTrackDCSub);
+
+    await this.pcManager?.close();
+    this.pcManager = undefined;
+
+    const dcCleanup = (dc: RTCDataChannel | undefined) => {
+      if (!dc) return;
+      dc.close();
     };
     dcCleanup(this.lossyDC);
     dcCleanup(this.lossyDCSub);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1059,9 +1059,13 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     const channel = event.currentTarget as RTCDataChannel;
     const channelKind = channel.maxRetransmits === 0 ? 'lossy' : 'reliable';
 
-    if (event instanceof ErrorEvent && event.error) {
-      const { error } = event.error;
-      this.log.error(`DataChannel error on ${channelKind}: ${event.message}`, { error });
+    if (typeof RTCErrorEvent !== 'undefined' && event instanceof RTCErrorEvent && event.error) {
+      const { error } = event;
+      this.log.error(`DataChannel error on ${channelKind}: ${error.message}`, {
+        error,
+        errorDetail: error.errorDetail,
+        sctpCauseCode: error.sctpCauseCode,
+      });
     } else {
       this.log.error(`Unknown DataChannel error on ${channelKind}`, { event });
     }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1054,6 +1054,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   };
 
   private handleDataError = (event: Event) => {
+    // Errors fired while we're tearing the connection down (e.g. the SCTP transport aborting as
+    // the peer connection closes) carry no actionable information — the channel is going away
+    // regardless. Suppress them so a graceful disconnect doesn't surface spurious errors.
+    // See livekit/client-sdk-js#1953.
+    if (this._isClosed) {
+      return;
+    }
+
     const channel = event.currentTarget as RTCDataChannel;
     const channelKind = channel.maxRetransmits === 0 ? 'lossy' : 'reliable';
 


### PR DESCRIPTION
Fixes #1953 (I think, still needs confirmation from the reporter - I was unable to reproduce locally).

In `main`, there is a possible race condition that could happen when disconnecting a room. The below three tasks run in this order:
1. Close peer connection
2. Close data channel
3. Remove handlers from data channel

What could happen is that when 1 would run, it would close the data channels pre-emptively and lead to some of the handlers (3) firing before they were cleaned up, leading to a `Unknown DataChannel error on ...` error being logged.

So to fix this, reorder the above to now run in 3 -> 2 -> 1 order. This means that by the time any data channel errors that occur during disconnect are fired (at 1), the handlers are already detached (3).

--------

As an unrelated fix, also, `Unknown DataChannel error on ...` shouldn't have been logged in this case. It looks like this was because of the `event instanceof ErrorEvent` check - actually, `event` would be a `RTCErrorEvent` and confusingly given their names, `RTCErrorEvent` does not extend `ErrorEvent`. So, alter this code to check the right error which should make these error paths show more detail.