### PR TITLE
fix: keep attached audio elements muted in startAudio() when webAudioMix is enabled

### DIFF
--- a/.changeset/spotty-donuts-remain.md
+++ b/.changeset/spotty-donuts-remain.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Keep attached audio elements muted in startAudio() when webAudioMix is enabled, preventing double playback on platforms where element.volume has no effect (e.g. iOS Safari)

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1383,7 +1383,13 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       await Promise.all([
         this.acquireAudioContext(),
         ...elements.map((e) => {
-          e.muted = false;
+          // when webAudioMix is enabled, attached elements are deliberately kept muted by
+          // RemoteAudioTrack.attach() and audio is routed through the web audio graph instead.
+          // unmuting them here would cause double playback on platforms where element.volume
+          // has no effect (e.g. iOS Safari)
+          if (!this.options.webAudioMix) {
+            e.muted = false;
+          }
           return e.play();
         }),
       ]);


### PR DESCRIPTION
Fixes #2003

## Problem

`Room.startAudio()` unconditionally sets `e.muted = false` on all attached remote audio elements. When `webAudioMix` is enabled, those elements are deliberately kept muted by `RemoteAudioTrack.attach()` (audio is routed through the web audio gain node instead), so unmuting them re-enables the element's direct output.

On desktop browsers this stays inaudible because `element.volume = 0` still applies, but on iOS Safari `element.volume` has no effect — the same track then plays twice (element output + web audio output), audible as doubled/echoing voices.

Since `startAudio()` also runs automatically (on `ParticipantEvent.AudioStreamAcquired` and on the iOS `visibilitychange` handler), this happens without any app-side call to `startAudio()`.

## Fix

Skip the unmute when `webAudioMix` is enabled, restoring the invariant established by `attach()`. `play()` is still called so autoplay recovery keeps working. Behavior without `webAudioMix` is unchanged.

We have been running this exact change as a local patch in production (a WebXR social VR app using webAudioMix for spatial audio) and it resolves the double playback on iOS Safari without regressions on desktop browsers.