### PR TITLE
Address data channel thundering herd due to concurrent sendFile(...) calls

### DIFF
--- a/.changeset/metal-lemons-warn.md
+++ b/.changeset/metal-lemons-warn.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix data channel concurrent data stream send race condition

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1743,7 +1743,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         this.waitForBufferedStatusLowResolves.push(resolve);
         if (!this.waitForBufferStatusLowAbortController) {
           this.waitForBufferStatusLowAbortController = new AbortController();
-          dc.addEventListener('bufferedamountlow', () => {
+          dc.addEventListener('bufferedamountlow', async () => {
             while (true) {
               const resolve = this.waitForBufferedStatusLowResolves[0];
               if (!resolve) {
@@ -1758,6 +1758,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
                 break;
               }
               resolve();
+              // Defer to the event loop so any `await dc.send(...)` calls can fire and fill back up
+              // the data channel.
+              await new Promise((r) => setTimeout(r, 0));
               this.waitForBufferedStatusLowResolves.shift();
             }
           }, { signal: this.waitForBufferStatusLowAbortController.signal });

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1715,6 +1715,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
   };
 
+  /** Abort controller which when called will remove the `bufferedamountlow` event on the data channel. */
+  private waitForBufferStatusLowAbortController: AbortController | null = null;
+  /** List of resolve functions which are waiting to be called by {@link waitForBufferStatusLow}.
+    * Note that these will be called in order, validating that the buffer status is still low
+    * between each call. */
+  private waitForBufferedStatusLowResolves: Array<() => void> = [];
   async waitForBufferStatusLow(kind: DataChannelKind) {
     return new TypedPromise<void, UnexpectedConnectionState>(async (resolve, reject) => {
       if (this.isClosed) {
@@ -1728,10 +1734,34 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           reject(new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`));
           return;
         }
+
+        // Proxy along any errors due to the engine closing
         this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
-        dc.addEventListener('bufferedamountlow', () => resolve(), {
-          once: true,
-        });
+
+        // Store resolve so that when the bufferedamountlow event fires, all resolve calls can be
+        // fired in order until the data channel buffer fills up again.
+        this.waitForBufferedStatusLowResolves.push(resolve);
+        if (!this.waitForBufferStatusLowAbortController) {
+          this.waitForBufferStatusLowAbortController = new AbortController();
+          dc.addEventListener('bufferedamountlow', () => {
+            while (true) {
+              const resolve = this.waitForBufferedStatusLowResolves[0];
+              if (!resolve) {
+                this.waitForBufferedStatusLowResolves = [];
+                this.waitForBufferStatusLowAbortController?.abort();
+                this.waitForBufferStatusLowAbortController = null;
+                break;
+              }
+              if (!this.isBufferStatusLow(kind)) {
+                // Buffer status no longer low, bail out and resume once the next bufferedamountlow
+                // event fires again.
+                break;
+              }
+              resolve();
+              this.waitForBufferedStatusLowResolves.shift();
+            }
+          }, { signal: this.waitForBufferStatusLowAbortController.signal });
+        }
       }
     });
   }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1715,58 +1715,58 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
   };
 
-  /** Abort controller which when called will remove the `bufferedamountlow` event on the data channel. */
-  private waitForBufferStatusLowAbortController: AbortController | null = null;
-  /** List of resolve functions which are waiting to be called by {@link waitForBufferStatusLow}.
-    * Note that these will be called in order, validating that the buffer status is still low
-    * between each call. */
-  private waitForBufferedStatusLowResolves: Array<() => void> = [];
+  /** Per-kind lock serializing callers of {@link waitForBufferStatusLow} that have to wait. */
+  private waitForBufferStatusLowLocks = new Map<DataChannelKind, Mutex>();
+
   async waitForBufferStatusLow(kind: DataChannelKind) {
-    return new TypedPromise<void, UnexpectedConnectionState>(async (resolve, reject) => {
-      if (this.isClosed) {
-        reject(new UnexpectedConnectionState('engine closed'));
-      }
-      if (this.isBufferStatusLow(kind)) {
-        resolve();
-      } else {
+    if (this.isClosed) {
+      throw new UnexpectedConnectionState('engine closed');
+    }
+    if (this.isBufferStatusLow(kind)) {
+      return;
+    }
+
+    // Slow path: the buffer is full, so serialize waiters. Only one proceeds per capacity window;
+    // without this, N concurrent senders all observe the bufferedamountlow signal in the same tick
+    // and call dc.send() together, blowing past the SCTP send buffer (see #1995).
+    let lock = this.waitForBufferStatusLowLocks.get(kind);
+    if (!lock) {
+      lock = new Mutex();
+      this.waitForBufferStatusLowLocks.set(kind, lock);
+    }
+    const unlock = await lock.lock();
+    try {
+      await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
+        // Re-check after acquiring the lock - the engine may have closed and the buffer may have
+        // drained while we were queued.
+        if (this.isClosed) {
+          reject(new UnexpectedConnectionState('engine closed'));
+          return;
+        }
+        if (this.isBufferStatusLow(kind)) {
+          resolve();
+          return;
+        }
         const dc = this.dataChannelForKind(kind);
         if (!dc) {
           reject(new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`));
           return;
         }
-
-        // Proxy along any errors due to the engine closing
-        this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
-
-        // Store resolve so that when the bufferedamountlow event fires, all resolve calls can be
-        // fired in order until the data channel buffer fills up again.
-        this.waitForBufferedStatusLowResolves.push(resolve);
-        if (!this.waitForBufferStatusLowAbortController) {
-          this.waitForBufferStatusLowAbortController = new AbortController();
-          dc.addEventListener('bufferedamountlow', async () => {
-            while (true) {
-              const resolve = this.waitForBufferedStatusLowResolves[0];
-              if (!resolve) {
-                this.waitForBufferedStatusLowResolves = [];
-                this.waitForBufferStatusLowAbortController?.abort();
-                this.waitForBufferStatusLowAbortController = null;
-                break;
-              }
-              if (!this.isBufferStatusLow(kind)) {
-                // Buffer status no longer low, bail out and resume once the next bufferedamountlow
-                // event fires again.
-                break;
-              }
-              resolve();
-              // Defer to the event loop so any `await dc.send(...)` calls can fire and fill back up
-              // the data channel.
-              await new Promise((r) => setTimeout(r, 0));
-              this.waitForBufferedStatusLowResolves.shift();
-            }
-          }, { signal: this.waitForBufferStatusLowAbortController.signal });
-        }
-      }
-    });
+        const onBufferedAmountLow = () => resolve();
+        dc.addEventListener('bufferedamountlow', onBufferedAmountLow, { once: true });
+        // Proxy along any errors due to the engine closing.
+        this.bufferStatusLowClosingFuture.promise.catch((e) => {
+          dc.removeEventListener('bufferedamountlow', onBufferedAmountLow);
+          reject(e);
+        });
+      });
+    } finally {
+      // Release only after the caller's synchronous dc.send() has run, so the next waiter reads the
+      // updated bufferedAmount rather than the stale (still-low) value. The caller's continuation is
+      // scheduled when this promise settles; deferring the unlock to a later task lets that send run
+      // first.
+      setTimeout(unlock, 0);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #1995

## Problem

Sending `n` files concurrently over a data stream can result in all of the `sendFile` calls attempting to send their first packet via the reliable data channel at the same time. When this happens, multiple writers can think the buffer status is low at the same time and all call `dc.send(...)`, exhausting the data channel buffer and causing the buffer to overflow (which causes data to get dropped).

## Pre-existing workaround
The reporter of the issue has had success with converting concurrent `sendFile` calls into sequential ones - so `await Promise.all([sendFile(...), sendFile(...), sendFile(...)])` vs `await sendFile(...); await sendFile(...); await sendFile(...);`. The latter works because there's only one data stream actively writing to the data channel at a time, so there's no contention.

## Solution
To address this, I've opted to sequentialize `waitForBufferStatusLow(...)` resolutions when the the data channel is not "low". So what will now happen:
1. `await waitForBufferStatusLow(...)` works as it did before as long as it is in "low status", and by default has no sequentializing semantics.
2. Once `await waitForBufferStatusLow(...)` gets called and the data channel is no longer in low status, then the `resolve` is cached in `waitForBufferedStatusLowResolves`. Once the data channel is no longer in "low status", instead of resolving all promises ASAP (ie, a "thundering herd"), instead resolve them in sequence and verify that the data channel buffer is still in "low status" between resolutions. This way events naturally resolve in the order they were called until the data channel buffer is full again, where they pause until the buffer is no longer full again and so on until the buffer exhausts.

## Demo

<details><summary>Code added to demo app to test this</summary>
<p>

```diff
diff --git a/examples/demo/demo.ts b/examples/demo/demo.ts
index 3471049a..002d744e 100644
--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -168,6 +168,54 @@ const appActions = {
       onProgress: (progress) => console.log('sending file, progress', Math.ceil(progress * 100)),
     });
   },
+  // Reproduces https://github.com/livekit/client-sdk-js/issues/1995 — several large
+  // sendFile() calls fired in parallel without awaiting between them race on the
+  // reliable data channel's buffer-low signal, so the receiver sees truncated files
+  // or the channel closes with "publisher data channel 'RELIABLE' closed unexpectedly".
+  reproduceParallelSendFile: async () => {
+    const lp = currentRoom?.localParticipant;
+    if (!lp) {
+      appendLog('reproduce: not connected to a room');
+      return;
+    }
+    const fileCount = 5;
+    const fileSizeBytes = 15.7 * 1024 * 1024; // ~15.7 MB, matching the issue report
+    appendLog(
+      `reproduce #1995: firing ${fileCount} parallel sendFile() calls of ~${(
+        fileSizeBytes /
+        (1024 * 1024)
+      ).toFixed(1)} MB each (no await between calls)`,
+    );
+
+    const files = Array.from({ length: fileCount }, (_, i) => {
+      // Fill with a per-file byte pattern so the receiver can spot truncation/corruption.
+      const bytes = new Uint8Array(fileSizeBytes);
+      bytes.fill((i + 1) & 0xff);
+      return new File([bytes], `repro-${i + 1}.bin`, { type: 'application/octet-stream' });
+    });
+
+    // Intentionally do NOT await sequentially — this is the buggy usage pattern.
+    const sends = files.map((file, i) =>
+      lp
+        .sendFile(file, {
+          mimeType: file.type,
+          topic: 'files',
+          onProgress: (progress) =>
+            console.log(`reproduce: file ${i + 1} send progress`, Math.ceil(progress * 100)),
+        })
+        .then((info) => appendLog(`reproduce: file ${i + 1} send resolved (streamId ${info.id})`))
+        .catch((err) => appendLog(`reproduce: file ${i + 1} send FAILED: ${err}`)),
+    );
+
+    try {
+      await Promise.all(sends);
+      appendLog(
+        'reproduce #1995: all send promises resolved — check the receiver, files are likely truncated',
+      );
+    } catch (err) {
+      appendLog(`reproduce #1995: a send rejected: ${err}`);
+    }
+  },
   connectWithFormInput: async () => {
     const url = (<HTMLInputElement>$('url')).value;
     const token = (<HTMLInputElement>$('token')).value;
@@ -479,7 +527,17 @@ const appActions = {
         throw err;
       }
       const result = new Blob(byteContents, { type: info.mimeType });
-      appendLog(`Completely received file "${info.name}" from ${participant?.identity}`);
+      const receivedBytes = result.size;
+      const expectedBytes = info.size;
+      const sizeSuffix =
+        expectedBytes != null
+          ? ` (${receivedBytes} / ${expectedBytes} bytes${
+              receivedBytes !== expectedBytes ? ' — TRUNCATED!' : ''
+            })`
+          : ` (${receivedBytes} bytes)`;
+      appendLog(
+        `Completely received file "${info.name}" from ${participant?.identity}${sizeSuffix}`,
+      );
 
       streamReaderAbortController = undefined;
       (<HTMLButtonElement>$('cancel-chat-receive-button')).style.display = 'none';
diff --git a/examples/demo/index.html b/examples/demo/index.html
index 9ec439b5..d8d8a939 100644
--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -190,6 +190,12 @@
               </button>
               <input id="file" type="file" />
               <button onclick="appActions.sendFile()">Send file</button>
+              <button
+                onclick="appActions.reproduceParallelSendFile()"
+                title="Fires several large sendFile() calls in parallel to reproduce https://github.com/livekit/client-sdk-js/issues/1995"
+              >
+                Reproduce #1995 (parallel sendFile)
+              </button>
               <select
                 id="simulate-scenario"
                 class="custom-select"
```

</p>
</details> 

Before, here was the behavior:

https://github.com/user-attachments/assets/e49cf096-adca-42b2-b44e-7b33915b81d1

Now, with this pull request:

https://github.com/user-attachments/assets/82a9d970-f65c-49d1-acfb-7d3286f2f41a

Note the decreased upload speed, because the bandwidth is being split between all file uploads.