### PR TITLE
Ensure that sortPresets does NOT mutate values passed in via options into Room

### DIFF
--- a/.changeset/tired-views-turn.md
+++ b/.changeset/tired-views-turn.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Ensure that sortPresets does NOT mutate values passed in via options into Room

--- a/src/room/participant/publishUtils.test.ts
+++ b/src/room/participant/publishUtils.test.ts
@@ -174,6 +174,12 @@ describe('customSimulcastLayers', () => {
     expect(sortedPresets[1].encoding.maxFramerate).toBe(15);
     expect(sortedPresets[2].encoding.maxFramerate).toBe(20);
   });
+  it('does not mutate the passed-in array', () => {
+    const presets = [VideoPresets.h1440, VideoPresets.h360, VideoPresets.h1080, VideoPresets.h90];
+    const original = [...presets];
+    sortPresets(presets);
+    expect(presets).toEqual(original);
+  });
 });
 
 describe('screenShareSimulcastDefaults', () => {

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -419,7 +419,10 @@ function encodingsFromPresets(
 /** @internal */
 export function sortPresets(presets: Array<VideoPreset> | undefined) {
   if (!presets) return;
-  return presets.sort((a, b) => {
+  // Sort a copy so we don't mutate the caller's array in place. Mutating the
+  // passed-in simulcast layers can cause consumers that compare options by value
+  // (e.g. components-react's useLiveKitRoom) to detect a spurious change.
+  return presets.slice().sort((a, b) => {
     const { encoding: aEnc } = a;
     const { encoding: bEnc } = b;
 


### PR DESCRIPTION
What could happen previously is if the user passed in the layers into `LiveKitRoom` in `components-js` in the wrong order, then the `JSON.stringify(...)` comparison [here](https://github.com/livekit/components-js/blob/97bf9dcc603b50530059904cdb4e34d5825e6baf/packages/react/src/hooks/useLiveKitRoom.ts#L64) could be attempting to compare the sorted (via side effect) version with the new value the user passed in (which has a different ref and would not be sorted), always recreating the room on every render.

Fixes https://github.com/livekit/components-js/issues/1345