### PR TITLE
Attempt to fix room GC cycle resulting in memory leak

### DIFF
--- a/.changeset/full-tires-call.md
+++ b/.changeset/full-tires-call.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix room GC cycle due to not unregistered devicechange event

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -22,6 +22,7 @@ import {
   isVideoTrack,
 } from '../room/utils';
 import type { NonSharedUint8Array } from '../type-polyfills/non-shared-typed-arrays';
+import { WeakRefPolyfill } from '../utils/weak-ref-polyfill';
 import type { BaseKeyProvider } from './KeyProvider';
 import { E2EE_FLAG } from './constants';
 import { type E2EEManagerCallbacks, EncryptionEvent, KeyProviderEvent } from './events';
@@ -72,7 +73,11 @@ export class E2EEManager
 {
   protected worker: Worker;
 
-  protected room?: Room;
+  private roomRef?: WeakRefPolyfill<Room>;
+
+  protected get room(): Room | undefined {
+    return this.roomRef?.deref();
+  }
 
   private encryptionEnabled: boolean;
 
@@ -113,7 +118,7 @@ export class E2EEManager
     }
     log.info('setting up e2ee');
     if (room !== this.room) {
-      this.room = room;
+      this.roomRef = new WeakRefPolyfill(room);
       this.setupEventListeners(room, this.keyProvider);
       // this.worker = new Worker('');
       const msg: InitMessage = {

--- a/src/frameMetadata/FrameMetadataManager.ts
+++ b/src/frameMetadata/FrameMetadataManager.ts
@@ -37,7 +37,32 @@ export interface FrameMetadataOptions {
 export class FrameMetadataManager {
   private worker?: Worker;
 
-  private room?: Room;
+  /**
+   * Held as a WeakRef to break the reference cycle between Room and this
+   * manager (`Room.frameMetadataManager` -> FrameMetadataManager -> Room).
+   * Without this, a Room could not be garbage collected once it constructed
+   * a FrameMetadataManager. Access via the `room` getter.
+   */
+  private roomRef?: WeakRef<Room>;
+
+  /**
+   * Fallback strong reference for legacy browsers without WeakRef. This
+   * reintroduces the reference cycle, but such browsers don't support the
+   * encoded-transform APIs this feature relies on anyway.
+   */
+  private roomStrong?: Room;
+
+  private get room(): Room | undefined {
+    return this.roomRef ? this.roomRef.deref() : this.roomStrong;
+  }
+
+  private setRoom(room: Room) {
+    if (typeof WeakRef !== 'undefined') {
+      this.roomRef = new WeakRef(room);
+    } else {
+      this.roomStrong = room;
+    }
+  }
 
   private extractors = new Map<string, FrameMetadataExtractor>();
 
@@ -58,7 +83,7 @@ export class FrameMetadataManager {
     if (room === this.room) {
       return;
     }
-    this.room = room;
+    this.setRoom(room);
 
     if (this.worker) {
       this.worker.onmessage = this.onWorkerMessage;

--- a/src/frameMetadata/FrameMetadataManager.ts
+++ b/src/frameMetadata/FrameMetadataManager.ts
@@ -5,6 +5,7 @@ import { RoomEvent } from '../room/events';
 import { FrameMetadataExtractor } from '../room/track/FrameMetadataExtractor';
 import type RemoteTrack from '../room/track/RemoteTrack';
 import RemoteVideoTrack from '../room/track/RemoteVideoTrack';
+import { WeakRefPolyfill } from '../utils/weak-ref-polyfill';
 import type { PTDecodeMessage, PTUpdateTrackIdMessage, PTWorkerMessage } from './types';
 import { isFrameMetadataSupported, shouldUseFrameMetadataScriptTransform } from './utils';
 
@@ -38,30 +39,15 @@ export class FrameMetadataManager {
   private worker?: Worker;
 
   /**
-   * Held as a WeakRef to break the reference cycle between Room and this
+   * Held as a weak reference to break the reference cycle between Room and this
    * manager (`Room.frameMetadataManager` -> FrameMetadataManager -> Room).
    * Without this, a Room could not be garbage collected once it constructed
    * a FrameMetadataManager. Access via the `room` getter.
    */
-  private roomRef?: WeakRef<Room>;
-
-  /**
-   * Fallback strong reference for legacy browsers without WeakRef. This
-   * reintroduces the reference cycle, but such browsers don't support the
-   * encoded-transform APIs this feature relies on anyway.
-   */
-  private roomStrong?: Room;
+  private roomRef?: WeakRefPolyfill<Room>;
 
   private get room(): Room | undefined {
-    return this.roomRef ? this.roomRef.deref() : this.roomStrong;
-  }
-
-  private setRoom(room: Room) {
-    if (typeof WeakRef !== 'undefined') {
-      this.roomRef = new WeakRef(room);
-    } else {
-      this.roomStrong = room;
-    }
+    return this.roomRef?.deref();
   }
 
   private extractors = new Map<string, FrameMetadataExtractor>();
@@ -83,7 +69,7 @@ export class FrameMetadataManager {
     if (room === this.room) {
       return;
     }
-    this.setRoom(room);
+    this.roomRef = new WeakRefPolyfill(room);
 
     if (this.worker) {
       this.worker.onmessage = this.onWorkerMessage;

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -192,7 +192,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   /** used for aborting pending connections to a LiveKit server */
   private abortController?: AbortController;
 
-
   /** future holding client initiated connection attempt */
   private connectFuture?: Future<void, Error>;
 

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1351,7 +1351,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         track.enabled = true;
         const stream = new MediaStream([track]);
         dummyAudioEl.srcObject = stream;
-        document.addEventListener('visibilitychange', () => {
+        const onVisibilityChange = () => {
           if (!dummyAudioEl) {
             return;
           }
@@ -1363,9 +1363,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
             );
             this.startAudio();
           }
-        });
+        };
+        document.addEventListener('visibilitychange', onVisibilityChange);
         document.body.append(dummyAudioEl);
         this.once(RoomEvent.Disconnected, () => {
+          document.removeEventListener('visibilitychange', onVisibilityChange);
           dummyAudioEl?.remove();
           dummyAudioEl = null;
         });

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -192,6 +192,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   /** used for aborting pending connections to a LiveKit server */
   private abortController?: AbortController;
 
+  /** used to remove the `devicechange` listener registered in the constructor */
+  private deviceChangeCleanupController?: AbortController;
+
   /** future holding client initiated connection attempt */
   private connectFuture?: Future<void, Error>;
 
@@ -375,6 +378,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
     if (isWeb()) {
       const cleanupController = new AbortController();
+      this.deviceChangeCleanupController = cleanupController;
       let onDeviceChange: () => void;
 
       if (Room.cleanupRegistry) {
@@ -1864,7 +1868,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         window.removeEventListener('beforeunload', this.onPageLeave);
         window.removeEventListener('pagehide', this.onPageLeave);
         window.removeEventListener('freeze', this.onPageLeave);
-        navigator.mediaDevices?.removeEventListener?.('devicechange', this.handleDeviceChange);
+        this.deviceChangeCleanupController?.abort();
       }
     } finally {
       this.setAndEmitConnectionState(ConnectionState.Disconnected);

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -192,8 +192,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   /** used for aborting pending connections to a LiveKit server */
   private abortController?: AbortController;
 
-  /** used to remove the `devicechange` listener registered in the constructor */
-  private deviceChangeCleanupController?: AbortController;
 
   /** future holding client initiated connection attempt */
   private connectFuture?: Future<void, Error>;
@@ -378,7 +376,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
     if (isWeb()) {
       const cleanupController = new AbortController();
-      this.deviceChangeCleanupController = cleanupController;
       let onDeviceChange: () => void;
 
       if (Room.cleanupRegistry) {
@@ -1870,7 +1867,6 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         window.removeEventListener('beforeunload', this.onPageLeave);
         window.removeEventListener('pagehide', this.onPageLeave);
         window.removeEventListener('freeze', this.onPageLeave);
-        this.deviceChangeCleanupController?.abort();
       }
     } finally {
       this.setAndEmitConnectionState(ConnectionState.Disconnected);

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -10,6 +10,8 @@ export default abstract class RemoteTrack<
   /** @internal */
   receiver: RTCRtpReceiver | undefined;
 
+  private mediaStreamAbort?: AbortController;
+
   constructor(
     mediaTrack: MediaStreamTrack,
     sid: string,
@@ -38,11 +40,16 @@ export default abstract class RemoteTrack<
 
   /** @internal */
   setMediaStream(stream: MediaStream) {
+    // Detach the listener bound to any previously set stream so the old
+    // MediaStream (and this track, captured by the handler closure) can be
+    // garbage collected when a new stream replaces it.
+    this.mediaStreamAbort?.abort();
+    this.mediaStreamAbort = new AbortController();
     // this is needed to determine when the track is finished
     this.mediaStream = stream;
     const onRemoveTrack = (event: MediaStreamTrackEvent) => {
       if (event.track === this._mediaStreamTrack) {
-        stream.removeEventListener('removetrack', onRemoveTrack);
+        this.mediaStreamAbort?.abort();
         if (this.receiver && 'playoutDelayHint' in this.receiver) {
           this.receiver.playoutDelayHint = undefined;
         }
@@ -51,7 +58,9 @@ export default abstract class RemoteTrack<
         this.emit(TrackEvent.Ended, this);
       }
     };
-    stream.addEventListener('removetrack', onRemoveTrack);
+    stream.addEventListener('removetrack', onRemoveTrack, {
+      signal: this.mediaStreamAbort.signal,
+    });
   }
 
   start() {

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -296,6 +296,10 @@ export abstract class Track<
       // we only need to re-use a single element
       let shouldCache = true;
       element.pause();
+      // Sever any lingering MediaStream reference before the element sits in
+      // the module-global pool, so a pooled element can never retain a stream
+      // (and its tracks) regardless of how detachTrack left srcObject.
+      element.srcObject = null;
       recycledElements.forEach((e) => {
         if (!e.parentElement) {
           shouldCache = false;

--- a/src/utils/weak-ref-polyfill.ts
+++ b/src/utils/weak-ref-polyfill.ts
@@ -1,0 +1,32 @@
+/**
+ * A `WeakRef`-like reference that falls back to a strong reference on runtime
+ * environments that do not implement `WeakRef`.
+ *
+ * This is primarily useful for breaking reference cycles (so an object can be
+ * garbage collected once no longer referenced elsewhere) while remaining safe
+ * on legacy browsers. On those legacy browsers the fallback reintroduces the
+ * strong reference — and therefore the cycle — which is an acceptable trade-off
+ * since they typically lack the modern APIs these cycles arise from anyway.
+ *
+ * Mirrors the `WeakRef` API: call {@link deref} to retrieve the referenced
+ * value, which returns `undefined` once it has been collected.
+ *
+ * @link https://developer.mozilla.org/en-US/docs/Web/API/WeakRef
+ */
+export class WeakRefPolyfill<T extends object> {
+  private weak?: WeakRef<T>;
+
+  private strong?: T;
+
+  constructor(value: T) {
+    if (typeof WeakRef !== 'undefined') {
+      this.weak = new WeakRef(value);
+    } else {
+      this.strong = value;
+    }
+  }
+
+  deref(): T | undefined {
+    return this.weak ? this.weak.deref() : this.strong;
+  }
+}


### PR DESCRIPTION
Fixes #2008

In the linked issue, it was reported that `Room` was not being garbage collected properly, leading to `Room` instances piling up in memory when a user joins and leaves a room in rapid succession.

The one issue reported was definitely valid - `Room` was not clearing its 'devicechange' event because a different handler was being registered than was being cleaned up. So, I adjusted the 'devicechange' unregistration mechanism to instead use the `cleanupController` added in #1944.

In addition, I found another reference cycle: `Room`.`frameMetadataManager` is a `FrameMetadataManager`, and `FrameMetadataManager`.`room` is a `Room`. To fix this one, I've made some updates to `FrameMetadataManager` to wrap `room` in a `WeakRef`.

With both of these updates, after running 10x connect -> disconnect cycles in a row, there don't look to be any clearly suspicious reference cycles in the heap snapshot:

<img width="1097" height="754" alt="Screenshot 2026-07-13 at 5 36 32 PM" src="https://github.com/user-attachments/assets/c1cd6fa8-5f67-4153-a8af-acddffa4b45a" />
