### PR TITLE
Fix initial video quality blurriness for all codecs

### DIFF
--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -17,13 +17,13 @@ interface TrackBitrateInfo {
   maxbr: number;
 }
 
-/* The svc codec (av1/vp9) would use a very low bitrate at the begining and
-increase slowly by the bandwidth estimator until it reach the target bitrate. The
-process commonly cost more than 10 seconds cause subscriber will get blur video at
-the first few seconds. So we use a 70% of target bitrate here as the start bitrate to
+/* Video codecs use a very low bitrate at the beginning and increase slowly by
+the bandwidth estimator until they reach the target bitrate. The process commonly
+costs more than 10 seconds causing subscribers to get blurry video at the first
+few seconds. So we use 70% of target bitrate here as the start bitrate to
 eliminate this issue.
 */
-const startBitrateForSVC = 0.7;
+const startBitrateMultiplier = 0.7;
 
 const debounceInterval = 20;
 
@@ -379,11 +379,7 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
             }
 
             // mung sdp for bitrate setting that can't apply by sendEncoding
-            if (!isSVCCodec(trackbr.codec)) {
-              return true;
-            }
-
-            const startBitrate = Math.round(trackbr.maxbr * startBitrateForSVC);
+            const startBitrate = Math.round(trackbr.maxbr * startBitrateMultiplier);
 
             for (const fmtp of media.fmtp) {
               if (fmtp.payload === codecPayload) {

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -17,13 +17,17 @@ interface TrackBitrateInfo {
   maxbr: number;
 }
 
-/* Video codecs use a very low bitrate at the beginning and increase slowly by
-the bandwidth estimator until they reach the target bitrate. The process commonly
-costs more than 10 seconds causing subscribers to get blurry video at the first
-few seconds. So we use 70% of target bitrate here as the start bitrate to
-eliminate this issue.
-*/
-const startBitrateMultiplier = 0.7;
+/*
+ * Video codecs use a very low bitrate at the beginning and increase slowly by
+ * the bandwidth estimator until they reach the target bitrate. The process commonly
+ * costs more than 10 seconds causing subscribers to get blurry video at the first
+ * few seconds. We use x-google-start-bitrate to hint the BWE to start higher.
+ *
+ * Why 90%: Gives ~10% headroom for bandwidth estimation while starting close to target.
+ * Why same for all codecs: Target bitrate already accounts for codec efficiency
+ * (e.g., users set lower targets for VP9/AV1 knowing they're more efficient).
+ */
+const startBitrateMultiplier = 0.9;
 
 const debounceInterval = 20;
 

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -15,6 +15,7 @@ interface TrackBitrateInfo {
   transceiver?: RTCRtpTransceiver;
   codec: string;
   maxbr: number;
+  isScreenShare?: boolean;
 }
 
 /*
@@ -387,11 +388,13 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
             }
 
             // mung sdp for bitrate setting that can't apply by sendEncoding
-            // Use 90% of target bitrate, capped at 1 Mbps to prevent BWE from starting too aggressively
-            const startBitrate = Math.min(
-              Math.round(trackbr.maxbr * startBitrateMultiplier),
-              maxStartBitrateKbps,
-            );
+            // Use 90% of target bitrate, capped at 1 Mbps for camera to prevent BWE from starting too aggressively
+            // Screen share is not capped since text/UI clarity requires high bitrate from the start
+            // TODO: dynamically adjust start bitrate based on network conditions (e.g., use previous BWE estimate)
+            const calculatedStartBitrate = Math.round(trackbr.maxbr * startBitrateMultiplier);
+            const startBitrate = trackbr.isScreenShare
+              ? calculatedStartBitrate
+              : Math.min(calculatedStartBitrate, maxStartBitrateKbps);
 
             let fmtpFound = false;
             for (const fmtp of media.fmtp) {

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -393,8 +393,10 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
               maxStartBitrateKbps,
             );
 
+            let fmtpFound = false;
             for (const fmtp of media.fmtp) {
               if (fmtp.payload === codecPayload) {
+                fmtpFound = true;
                 // if another track's fmtp already is set, we cannot override the bitrate
                 // this has the unfortunate consequence of being forced to use the
                 // initial track's bitrate for all tracks
@@ -403,6 +405,13 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
                 }
                 break;
               }
+            }
+            // VP8 and some codecs may not have an existing fmtp line - create one
+            if (!fmtpFound) {
+              media.fmtp.push({
+                payload: codecPayload,
+                config: `x-google-start-bitrate=${startBitrate}`,
+              });
             }
             return true;
           });

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -26,8 +26,12 @@ interface TrackBitrateInfo {
  * Why 90%: Gives ~10% headroom for bandwidth estimation while starting close to target.
  * Why same for all codecs: Target bitrate already accounts for codec efficiency
  * (e.g., users set lower targets for VP9/AV1 knowing they're more efficient).
+ * Why cap at 1 Mbps: Prevents BWE from starting too aggressively on high bitrate tracks.
  */
 const startBitrateMultiplier = 0.9;
+
+/** Maximum x-google-start-bitrate in kbps. 1 Mbps prevents BWE from starting too aggressively. */
+const maxStartBitrateKbps = 1000;
 
 const debounceInterval = 20;
 
@@ -383,7 +387,11 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
             }
 
             // mung sdp for bitrate setting that can't apply by sendEncoding
-            const startBitrate = Math.round(trackbr.maxbr * startBitrateMultiplier);
+            // Use 90% of target bitrate, capped at 1 Mbps to prevent BWE from starting too aggressively
+            const startBitrate = Math.min(
+              Math.round(trackbr.maxbr * startBitrateMultiplier),
+              maxStartBitrateKbps,
+            );
 
             for (const fmtp of media.fmtp) {
               if (fmtp.payload === codecPayload) {

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -99,6 +99,7 @@ import {
   isLocalVideoTrack,
   isSVCCodec,
   isSafari17Based,
+  isVideoCodec,
   isVideoTrack,
   isWeb,
   sleep,
@@ -1248,7 +1249,8 @@ export default class LocalParticipant extends Participant {
               maxbr: encodings[0]?.maxBitrate ? encodings[0].maxBitrate / 1000 : 0,
             });
           }
-        } else if (track.codec && isSVCCodec(track.codec) && encodings[0]?.maxBitrate) {
+        } else if (track.codec && isVideoCodec(track.codec) && encodings[0]?.maxBitrate) {
+          // Apply start bitrate for all video codecs to prevent initial blurriness
           this.engine.pcManager.publisher.setTrackCodecBitrate({
             cid: req.cid,
             codec: track.codec,

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1249,13 +1249,17 @@ export default class LocalParticipant extends Participant {
               maxbr: encodings[0]?.maxBitrate ? encodings[0].maxBitrate / 1000 : 0,
             });
           }
-        } else if (track.codec && isVideoCodec(track.codec) && encodings[0]?.maxBitrate) {
-          // Apply start bitrate for all video codecs to prevent initial blurriness
-          this.engine.pcManager.publisher.setTrackCodecBitrate({
-            cid: req.cid,
-            codec: track.codec,
-            maxbr: encodings[0].maxBitrate / 1000,
-          });
+        } else if (track.codec && isVideoCodec(track.codec)) {
+          // Apply start bitrate for all video codecs to prevent initial blurriness.
+          // Sum all encoding bitrates for simulcast (BWE needs to handle all layers combined).
+          const totalBitrate = encodings.reduce((sum, enc) => sum + (enc.maxBitrate ?? 0), 0);
+          if (totalBitrate > 0) {
+            this.engine.pcManager.publisher.setTrackCodecBitrate({
+              cid: req.cid,
+              codec: track.codec,
+              maxbr: totalBitrate / 1000,
+            });
+          }
         }
       }
 

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1261,6 +1261,7 @@ export default class LocalParticipant extends Participant {
               cid: req.cid,
               codec: track.codec,
               maxbr: targetBitrate / 1000,
+              isScreenShare: track.source === Track.Source.ScreenShare,
             });
           }
         }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1251,13 +1251,16 @@ export default class LocalParticipant extends Participant {
           }
         } else if (track.codec && isVideoCodec(track.codec)) {
           // Apply start bitrate for all video codecs to prevent initial blurriness.
-          // Sum all encoding bitrates for simulcast (BWE needs to handle all layers combined).
-          const totalBitrate = encodings.reduce((sum, enc) => sum + (enc.maxBitrate ?? 0), 0);
-          if (totalBitrate > 0) {
+          // - SVC codecs: use first encoding's bitrate (single stream with built-in layers)
+          // - Simulcast: sum all encoding bitrates (independent streams, BWE needs total)
+          const targetBitrate = isSVCCodec(track.codec)
+            ? encodings[0]?.maxBitrate ?? 0
+            : encodings.reduce((sum, enc) => sum + (enc.maxBitrate ?? 0), 0);
+          if (targetBitrate > 0) {
             this.engine.pcManager.publisher.setTrackCodecBitrate({
               cid: req.cid,
               codec: track.codec,
-              maxbr: totalBitrate / 1000,
+              maxbr: targetBitrate / 1000,
             });
           }
         }

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1254,7 +1254,7 @@ export default class LocalParticipant extends Participant {
           // - SVC codecs: use first encoding's bitrate (single stream with built-in layers)
           // - Simulcast: sum all encoding bitrates (independent streams, BWE needs total)
           const targetBitrate = isSVCCodec(track.codec)
-            ? encodings[0]?.maxBitrate ?? 0
+            ? (encodings[0]?.maxBitrate ?? 0)
             : encodings.reduce((sum, enc) => sum + (enc.maxBitrate ?? 0), 0);
           if (targetBitrate > 0) {
             this.engine.pcManager.publisher.setTrackCodecBitrate({

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -19,7 +19,6 @@ import {
   isSVCCodec,
   isSafariBased,
   isSafariSvcApi,
-  unwrapConstraint,
 } from '../utils';
 
 /** @internal */
@@ -468,16 +467,9 @@ export class ScalabilityMode {
   }
 }
 
-export function getDefaultDegradationPreference(track: LocalVideoTrack): RTCDegradationPreference {
-  // a few of reasons we have different default paths:
-  // 1. without this, Chrome seems to aggressively resize the SVC video stating `quality-limitation: bandwidth` even when BW isn't an issue
-  // 2. since we are overriding contentHint to motion (to workaround L1T3 publishing), it overrides the default degradationPreference to `balanced`
-  if (
-    track.source === Track.Source.ScreenShare ||
-    (track.constraints.height && unwrapConstraint(track.constraints.height) >= 1080)
-  ) {
-    return 'maintain-resolution';
-  } else {
-    return 'balanced';
-  }
+export function getDefaultDegradationPreference(_track: LocalVideoTrack): RTCDegradationPreference {
+  // Default to 'maintain-resolution' for all video tracks to prevent initial blurriness.
+  // When bandwidth is constrained, this prefers dropping frames over reducing resolution,
+  // which maintains video clarity at the cost of smoothness.
+  return 'maintain-resolution';
 }

--- a/src/room/participant/publishUtils.ts
+++ b/src/room/participant/publishUtils.ts
@@ -467,9 +467,20 @@ export class ScalabilityMode {
   }
 }
 
-export function getDefaultDegradationPreference(_track: LocalVideoTrack): RTCDegradationPreference {
-  // Default to 'maintain-resolution' for all video tracks to prevent initial blurriness.
-  // When bandwidth is constrained, this prefers dropping frames over reducing resolution,
-  // which maintains video clarity at the cost of smoothness.
-  return 'maintain-resolution';
+/**
+ * Returns the appropriate degradation preference for a video track based on its source.
+ *
+ * - Camera: 'maintain-framerate' (smoother video for real-time communication)
+ * - Screen share: 'maintain-resolution' (clarity is critical for reading text/UI)
+ * - Other/unknown: 'balanced'
+ */
+export function getDefaultDegradationPreference(track: LocalVideoTrack): RTCDegradationPreference {
+  switch (track.source) {
+    case Track.Source.Camera:
+      return 'maintain-framerate';
+    case Track.Source.ScreenShare:
+      return 'maintain-resolution';
+    default:
+      return 'balanced';
+  }
 }

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -84,7 +84,17 @@ export interface TrackPublishDefaults {
   scalabilityMode?: ScalabilityMode;
 
   /**
-   * degradation preference
+   * Controls how the encoder trades off between resolution and framerate
+   * when bandwidth is constrained.
+   *
+   * - 'maintain-framerate': Prioritizes framerate, reduces resolution if needed
+   * - 'maintain-resolution': Prioritizes resolution, drops frames if needed
+   * - 'balanced': Balances between both
+   *
+   * If not set, the SDK uses defaults based on track source:
+   * - Camera: 'maintain-framerate' (smoother video for real-time communication)
+   * - Screen share: 'maintain-resolution' (clarity is critical for text/UI)
+   * - Other/unknown: 'balanced'
    */
   degradationPreference?: RTCDegradationPreference;
 


### PR DESCRIPTION
 Summary

  Improve initial video quality by:
  1. Capping x-google-start-bitrate at 1 Mbps to prevent BWE from starting too aggressively on high bitrate tracks
  2. Setting source-based degradationPreference defaults for optimal quality per use case

  Changes

  PCTransport.ts
  - Added 1 Mbps cap on x-google-start-bitrate: min(target * 0.9, 1000 kbps)
  - Prevents bandwidth estimator from overwhelming the network on high bitrate tracks (e.g., 4K video)

  publishUtils.ts
  - Updated getDefaultDegradationPreference() to return defaults based on track source:
    - Camera: maintain-framerate (smoother video for real-time communication)
    - Screen share: maintain-resolution (clarity is critical for text/UI)
    - Other/unknown: balanced

  options.ts
  - Updated documentation for degradationPreference option

  Behavior
  │              Setting               │          Before           │           After            │
  │ x-google-start-bitrate             │ 90% of target (unbounded) │ min(90% of target, 1 Mbps) │
  │ Camera degradationPreference       │ maintain-resolution       │ maintain-framerate         │
  │ Screen share degradationPreference │ maintain-resolution       │ maintain-resolution        │
  │ Other degradationPreference        │ maintain-resolution       │ balanced                   │
 
  Related

  Aligns with rust-sdks PRs:
  - #1197 - Fix initial video quality blurriness for all codecs
  - #1226 - fix x-google-start-bitrate and make it adaptive to network



See Rust PR: https://github.com/livekit/rust-sdks/pull/1197