### PR TITLE
Skip pre-populated media sections on React Native

### DIFF
--- a/.changeset/slow-olives-fry.md
+++ b/.changeset/slow-olives-fry.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Skip pre-populated media sections for single peer connections on React Native

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -92,6 +92,7 @@ import type { LoggerOptions } from './types';
 import {
   Future,
   isPublisherOfferWithJoinSupported,
+  isReactNative,
   isVideoCodec,
   isVideoTrack,
   isWeb,
@@ -857,7 +858,15 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
    */
   private applyInitialPublisherLayout() {
     this.createDataChannels();
-    this.addMediaSections(initialMediaSectionsAudio, initialMediaSectionsVideo);
+    /**
+     * Native libwebrtc does not support pre-populating the media sections,
+     * so we skip it for React Native.
+     * 
+     * Related: https://github.com/livekit/rust-sdks/pull/1151
+     */
+    if(!isReactNative()) {
+      this.addMediaSections(initialMediaSectionsAudio, initialMediaSectionsVideo);
+    }
   }
 
   private addMediaSections(numAudios: number, numVideos: number) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -861,10 +861,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     /**
      * Native libwebrtc does not support pre-populating the media sections,
      * so we skip it for React Native.
-     * 
+     *
      * Related: https://github.com/livekit/rust-sdks/pull/1151
      */
-    if(!isReactNative()) {
+    if (!isReactNative()) {
       this.addMediaSections(initialMediaSectionsAudio, initialMediaSectionsVideo);
     }
   }


### PR DESCRIPTION
Fixes #1981, #1977

## Summary
Native libwebrtc (used by React Native WebRTC) doesn't support adding media sections before the initial publisher offer the way browser WebRTC does (see https://github.com/livekit/rust-sdks/pull/1151), so this change disables it entirely.

## Test plan
- [x] **React Native (single-PC, default)** — Connect to a room, publish camera + mic, subscribe to remote audio/video (in that order); confirm tracks attach and play in both directions
- [x] **React Native (single-PC, default)** — Connect to a room with preexisting publishers, subscribe to remote audio/video (in that order); confirm tracks attach and play in both directions
- [x] **React Native data channels** — Send/receive chat or other data messages after connect
- [x] **Remote participant reconnect** — App does not crash when remote participant reconnects
- [x] **Reconnection** — Disconnect and reconnect (or trigger network drop); confirm tracks recover
