### PR TITLE
fix: remove Firefox VP9 SVC workaround

### DIFF
--- a/.changeset/silly-crews-show.md
+++ b/.changeset/silly-crews-show.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Remove Firefox VP9 SVC workaround

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -91,11 +91,6 @@ export function supportsVP9(): boolean {
   if (!('getCapabilities' in RTCRtpSender)) {
     return false;
   }
-  if (isFireFox()) {
-    // technically speaking FireFox supports VP9, but SVC publishing is broken
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1633876
-    return false;
-  }
   if (isSafari()) {
     const browser = getBrowser();
     if (browser?.version && compareVersions(browser.version, '16') < 0) {


### PR DESCRIPTION
Removes the workaround that disabled VP9 publishing for Firefox clients. According to the linked Bugzilla thread, this issue has been resolved in modern Firefox versions.

Fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1633876
Discussion: https://livekit-users.slack.com/archives/C025KM0S1CK/p1783681641812789