### PR TITLE
Add new data channel high / low water mark approach for packet congestion control

### DIFF
--- a/.changeset/data-channel-buffer-range.md
+++ b/.changeset/data-channel-buffer-range.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Fix the reliable data channel dying under concurrent  / multi-packet writes (#1995). Data-channel sends now use two-watermark flow control (fill up to a high-water mark, resume when drained to a low-water mark) and serialize contended senders through a per-kind lock, which prevents the SCTP send buffer from overflowing while keeping throughput saturated for data tracks.

--- a/.changeset/data-channel-buffer-range.md
+++ b/.changeset/data-channel-buffer-range.md
@@ -2,4 +2,4 @@
 "livekit-client": patch
 ---
 
-Fix the reliable data channel dying under concurrent  / multi-packet writes (#1995). Data-channel sends now use two-watermark flow control (fill up to a high-water mark, resume when drained to a low-water mark) and serialize contended senders through a per-kind lock, which prevents the SCTP send buffer from overflowing while keeping throughput saturated for data tracks.
+Fix the reliable data channel dying under concurrent / multi-packet writes (#1995). Data-channel sends now use two-watermark flow control (fill up to a high-water mark, resume when drained to a low-water mark) and serialize contended senders through a per-kind lock, which prevents the SCTP send buffer from overflowing while keeping throughput saturated for data tracks.

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -231,7 +231,7 @@ describe('RTCEngine', () => {
       const send = vi.fn();
       Object.assign(engine as unknown as Record<string, unknown>, {
         ensurePublisherConnected: vi.fn().mockResolvedValue(undefined),
-        waitForBufferHeadroom: vi.fn().mockResolvedValue(undefined),
+        waitForBufferHeadroomWithLock: vi.fn().mockResolvedValue(undefined),
         updateAndEmitDCBufferStatus: vi.fn(),
         dataChannelForKind: vi.fn(() => ({ send })),
         pcManager: {
@@ -322,8 +322,7 @@ describe('RTCEngine', () => {
         },
       });
 
-      // Two messages queued for replay, and a full buffer so the replay parks on
-      // waitForBufferHeadroom before its first send.
+      // Two messages queued for replay, and a full buffer so the XX its first send.
       const replayed1 = new Uint8Array([1]);
       const replayed2 = new Uint8Array([2]);
       const buffer = (
@@ -379,7 +378,7 @@ describe('RTCEngine', () => {
         .reliableMessageBuffer;
       const replayed = new Uint8Array([1]);
       buffer.push({ data: replayed, sequence: 1, sent: true });
-      // Full buffer so replay parks on waitForBufferHeadroom before its first send.
+      // Full buffer so replay parks on waitForBufferHeadroomWithLock before its first send.
       dc.bufferedAmount = 2 * 1024 * 1024;
 
       const replay = (
@@ -540,7 +539,7 @@ describe('RTCEngine', () => {
     });
   });
 
-  describe('waitForBufferHeadroom', () => {
+  describe('waitForBufferHeadroomWithLock', () => {
     it('rejects parked waiters and releases the lock when the data channels are invalidated', async () => {
       const engine = new RTCEngine(roomOptionDefaults);
       const dc = new FakeDataChannel();
@@ -551,7 +550,7 @@ describe('RTCEngine', () => {
 
       // Park a waiter: buffer above the reliable high-water mark, holding the headroom lock.
       dc.bufferedAmount = 2 * 1024 * 1024;
-      const parked = engine.waitForBufferHeadroom(DataChannelKind.RELIABLE);
+      const parked = engine.waitForBufferHeadroomWithLock(DataChannelKind.RELIABLE);
       // Swallow the expected rejection so it can't surface as unhandled before we assert on it.
       parked.catch(() => {});
       await tick();
@@ -566,7 +565,9 @@ describe('RTCEngine', () => {
       // The lock must be free again: a wait against the fresh, drained channel resolves instead
       // of queueing forever behind the stranded waiter.
       dc.bufferedAmount = 0;
-      await expect(engine.waitForBufferHeadroom(DataChannelKind.RELIABLE)).resolves.toBeUndefined();
+      await expect(
+        engine.waitForBufferHeadroomWithLock(DataChannelKind.RELIABLE),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -1,6 +1,6 @@
 import { DataPacket, DataPacket_Kind, UserPacket } from '@livekit/protocol';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { DataPacketBuffer } from '../utils/dataPacketBuffer';
+import type { DataPacketBuffer, DataPacketItem } from '../utils/dataPacketBuffer';
 import RTCEngine, { DataChannelKind } from './RTCEngine';
 import { roomOptionDefaults } from './defaults';
 import { PublishDataError, UnexpectedConnectionState } from './errors';
@@ -326,8 +326,9 @@ describe('RTCEngine', () => {
       // waitForBufferHeadroom before its first send.
       const replayed1 = new Uint8Array([1]);
       const replayed2 = new Uint8Array([2]);
-      const buffer = (engine as unknown as { reliableMessageBuffer: { push: Function } })
-        .reliableMessageBuffer;
+      const buffer = (
+        engine as unknown as { reliableMessageBuffer: { push: (item: DataPacketItem) => void } }
+      ).reliableMessageBuffer;
       buffer.push({ data: replayed1, sequence: 1, sent: true });
       buffer.push({ data: replayed2, sequence: 2, sent: true });
       dc.bufferedAmount = 2 * 1024 * 1024; // above the reliable high-water mark

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -230,7 +230,7 @@ describe('RTCEngine', () => {
       const send = vi.fn();
       Object.assign(engine as unknown as Record<string, unknown>, {
         ensurePublisherConnected: vi.fn().mockResolvedValue(undefined),
-        waitForBufferStatusLow: vi.fn().mockResolvedValue(undefined),
+        waitUntilBelowHighWaterMark: vi.fn().mockResolvedValue(undefined),
         updateAndEmitDCBufferStatus: vi.fn(),
         dataChannelForKind: vi.fn(() => ({ send })),
         pcManager: {

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -298,6 +298,68 @@ describe('RTCEngine', () => {
     });
   });
 
+  describe('resendReliableMessagesForResume', () => {
+    class FakeDataChannel extends EventTarget {
+      bufferedAmount = 0;
+
+      bufferedAmountLowThreshold = 64 * 1024;
+
+      send = vi.fn();
+    }
+
+    const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    it('does not let a concurrent reliable send interleave into the resume replay', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      Object.assign(engine as unknown as Record<string, unknown>, {
+        _isClosed: false,
+        ensurePublisherConnected: vi.fn().mockResolvedValue(undefined),
+        dataChannelForKind: vi.fn(() => dc),
+        pcManager: {
+          getMaxPublisherMessageSize: vi.fn(() => 64 * 1024 - 1),
+        },
+      });
+
+      // Two messages queued for replay, and a full buffer so the replay parks on
+      // waitForBufferHeadroom before its first send.
+      const replayed1 = new Uint8Array([1]);
+      const replayed2 = new Uint8Array([2]);
+      const buffer = (engine as unknown as { reliableMessageBuffer: { push: Function } })
+        .reliableMessageBuffer;
+      buffer.push({ data: replayed1, sequence: 1 });
+      buffer.push({ data: replayed2, sequence: 2 });
+      dc.bufferedAmount = 2 * 1024 * 1024; // above the reliable high-water mark
+
+      const replay = (
+        engine as unknown as { resendReliableMessagesForResume: (seq: number) => Promise<void> }
+      ).resendReliableMessagesForResume(0);
+      await tick();
+
+      // A send racing the replay: its sequence is assigned immediately, but it must not hit the
+      // wire before the replayed (lower-sequence) messages, or receivers discard those as dupes.
+      const concurrentSend = engine.sendDataPacket(
+        new DataPacket({
+          kind: DataPacket_Kind.RELIABLE,
+          value: { case: 'user', value: new UserPacket({ payload: new Uint8Array([3]) }) },
+        }),
+        DataChannelKind.RELIABLE,
+      );
+      await tick();
+
+      // Buffer drains: the replay must finish its whole batch before the concurrent send.
+      dc.bufferedAmount = 0;
+      dc.dispatchEvent(new Event('bufferedamountlow'));
+      await Promise.all([replay, concurrentSend]);
+
+      expect(dc.send).toHaveBeenCalledTimes(3);
+      expect(dc.send.mock.calls[0][0]).toBe(replayed1);
+      expect(dc.send.mock.calls[1][0]).toBe(replayed2);
+      expect(dc.send.mock.calls[2][0]).not.toBe(replayed1);
+      expect(dc.send.mock.calls[2][0]).not.toBe(replayed2);
+    });
+  });
+
   describe('handleDataChannelClose', () => {
     function stubCloseEnv(
       engine: RTCEngine,

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -230,7 +230,7 @@ describe('RTCEngine', () => {
       const send = vi.fn();
       Object.assign(engine as unknown as Record<string, unknown>, {
         ensurePublisherConnected: vi.fn().mockResolvedValue(undefined),
-        waitUntilBelowHighWaterMark: vi.fn().mockResolvedValue(undefined),
+        waitForBufferHeadroom: vi.fn().mockResolvedValue(undefined),
         updateAndEmitDCBufferStatus: vi.fn(),
         dataChannelForKind: vi.fn(() => ({ send })),
         pcManager: {

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -360,6 +360,59 @@ describe('RTCEngine', () => {
       expect(dc.send.mock.calls[2][0]).not.toBe(replayed1);
       expect(dc.send.mock.calls[2][0]).not.toBe(replayed2);
     });
+
+    it('transmits a packet deferred mid-replay instead of marking it sent without sending', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      Object.assign(engine as unknown as Record<string, unknown>, {
+        _isClosed: false,
+        // Reconnect still active: a send arriving during replay takes the deferral path.
+        attemptingReconnect: true,
+        ensurePublisherConnected: vi.fn().mockResolvedValue(undefined),
+        dataChannelForKind: vi.fn(() => dc),
+        pcManager: {
+          getMaxPublisherMessageSize: vi.fn(() => 64 * 1024 - 1),
+        },
+      });
+
+      const buffer = (engine as unknown as { reliableMessageBuffer: DataPacketBuffer })
+        .reliableMessageBuffer;
+      const replayed = new Uint8Array([1]);
+      buffer.push({ data: replayed, sequence: 1, sent: true });
+      // Full buffer so replay parks on waitForBufferHeadroom before its first send.
+      dc.bufferedAmount = 2 * 1024 * 1024;
+
+      const replay = (
+        engine as unknown as { resendReliableMessagesForResume: (seq: number) => Promise<void> }
+      ).resendReliableMessagesForResume(0);
+      await tick();
+
+      // A reliable send arrives while replay is parked; attemptingReconnect defers it into the
+      // buffer as sent:false, after the replay's first drain pass already started.
+      const deferred = new Uint8Array([2]);
+      const deferredSend = engine.sendDataPacket(
+        new DataPacket({
+          kind: DataPacket_Kind.RELIABLE,
+          value: { case: 'user', value: new UserPacket({ payload: deferred }) },
+        }),
+        DataChannelKind.RELIABLE,
+      );
+      await tick();
+
+      dc.bufferedAmount = 0;
+      dc.dispatchEvent(new Event('bufferedamountlow'));
+      await Promise.all([replay, deferredSend]);
+
+      // Pre-fix, replay sends only its snapshot ([replayed]) and blanket-marks the deferred packet
+      // sent without ever transmitting it — one send. The drain loop must transmit both (the
+      // deferred packet is serialized through sendDataPacket, so it's distinct from `replayed`),
+      // leaving nothing unsent for a later align to strand.
+      const sent = dc.send.mock.calls.map(([d]) => d);
+      expect(sent).toHaveLength(2);
+      expect(sent[0]).toBe(replayed);
+      expect(sent[1]).not.toBe(replayed);
+      expect(buffer.getUnsent()).toHaveLength(0);
+    });
   });
 
   describe('reliable sends during teardown windows', () => {

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -1,8 +1,9 @@
 import { DataPacket, DataPacket_Kind, UserPacket } from '@livekit/protocol';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DataPacketBuffer } from '../utils/dataPacketBuffer';
 import RTCEngine, { DataChannelKind } from './RTCEngine';
 import { roomOptionDefaults } from './defaults';
-import { PublishDataError } from './errors';
+import { PublishDataError, UnexpectedConnectionState } from './errors';
 
 describe('RTCEngine', () => {
   const originalRTCRtpSender = window.RTCRtpSender;
@@ -298,17 +299,17 @@ describe('RTCEngine', () => {
     });
   });
 
+  class FakeDataChannel extends EventTarget {
+    bufferedAmount = 0;
+
+    bufferedAmountLowThreshold = 64 * 1024;
+
+    send = vi.fn();
+  }
+
+  const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
   describe('resendReliableMessagesForResume', () => {
-    class FakeDataChannel extends EventTarget {
-      bufferedAmount = 0;
-
-      bufferedAmountLowThreshold = 64 * 1024;
-
-      send = vi.fn();
-    }
-
-    const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
-
     it('does not let a concurrent reliable send interleave into the resume replay', async () => {
       const engine = new RTCEngine(roomOptionDefaults);
       const dc = new FakeDataChannel();
@@ -327,8 +328,8 @@ describe('RTCEngine', () => {
       const replayed2 = new Uint8Array([2]);
       const buffer = (engine as unknown as { reliableMessageBuffer: { push: Function } })
         .reliableMessageBuffer;
-      buffer.push({ data: replayed1, sequence: 1 });
-      buffer.push({ data: replayed2, sequence: 2 });
+      buffer.push({ data: replayed1, sequence: 1, sent: true });
+      buffer.push({ data: replayed2, sequence: 2, sent: true });
       dc.bufferedAmount = 2 * 1024 * 1024; // above the reliable high-water mark
 
       const replay = (
@@ -357,6 +358,161 @@ describe('RTCEngine', () => {
       expect(dc.send.mock.calls[1][0]).toBe(replayed2);
       expect(dc.send.mock.calls[2][0]).not.toBe(replayed1);
       expect(dc.send.mock.calls[2][0]).not.toBe(replayed2);
+    });
+  });
+
+  describe('reliable sends during teardown windows', () => {
+    const makePacket = (byte: number) =>
+      new DataPacket({
+        kind: DataPacket_Kind.RELIABLE,
+        value: { case: 'user', value: new UserPacket({ payload: new Uint8Array([byte]) }) },
+      });
+
+    function stubEngine(engine: RTCEngine, dc: FakeDataChannel) {
+      Object.assign(engine as unknown as Record<string, unknown>, {
+        _isClosed: false,
+        ensurePublisherConnected: vi.fn().mockResolvedValue(undefined),
+        dataChannelForKind: vi.fn(() => dc),
+        pcManager: {
+          getMaxPublisherMessageSize: vi.fn(() => 64 * 1024 - 1),
+        },
+      });
+      return (engine as unknown as { reliableMessageBuffer: DataPacketBuffer })
+        .reliableMessageBuffer;
+    }
+
+    it('resolves and queues the packet for replay when the wait is torn down transiently', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      const buffer = stubEngine(engine, dc);
+
+      // Park the send on a full buffer, then invalidate the channel (reconnect/replacement).
+      dc.bufferedAmount = 2 * 1024 * 1024;
+      const send = engine.sendDataPacket(makePacket(1), DataChannelKind.RELIABLE);
+      await tick();
+      (
+        engine as unknown as { invalidateDataChannelWaiters: (reason: string) => void }
+      ).invalidateDataChannelWaiters('data channels recreated');
+
+      // The send must not surface the teardown — the packet is queued for the resume replay.
+      await expect(send).resolves.toBeUndefined();
+      expect(dc.send).not.toHaveBeenCalled();
+      expect(buffer.length).toBe(1);
+      expect(buffer.getAll()[0].sent).toBe(false);
+
+      // The replay then delivers it.
+      dc.bufferedAmount = 0;
+      await (
+        engine as unknown as { resendReliableMessagesForResume: (seq: number) => Promise<void> }
+      ).resendReliableMessagesForResume(0);
+      expect(dc.send).toHaveBeenCalledTimes(1);
+      expect(buffer.getAll()[0].sent).toBe(true);
+    });
+
+    it('still rejects when the engine is closed while waiting', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      stubEngine(engine, dc);
+
+      dc.bufferedAmount = 2 * 1024 * 1024;
+      const send = engine.sendDataPacket(makePacket(1), DataChannelKind.RELIABLE);
+      await tick();
+      Object.assign(engine as unknown as Record<string, unknown>, { _isClosed: true });
+      (
+        engine as unknown as { invalidateDataChannelWaiters: (reason: string) => void }
+      ).invalidateDataChannelWaiters('engine closed');
+
+      await expect(send).rejects.toBeInstanceOf(UnexpectedConnectionState);
+      expect(dc.send).not.toHaveBeenCalled();
+    });
+
+    it('queues without waiting while a reconnect attempt is in progress', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      const buffer = stubEngine(engine, dc);
+      Object.assign(engine as unknown as Record<string, unknown>, { attemptingReconnect: true });
+
+      // Even with a full buffer, the send resolves immediately instead of parking.
+      dc.bufferedAmount = 2 * 1024 * 1024;
+      await expect(
+        engine.sendDataPacket(makePacket(1), DataChannelKind.RELIABLE),
+      ).resolves.toBeUndefined();
+      expect(dc.send).not.toHaveBeenCalled();
+      expect(buffer.length).toBe(1);
+      expect(buffer.getAll()[0].sent).toBe(false);
+    });
+  });
+
+  describe('sendLossyBytes', () => {
+    it('ensures the publisher is connected before sending (direct data-track path)', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      // The channel only becomes available once the publisher connection has been established —
+      // mirroring the lazily negotiated publisher case that Room's packetAvailable path hits.
+      let connected = false;
+      const ensurePublisherConnected = vi.fn(async () => {
+        connected = true;
+      });
+      Object.assign(engine as unknown as Record<string, unknown>, {
+        _isClosed: false,
+        ensurePublisherConnected,
+        dataChannelForKind: vi.fn(() => (connected ? dc : undefined)),
+      });
+
+      await engine.sendLossyBytes(new Uint8Array([1]), DataChannelKind.DATA_TRACK_LOSSY, 'wait');
+
+      expect(ensurePublisherConnected).toHaveBeenCalledWith(DataChannelKind.DATA_TRACK_LOSSY);
+      expect(dc.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('only counts LOSSY bytes into the byterate stat that tunes the lossy drop threshold', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      Object.assign(engine as unknown as Record<string, unknown>, {
+        _isClosed: false,
+        ensurePublisherConnected: vi.fn().mockResolvedValue(undefined),
+        dataChannelForKind: vi.fn(() => dc),
+      });
+      const stat = () =>
+        (engine as unknown as { lossyDataStatCurrentBytes: number }).lossyDataStatCurrentBytes;
+
+      // Data-track traffic must not move the stat — it would inflate the LOSSY channel's
+      // dynamically tuned drop threshold with traffic that channel never carries.
+      await engine.sendLossyBytes(new Uint8Array(1000), DataChannelKind.DATA_TRACK_LOSSY, 'wait');
+      expect(stat()).toBe(0);
+
+      await engine.sendLossyBytes(new Uint8Array(100), DataChannelKind.LOSSY, 'drop');
+      expect(stat()).toBe(100);
+    });
+  });
+
+  describe('waitForBufferHeadroom', () => {
+    it('rejects parked waiters and releases the lock when the data channels are invalidated', async () => {
+      const engine = new RTCEngine(roomOptionDefaults);
+      const dc = new FakeDataChannel();
+      Object.assign(engine as unknown as Record<string, unknown>, {
+        _isClosed: false,
+        dataChannelForKind: vi.fn(() => dc),
+      });
+
+      // Park a waiter: buffer above the reliable high-water mark, holding the headroom lock.
+      dc.bufferedAmount = 2 * 1024 * 1024;
+      const parked = engine.waitForBufferHeadroom(DataChannelKind.RELIABLE);
+      // Swallow the expected rejection so it can't surface as unhandled before we assert on it.
+      parked.catch(() => {});
+      await tick();
+
+      // The channel object gets abandoned (e.g. createDataChannels on the Safari resume path).
+      (
+        engine as unknown as { invalidateDataChannelWaiters: (reason: string) => void }
+      ).invalidateDataChannelWaiters('data channels recreated');
+
+      await expect(parked).rejects.toBeInstanceOf(UnexpectedConnectionState);
+
+      // The lock must be free again: a wait against the fresh, drained channel resolves instead
+      // of queueing forever behind the stranded waiter.
+      dc.bufferedAmount = 0;
+      await expect(engine.waitForBufferHeadroom(DataChannelKind.RELIABLE)).resolves.toBeUndefined();
     });
   });
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1690,43 +1690,52 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     await this.ensurePublisherConnected(kind);
 
     const dc = this.dataChannelForKind(kind);
-    if (dc) {
-      // Depending on the exact circumstance that data is being sent, either drop or wait for the
-      // buffer to drain below the high-water mark before continuing.
-      switch (bufferStatusFullBehavior) {
-        case 'wait':
-          if (!this.isBelowHighWaterMark(kind)) {
-            await this.waitForBufferHeadroom(kind);
-          }
-          break;
-        case 'drop':
-          // we check against the actual threshold on the DC here, as it is dynamic for the lossy DC
-          if (!this.isBelowLowWaterMark(kind)) {
-            // Drop messages to reduce latency
-            this.lossyDataDropCount += 1;
-            if (this.lossyDataDropCount % 100 === 0) {
-              this.log.warn(
-                `dropping lossy data channel messages, total dropped: ${this.lossyDataDropCount}`,
-              );
+    try {
+      if (dc) {
+        // Depending on the exact circumstance that data is being sent, either drop or wait for the
+        // buffer to drain below the high-water mark before continuing.
+        switch (bufferStatusFullBehavior) {
+          case 'wait':
+            if (!this.isBelowHighWaterMark(kind)) {
+              await this.waitForBufferHeadroom(kind);
             }
-            return;
-          }
-      }
-      if (kind === DataChannelKind.LOSSY) {
-        // The byterate stat tunes the LOSSY channel's dynamic drop threshold; counting data-track
-        // bytes here would inflate it and let the lossy channel buffer far more latency than the
-        // ~100ms the tuning targets.
-        this.lossyDataStatCurrentBytes += bytes.byteLength;
+            break;
+          case 'drop':
+            // we check against the actual threshold on the DC here, as it is dynamic for the lossy DC
+            if (!this.isBelowLowWaterMark(kind)) {
+              // Drop messages to reduce latency
+              this.lossyDataDropCount += 1;
+              if (this.lossyDataDropCount % 100 === 0) {
+                this.log.warn(
+                  `dropping lossy data channel messages, total dropped: ${this.lossyDataDropCount}`,
+                );
+              }
+              return;
+            }
+        }
+        if (kind === DataChannelKind.LOSSY) {
+          // The byterate stat tunes the LOSSY channel's dynamic drop threshold; counting data-track
+          // bytes here would inflate it and let the lossy channel buffer far more latency than the
+          // ~100ms the tuning targets.
+          this.lossyDataStatCurrentBytes += bytes.byteLength;
+        }
+
+        if (this.attemptingReconnect) {
+          return;
+        }
+
+        dc.send(bytes);
       }
 
-      if (this.attemptingReconnect) {
-        return;
+      this.updateAndEmitDCBufferStatus(kind);
+    } catch (error: unknown) {
+      // ensure same surface behaviour as before with missing data channel being silently ignored, just log an error message for clarity
+      if (error instanceof TypeError) {
+        this.log.error(error);
+      } else {
+        throw error;
       }
-
-      dc.send(bytes);
     }
-
-    this.updateAndEmitDCBufferStatus(kind);
   }
 
   private async resendReliableMessagesForResume(lastMessageSeq: number) {
@@ -1865,7 +1874,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
    * batch senders (the resume replay) hold it across all of their sends so no other sender can
    * interleave, and call this per message to respect flow control within the batch.
    */
-  private async waitForBufferHeadroomLocked(kind: DataChannelKind) {
+  private async waitForBufferHeadroomLocked(
+    kind: DataChannelKind,
+  ): Promise<Throws<void, UnexpectedConnectionState | TypeError>> {
     if (this.isClosed) {
       throw new UnexpectedConnectionState('engine closed');
     }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1505,7 +1505,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     }
 
     if (res?.lastMessageSeq) {
-      this.resendReliableMessagesForResume(res.lastMessageSeq);
+      this.resendReliableMessagesForResume(res.lastMessageSeq).catch((error) => {
+        this.log.warn('failed to resend reliable messages after resume', {
+          ...this.logContext,
+          error,
+        });
+      });
     }
 
     // resume success
@@ -1685,10 +1690,19 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     const dc = this.dataChannelForKind(DataChannelKind.RELIABLE);
     if (dc) {
       this.reliableMessageBuffer.popToSequence(lastMessageSeq);
-      for (const msg of this.reliableMessageBuffer.getAll()) {
-        // Respect flow control on resume too, so a large resend doesn't overflow the send buffer.
-        await this.waitForBufferHeadroom(DataChannelKind.RELIABLE);
-        dc.send(msg.data);
+      // Hold the headroom lock across the whole replay. Releasing it between messages would let a
+      // concurrent send — whose (newer) sequence was already assigned in sendDataPacket before it
+      // queued on the lock — hit the wire mid-replay, and receivers would then discard the
+      // remaining lower-sequence resent messages as duplicates.
+      const unlock = await this.lockBufferHeadroom(DataChannelKind.RELIABLE);
+      try {
+        for (const msg of this.reliableMessageBuffer.getAll()) {
+          // Respect flow control on resume too, so a large resend doesn't overflow the send buffer.
+          await this.waitForBufferHeadroomLocked(DataChannelKind.RELIABLE);
+          dc.send(msg.data);
+        }
+      } finally {
+        unlock();
       }
     }
     this.updateAndEmitDCBufferStatus(DataChannelKind.RELIABLE);
@@ -1742,6 +1756,16 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** Per-kind lock serializing senders that have to wait for the buffer to drain. */
   private waitForBufferHeadroomLocks = new Map<DataChannelKind, Mutex>();
 
+  /** Acquires the per-kind headroom lock, resolving with the unlock function. */
+  private lockBufferHeadroom(kind: DataChannelKind): Promise<() => void> {
+    let lock = this.waitForBufferHeadroomLocks.get(kind);
+    if (!lock) {
+      lock = new Mutex();
+      this.waitForBufferHeadroomLocks.set(kind, lock);
+    }
+    return lock.lock();
+  }
+
   /**
    * Resolves once the caller may send on the `kind` channel: immediately while the send buffer is
    * at or below its high-water mark, otherwise once the buffer has drained to the low-water mark
@@ -1751,45 +1775,49 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
    * closed/buffer checks run inside the lock so queued callers proceed in FIFO order.
    */
   async waitForBufferHeadroom(kind: DataChannelKind) {
-    let lock = this.waitForBufferHeadroomLocks.get(kind);
-    if (!lock) {
-      lock = new Mutex();
-      this.waitForBufferHeadroomLocks.set(kind, lock);
-    }
-    const unlock = await lock.lock();
+    const unlock = await this.lockBufferHeadroom(kind);
     try {
-      if (this.isClosed) {
-        throw new UnexpectedConnectionState('engine closed');
-      }
-      if (this.isBelowHighWaterMark(kind)) {
-        return;
-      }
-      const dc = this.dataChannelForKind(kind);
-      if (!dc) {
-        throw new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`);
-      }
-      await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
-        const onBufferedAmountLow = () => {
-          cleanup();
-          resolve();
-        };
-        const onDCClose = () => {
-          cleanup();
-          reject(
-            new UnexpectedConnectionState(`DataChannel ${kind} closed while draining the buffer`),
-          );
-        };
-        const cleanup = () => {
-          dc.removeEventListener('bufferedamountlow', onBufferedAmountLow);
-          dc.removeEventListener('close', onDCClose);
-        };
-        dc.addEventListener('bufferedamountlow', onBufferedAmountLow);
-        // Proxy along any error caused by the data channel closing while we wait.
-        dc.addEventListener('close', onDCClose);
-      });
+      await this.waitForBufferHeadroomLocked(kind);
     } finally {
       unlock();
     }
+  }
+
+  /**
+   * Core wait of {@link waitForBufferHeadroom}. The caller must hold the kind's headroom lock —
+   * batch senders (the resume replay) hold it across all of their sends so no other sender can
+   * interleave, and call this per message to respect flow control within the batch.
+   */
+  private async waitForBufferHeadroomLocked(kind: DataChannelKind) {
+    if (this.isClosed) {
+      throw new UnexpectedConnectionState('engine closed');
+    }
+    if (this.isBelowHighWaterMark(kind)) {
+      return;
+    }
+    const dc = this.dataChannelForKind(kind);
+    if (!dc) {
+      throw new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`);
+    }
+    await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
+      const onBufferedAmountLow = () => {
+        cleanup();
+        resolve();
+      };
+      const onDCClose = () => {
+        cleanup();
+        reject(
+          new UnexpectedConnectionState(`DataChannel ${kind} closed while draining the buffer`),
+        );
+      };
+      const cleanup = () => {
+        dc.removeEventListener('bufferedamountlow', onBufferedAmountLow);
+        dc.removeEventListener('close', onDCClose);
+      };
+      dc.addEventListener('bufferedamountlow', onBufferedAmountLow);
+      // Proxy along any error caused by the data channel closing while we wait.
+      dc.addEventListener('close', onDCClose);
+    });
   }
 
   /**

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1829,29 +1829,29 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   private waitForBufferHeadroomLocks = new Map<DataChannelKind, Mutex>();
 
   /**
-   * Per-kind epoch for headroom waiters: aborted whenever a kind's channel object stops being
-   * current (replaced by createDataChannels or torn down by cleanupPeerConnections). A waiter is
-   * parked on the channel object it captured at wait entry; if that object is abandoned its
-   * events may never fire again, so the abort is what rejects the waiter and releases the
+   * Per-kind AbortController that cancels parked headroom waiters whenever a kind's channel object
+   * stops being current (replaced by createDataChannels or torn down by cleanupPeerConnections). A
+   * waiter is parked on the channel object it captured at wait entry; if that object is abandoned
+   * its events may never fire again, so the abort is what rejects the waiter and releases the
    * headroom lock instead of stranding every future sender behind it.
    */
-  private dataChannelEpochs = new Map<DataChannelKind, AbortController>();
+  private waiterAbortControllers = new Map<DataChannelKind, AbortController>();
 
-  private dataChannelEpochSignal(kind: DataChannelKind): AbortSignal {
-    let controller = this.dataChannelEpochs.get(kind);
+  private waiterAbortSignal(kind: DataChannelKind): AbortSignal {
+    let controller = this.waiterAbortControllers.get(kind);
     if (!controller) {
       controller = new AbortController();
-      this.dataChannelEpochs.set(kind, controller);
+      this.waiterAbortControllers.set(kind, controller);
     }
     return controller.signal;
   }
 
-  /** Rejects all parked headroom waiters (all kinds) and starts a fresh epoch. */
+  /** Rejects all parked headroom waiters (all kinds); the next waiter gets a fresh controller. */
   private invalidateDataChannelWaiters(reason: string) {
-    for (const controller of this.dataChannelEpochs.values()) {
+    for (const controller of this.waiterAbortControllers.values()) {
       controller.abort(reason);
     }
-    this.dataChannelEpochs.clear();
+    this.waiterAbortControllers.clear();
   }
 
   /** Acquires the per-kind headroom lock, resolving with the unlock function. */
@@ -1903,7 +1903,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (!dc) {
       throw new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`);
     }
-    const epochSignal = this.dataChannelEpochSignal(kind);
+    const abortSignal = this.waiterAbortSignal(kind);
     await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
       const onBufferedAmountLow = () => {
         cleanup();
@@ -1915,7 +1915,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           new UnexpectedConnectionState(`DataChannel ${kind} closed while draining the buffer`),
         );
       };
-      const onEpochAbort = () => {
+      const onAbort = () => {
         cleanup();
         reject(
           new UnexpectedConnectionState(
@@ -1926,18 +1926,18 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       const cleanup = () => {
         dc.removeEventListener('bufferedamountlow', onBufferedAmountLow);
         dc.removeEventListener('close', onDCClose);
-        epochSignal.removeEventListener('abort', onEpochAbort);
+        abortSignal.removeEventListener('abort', onAbort);
       };
-      if (epochSignal.aborted) {
-        onEpochAbort();
+      if (abortSignal.aborted) {
+        onAbort();
         return;
       }
       dc.addEventListener('bufferedamountlow', onBufferedAmountLow);
       // Proxy along any error caused by the data channel closing while we wait.
       dc.addEventListener('close', onDCClose);
       // The channel object we're parked on can be abandoned without ever firing another event
-      // (e.g. createDataChannels replacing it); the epoch abort is our way out.
-      epochSignal.addEventListener('abort', onEpochAbort);
+      // (e.g. createDataChannels replacing it); the abort is our way out.
+      abortSignal.addEventListener('abort', onAbort);
     });
   }
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -115,10 +115,10 @@ const reliabeReceiveStateTTL = 30_000;
 // The gap between the marks keeps the SCTP send buffer saturated while we refill, so throughput
 // isn't starved, while the high-water mark bounds the buffer well below the level that would abort
 // the channel (see livekit/client-sdk-js#1995).
-const reliableDataChannelLowWaterMark = 64 * 1024;
-const reliableDataChannelHighWaterMark = 1024 * 1024;
-const lossyDataChannelLowWaterMark = 8 * 1024;
-const lossyDataChannelHighWaterMark = 256 * 1024;
+const reliableDataChannelWaterMarkLow = 64 * 1024;
+const reliableDataChannelWaterMarkHigh = 1024 * 1024;
+const lossyDataChannelWaterMarkLow = 8 * 1024;
+const lossyDataChannelWaterMarkHigh = 256 * 1024;
 
 const initialMediaSectionsAudio = 3;
 const initialMediaSectionsVideo = 3;
@@ -137,18 +137,17 @@ export enum DataChannelKind {
   DATA_TRACK_LOSSY = 2,
 }
 
-// Water marks for the two-watermark flow control. Only defined for the reliable and data-track
-// channels; the plain lossy channel keeps its adaptive single threshold and never consults these.
+// Water marks for the two-watermark flow control
 function dataChannelLowWaterMark(kind: DataChannelKind): number {
   return kind === DataChannelKind.RELIABLE
-    ? reliableDataChannelLowWaterMark
-    : lossyDataChannelLowWaterMark;
+    ? reliableDataChannelWaterMarkLow
+    : lossyDataChannelWaterMarkLow;
 }
 
 function dataChannelHighWaterMark(kind: DataChannelKind): number {
   return kind === DataChannelKind.RELIABLE
-    ? reliableDataChannelHighWaterMark
-    : lossyDataChannelHighWaterMark;
+    ? reliableDataChannelWaterMarkHigh
+    : lossyDataChannelWaterMarkHigh;
 }
 
 // Default data-channel max message size (bytes), used when the remote SDP
@@ -967,8 +966,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         // control buffered latency to ~100ms
         const threshold = this.lossyDataStatByterate / 10;
         dc.bufferedAmountLowThreshold = Math.min(
-          Math.max(threshold, lossyDataChannelLowWaterMark),
-          lossyDataChannelHighWaterMark,
+          Math.max(threshold, lossyDataChannelWaterMarkLow),
+          lossyDataChannelWaterMarkHigh,
         );
       }
     }, 1000);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -109,8 +109,22 @@ const dataTrackDataChannel = '_data_track';
 const minReconnectWait = 2 * 1000;
 const leaveReconnect = 'leave-reconnect';
 const reliabeReceiveStateTTL = 30_000;
+
+// Adaptive threshold bounds for the (unchanged) lossy data channel; see the interval in
+// createDataChannels that tunes lossyDC.bufferedAmountLowThreshold to control buffered latency.
 const lossyDataChannelBufferThresholdMin = 8 * 1024;
 const lossyDataChannelBufferThresholdMax = 256 * 1024;
+
+// Two-watermark flow control for the reliable and data-track channels. Senders fill the buffer
+// freely up to the high-water mark; once it's exceeded they block until the browser's
+// `bufferedamountlow` event (which we arm at the low-water mark) signals the buffer has drained.
+// The gap between the marks keeps the SCTP send buffer saturated while we refill, so throughput
+// isn't starved, while the high-water mark bounds the buffer well below the level that would abort
+// the channel (see livekit/client-sdk-js#1995).
+const reliableDataChannelLowWaterMark = 64 * 1024;
+const reliableDataChannelHighWaterMark = 1024 * 1024;
+const lossyDataChannelLowWaterMark = 8 * 1024;
+const lossyDataChannelHighWaterMark = 256 * 1024;
 
 const initialMediaSectionsAudio = 3;
 const initialMediaSectionsVideo = 3;
@@ -127,6 +141,20 @@ export enum DataChannelKind {
   RELIABLE = DataPacket_Kind.RELIABLE,
   LOSSY = DataPacket_Kind.LOSSY,
   DATA_TRACK_LOSSY = 2,
+}
+
+// Water marks for the two-watermark flow control. Only defined for the reliable and data-track
+// channels; the plain lossy channel keeps its adaptive single threshold and never consults these.
+function dataChannelLowWaterMark(kind: DataChannelKind): number {
+  return kind === DataChannelKind.RELIABLE
+    ? reliableDataChannelLowWaterMark
+    : lossyDataChannelLowWaterMark;
+}
+
+function dataChannelHighWaterMark(kind: DataChannelKind): number {
+  return kind === DataChannelKind.RELIABLE
+    ? reliableDataChannelHighWaterMark
+    : lossyDataChannelHighWaterMark;
 }
 
 // Default data-channel max message size (bytes), used when the remote SDP
@@ -302,7 +330,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.bufferStatusLowClosingFuture.reject?.(new UnexpectedConnectionState('engine closed'));
     });
     // Swallow the rejection at the source so it doesn't surface as an unhandled promise rejection
-    // when no waitForBufferStatusLow callers are attached.
+    // when no waitUntilBelowHighWaterMark callers are attached.
     this.bufferStatusLowClosingFuture.promise.catch(() => {});
   }
 
@@ -930,10 +958,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.reliableDC.onclose = this.handleDataChannelClose(DataChannelKind.RELIABLE);
     this.dataTrackDC.onclose = this.handleDataChannelClose(DataChannelKind.DATA_TRACK_LOSSY);
 
-    // set up dc buffer threshold, set to 64kB (otherwise 0 by default)
-    this.lossyDC.bufferedAmountLowThreshold = 65535;
-    this.reliableDC.bufferedAmountLowThreshold = 65535;
-    this.dataTrackDC.bufferedAmountLowThreshold = 65535;
+    // set up dc buffer threshold - if this is not set, it will default to 0
+    this.lossyDC.bufferedAmountLowThreshold = dataChannelLowWaterMark(DataChannelKind.LOSSY);
+    this.reliableDC.bufferedAmountLowThreshold = reliableDataChannelLowWaterMark;
+    this.dataTrackDC.bufferedAmountLowThreshold = lossyDataChannelLowWaterMark;
 
     // handle buffer amount low events
     this.lossyDC.onbufferedamountlow = () => this.handleBufferedAmountLow(DataChannelKind.LOSSY);
@@ -952,8 +980,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         // control buffered latency to ~100ms
         const threshold = this.lossyDataStatByterate / 10;
         dc.bufferedAmountLowThreshold = Math.min(
-          Math.max(threshold, lossyDataChannelBufferThresholdMin),
-          lossyDataChannelBufferThresholdMax,
+          Math.max(threshold, lossyDataChannelLowWaterMark),
+          lossyDataChannelHighWaterMark,
         );
       }
     }, 1000);
@@ -1624,7 +1652,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       case DataChannelKind.RELIABLE:
         const dc = this.dataChannelForKind(kind);
         if (dc) {
-          await this.waitForBufferStatusLow(kind);
+          await this.waitUntilBelowHighWaterMark(kind);
           this.reliableMessageBuffer.push({ data: msg, sequence: packet.sequence });
 
           if (this.attemptingReconnect) {
@@ -1650,12 +1678,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     const dc = this.dataChannelForKind(kind);
     if (dc) {
-      if (!this.isBufferStatusLow(kind)) {
+      if (!this.isBelowHighWaterMark(kind)) {
         // Depending on the exact circumstance that data is being sent, either drop or wait for the
-        // buffer status to not be low before continuing.
+        // buffer to drain below the high-water mark before continuing.
         switch (bufferStatusLowBehavior) {
           case 'wait':
-            await this.waitForBufferStatusLow(kind);
+            await this.waitUntilBelowHighWaterMark(kind);
             break;
           case 'drop':
             // this.log.warn(`dropping lossy data channel message`, this.logContext);
@@ -1686,9 +1714,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     const dc = this.dataChannelForKind(DataChannelKind.RELIABLE);
     if (dc) {
       this.reliableMessageBuffer.popToSequence(lastMessageSeq);
-      this.reliableMessageBuffer.getAll().forEach((msg) => {
+      for (const msg of this.reliableMessageBuffer.getAll()) {
+        // Respect flow control on resume too, so a large resend doesn't overflow the send buffer.
+        await this.waitUntilBelowHighWaterMark(DataChannelKind.RELIABLE);
         dc.send(msg.data);
-      });
+      }
     }
     this.updateAndEmitDCBufferStatus(DataChannelKind.RELIABLE);
   }
@@ -1701,39 +1731,76 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       }
     }
 
-    const status = this.isBufferStatusLow(kind);
+    const status = this.isBelowLowWaterMark(kind);
     if (typeof status !== 'undefined' && status !== this.dcBufferStatus.get(kind)) {
       this.dcBufferStatus.set(kind, status);
       this.emit(EngineEvent.DCBufferStatusChanged, status, kind);
     }
   };
 
-  private isBufferStatusLow = (kind: DataChannelKind): boolean | undefined => {
+  /**
+   * Whether the send buffer has room to accept more data (the send gate). Senders proceed while
+   * this is true and block once it goes false.
+   */
+  private isBelowHighWaterMark = (kind: DataChannelKind): boolean | undefined => {
     const dc = this.dataChannelForKind(kind);
-    if (dc) {
-      return dc.bufferedAmount <= dc.bufferedAmountLowThreshold;
+    if (!dc) {
+      return;
     }
+    return dc.bufferedAmount <= dataChannelHighWaterMark(kind);
   };
 
-  async waitForBufferStatusLow(kind: DataChannelKind) {
-    return new TypedPromise<void, UnexpectedConnectionState>(async (resolve, reject) => {
+  /**
+   * Whether the send buffer has drained to its low-water mark. Drives the public
+   * {@link EngineEvent.DCBufferStatusChanged} event.
+   */
+  private isBelowLowWaterMark = (kind: DataChannelKind): boolean | undefined => {
+    const dc = this.dataChannelForKind(kind);
+    if (!dc) {
+      return;
+    }
+    return dc.bufferedAmount <= dataChannelLowWaterMark(kind);
+  };
+
+  /** Per-kind lock serializing senders that have to wait for the buffer to drain. */
+  private waitUntilBelowHighWaterMarkLocks = new Map<DataChannelKind, Mutex>();
+
+  /**
+   * Resolves once the send buffer for `kind` is at or below its high-water mark, blocking the
+   * caller otherwise. Callers are serialized through a per-kind mutex so that, when the buffer
+   * drains, they refill it one at a time (up to the high-water mark) rather than all sending at
+   * once and overflowing the SCTP send buffer (see livekit/client-sdk-js#1995). The closed/buffer
+   * checks run inside the lock so queued callers proceed in FIFO order.
+   */
+  async waitUntilBelowHighWaterMark(kind: DataChannelKind) {
+    let lock = this.waitUntilBelowHighWaterMarkLocks.get(kind);
+    if (!lock) {
+      lock = new Mutex();
+      this.waitUntilBelowHighWaterMarkLocks.set(kind, lock);
+    }
+    const unlock = await lock.lock();
+    try {
       if (this.isClosed) {
-        reject(new UnexpectedConnectionState('engine closed'));
+        throw new UnexpectedConnectionState('engine closed');
       }
-      if (this.isBufferStatusLow(kind)) {
-        resolve();
-      } else {
-        const dc = this.dataChannelForKind(kind);
-        if (!dc) {
-          reject(new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`));
-          return;
-        }
-        this.bufferStatusLowClosingFuture.promise.catch((e) => reject(e));
-        dc.addEventListener('bufferedamountlow', () => resolve(), {
-          once: true,
+      if (this.isBelowHighWaterMark(kind)) {
+        return;
+      }
+      const dc = this.dataChannelForKind(kind);
+      if (!dc) {
+        throw new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`);
+      }
+      await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
+        dc.addEventListener('bufferedamountlow', resolve, { once: true });
+        // Proxy along any error caused by the engine closing while we wait.
+        this.bufferStatusLowClosingFuture.promise.catch((e) => {
+          dc.removeEventListener('bufferedamountlow', resolve);
+          reject(e);
         });
-      }
-    });
+      });
+    } finally {
+      unlock();
+    }
   }
 
   /**

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1647,7 +1647,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         const dc = this.dataChannelForKind(kind);
         if (dc) {
           try {
-            await this.waitForBufferHeadroom(kind);
+            await this.waitForBufferHeadroomWithLock(kind);
           } catch (error) {
             if (this.isClosed) {
               // No replay is coming after an engine close — surface the failure.
@@ -1697,7 +1697,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         switch (bufferStatusFullBehavior) {
           case 'wait':
             if (!this.isBelowHighWaterMark(kind)) {
-              await this.waitForBufferHeadroom(kind);
+              await this.waitForBufferHeadroomWithLock(kind);
             }
             break;
           case 'drop':
@@ -1747,7 +1747,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       // concurrent send — whose (newer) sequence was already assigned in sendDataPacket before it
       // queued on the lock — hit the wire mid-replay, and receivers would then discard the
       // remaining lower-sequence resent messages as duplicates.
-      const unlock = await this.lockBufferHeadroom(DataChannelKind.RELIABLE);
+      const unlock = await this.getBufferHeadroomLock(DataChannelKind.RELIABLE).lock();
       try {
         // Everything left after the ack cutoff must be re-handed to the current channel.
         this.reliableMessageBuffer.markAllUnsent();
@@ -1764,7 +1764,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         ) {
           for (const item of batch) {
             // Respect flow control on resume too, so a large resend doesn't overflow the buffer.
-            await this.waitForBufferHeadroomLocked(DataChannelKind.RELIABLE);
+            // We already hold the lock across the whole replay, so use the lock-free wait.
+            await this.waitForBufferHeadroomWithoutLock(DataChannelKind.RELIABLE);
             dc.send(item.data);
             this.reliableMessageBuffer.markSent(item);
           }
@@ -1854,38 +1855,42 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   }
 
   /** Acquires the per-kind headroom lock, resolving with the unlock function. */
-  private lockBufferHeadroom(kind: DataChannelKind): Promise<() => void> {
+  private getBufferHeadroomLock(kind: DataChannelKind): Mutex {
     let lock = this.waitForBufferHeadroomLocks.get(kind);
     if (!lock) {
       lock = new Mutex();
       this.waitForBufferHeadroomLocks.set(kind, lock);
     }
-    return lock.lock();
+    return lock;
   }
 
   /**
-   * Resolves once the caller may send on the `kind` channel: immediately while the send buffer is
-   * at or below its high-water mark, otherwise once the buffer has drained to the low-water mark
-   * (the `bufferedamountlow` event). Callers are serialized through a per-kind mutex so that, when
-   * the buffer drains, they refill it one at a time (up to the high-water mark) rather than all
-   * sending at once and overflowing the SCTP send buffer (see livekit/client-sdk-js#1995). The
-   * closed/buffer checks run inside the lock so queued callers proceed in FIFO order.
+   * Acquires the `kind` headroom lock, waits until the send buffer has room, then releases. The
+   * common single-send entry point. Callers that need to hold the lock across several sends (the
+   * resume replay) acquire it via {@link getBufferHeadroomLock} and call
+   * {@link waitForBufferHeadroomWithoutLock} per message instead.
    */
-  async waitForBufferHeadroom(kind: DataChannelKind) {
-    const unlock = await this.lockBufferHeadroom(kind);
+  async waitForBufferHeadroomWithLock(kind: DataChannelKind) {
+    const unlock = await this.getBufferHeadroomLock(kind).lock();
     try {
-      await this.waitForBufferHeadroomLocked(kind);
+      await this.waitForBufferHeadroomWithoutLock(kind);
     } finally {
       unlock();
     }
   }
 
   /**
-   * Core wait of {@link waitForBufferHeadroom}. The caller must hold the kind's headroom lock —
-   * batch senders (the resume replay) hold it across all of their sends so no other sender can
-   * interleave, and call this per message to respect flow control within the batch.
+   * Waits until the send buffer for `kind` is at or below the high-water mark (draining, if
+   * needed, via the `bufferedamountlow` event). Does no locking of its own — the caller must
+   * already hold the kind's headroom lock (via {@link getBufferHeadroomLock}). The resume replay
+   * holds the lock across its whole batch and calls this per message so no other sender can
+   * interleave; the single-send path goes through {@link waitForBufferHeadroomWithLock}.
+   *
+   * Serializing through the per-kind lock means that, once the buffer drains, queued callers
+   * refill it one at a time (up to the high-water mark) rather than all at once and overflowing
+   * the SCTP send buffer (see livekit/client-sdk-js#1995).
    */
-  private async waitForBufferHeadroomLocked(
+  private async waitForBufferHeadroomWithoutLock(
     kind: DataChannelKind,
   ): Promise<Throws<void, UnexpectedConnectionState | TypeError>> {
     if (this.isClosed) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1671,8 +1671,8 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           }
           break;
         case 'drop':
-          if (!this.isBelowLowWaterMark(kind)) {
-            // this.log.warn(`dropping lossy data channel message`, this.logContext);
+          // we check against the actual threshold on the DC here, as it is dynamic for the lossy DC
+          if (dc.bufferedAmount > dc.bufferedAmountLowThreshold) {
             // Drop messages to reduce latency
             this.lossyDataDropCount += 1;
             if (this.lossyDataDropCount % 100 === 0) {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -110,11 +110,6 @@ const minReconnectWait = 2 * 1000;
 const leaveReconnect = 'leave-reconnect';
 const reliabeReceiveStateTTL = 30_000;
 
-// Adaptive threshold bounds for the (unchanged) lossy data channel; see the interval in
-// createDataChannels that tunes lossyDC.bufferedAmountLowThreshold to control buffered latency.
-const lossyDataChannelBufferThresholdMin = 8 * 1024;
-const lossyDataChannelBufferThresholdMax = 256 * 1024;
-
 // Two-watermark flow control for the reliable and data-track channels. Senders fill the buffer
 // freely up to the high-water mark; once it's exceeded they block until the browser's
 // `bufferedamountlow` event (which we arm at the low-water mark) signals the buffer has drained.
@@ -1791,10 +1786,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         throw new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`);
       }
       await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
-        dc.addEventListener('bufferedamountlow', resolve, { once: true });
+        const onBufferedAmountLow = () => resolve();
+        dc.addEventListener('bufferedamountlow', onBufferedAmountLow, { once: true });
         // Proxy along any error caused by the engine closing while we wait.
         this.bufferStatusLowClosingFuture.promise.catch((e) => {
-          dc.removeEventListener('bufferedamountlow', resolve);
+          dc.removeEventListener('bufferedamountlow', onBufferedAmountLow);
           reject(e);
         });
       });

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1749,15 +1749,26 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       // remaining lower-sequence resent messages as duplicates.
       const unlock = await this.lockBufferHeadroom(DataChannelKind.RELIABLE);
       try {
-        for (const msg of this.reliableMessageBuffer.getAll()) {
-          // Respect flow control on resume too, so a large resend doesn't overflow the send buffer.
-          await this.waitForBufferHeadroomLocked(DataChannelKind.RELIABLE);
-          dc.send(msg.data);
+        // Everything left after the ack cutoff must be re-handed to the current channel.
+        this.reliableMessageBuffer.markAllUnsent();
+        // Drain in passes, re-scanning the live buffer each time: a send that arrives (deferred,
+        // sent:false) during our own awaits appends after this pass started, so we pick it up on
+        // the next one. We mark each packet only once we've actually handed it to the channel — a
+        // blanket "mark all sent" would flip such a late arrival to sent without transmitting it,
+        // and a later alignBufferedAmount would then drop it for good. If the loop throws
+        // mid-drain, unsent entries keep their flag and the next replay picks them up.
+        for (
+          let batch = this.reliableMessageBuffer.getUnsent();
+          batch.length > 0;
+          batch = this.reliableMessageBuffer.getUnsent()
+        ) {
+          for (const item of batch) {
+            // Respect flow control on resume too, so a large resend doesn't overflow the buffer.
+            await this.waitForBufferHeadroomLocked(DataChannelKind.RELIABLE);
+            dc.send(item.data);
+            this.reliableMessageBuffer.markSent(item);
+          }
         }
-        // Everything queued (including packets buffered unsent during the reconnect window) has
-        // been handed to the channel. If the loop throws instead, entries keep their unsent flag
-        // and the next replay picks them up — receivers dedupe any that did make it out.
-        this.reliableMessageBuffer.markAllSent();
       } finally {
         unlock();
       }

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -458,6 +458,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   }
 
   async cleanupPeerConnections() {
+    // Reject parked headroom waiters up front: closing the peer connection is allowed (per spec)
+    // to transition data channels to 'closed' without firing events, which would otherwise strand
+    // a waiter holding the headroom lock.
+    this.invalidateDataChannelWaiters('peer connections cleaned up');
+
     const dcCleanup = (dc: RTCDataChannel | undefined) => {
       if (!dc) {
         return;
@@ -884,6 +889,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (!this.pcManager) {
       return;
     }
+
+    // Waiters parked on the old channel objects would never see another event from them once they
+    // are replaced below — reject them so the headroom lock is released and queued senders
+    // re-check against the new channels.
+    this.invalidateDataChannelWaiters('data channels recreated');
 
     // clear old data channel callbacks if recreate
     if (this.lossyDC) {
@@ -1626,21 +1636,43 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       case DataChannelKind.DATA_TRACK_LOSSY:
         return this.sendLossyBytes(msg, kind);
 
-      case DataChannelKind.RELIABLE:
+      case DataChannelKind.RELIABLE: {
+        if (this.attemptingReconnect) {
+          // A reconnect is already underway — queue for the resume replay instead of parking on a
+          // channel that is being torn down. The send resolves; delivery is deferred to the replay.
+          this.reliableMessageBuffer.push({ data: msg, sequence: packet.sequence, sent: false });
+          return;
+        }
+
         const dc = this.dataChannelForKind(kind);
         if (dc) {
-          await this.waitForBufferHeadroom(kind);
-          this.reliableMessageBuffer.push({ data: msg, sequence: packet.sequence });
-
-          if (this.attemptingReconnect) {
+          try {
+            await this.waitForBufferHeadroom(kind);
+          } catch (error) {
+            if (this.isClosed) {
+              // No replay is coming after an engine close — surface the failure.
+              throw error;
+            }
+            // Transient teardown (the channel closed or was replaced while we waited): the
+            // reliable channel promises delivery across resume, so queue the packet for the
+            // replay instead of rejecting a send the app can't meaningfully retry.
+            this.reliableMessageBuffer.push({ data: msg, sequence: packet.sequence, sent: false });
             return;
           }
 
+          if (this.attemptingReconnect) {
+            // A reconnect began while we waited for headroom — same deal as above.
+            this.reliableMessageBuffer.push({ data: msg, sequence: packet.sequence, sent: false });
+            return;
+          }
+
+          this.reliableMessageBuffer.push({ data: msg, sequence: packet.sequence, sent: true });
           dc.send(msg);
         }
 
         this.updateAndEmitDCBufferStatus(kind);
         break;
+      }
     }
   }
 
@@ -1650,6 +1682,13 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     kind: Exclude<DataChannelKind, DataChannelKind.RELIABLE>,
     bufferStatusFullBehavior: 'drop' | 'wait' = 'drop',
   ) {
+    // Make sure we do have a data connection. This matters most for the direct data-track path
+    // (Room's packetAvailable handler), which doesn't go through sendDataPacket: it both waits for
+    // the channel to be open and — on lazily negotiated publisher connections — is what kicks the
+    // negotiation off in the first place. The call is memoized, so the steady-state cost is one
+    // await on an already-resolved promise.
+    await this.ensurePublisherConnected(kind);
+
     const dc = this.dataChannelForKind(kind);
     if (dc) {
       // Depending on the exact circumstance that data is being sent, either drop or wait for the
@@ -1673,7 +1712,12 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
             return;
           }
       }
-      this.lossyDataStatCurrentBytes += bytes.byteLength;
+      if (kind === DataChannelKind.LOSSY) {
+        // The byterate stat tunes the LOSSY channel's dynamic drop threshold; counting data-track
+        // bytes here would inflate it and let the lossy channel buffer far more latency than the
+        // ~100ms the tuning targets.
+        this.lossyDataStatCurrentBytes += bytes.byteLength;
+      }
 
       if (this.attemptingReconnect) {
         return;
@@ -1701,6 +1745,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           await this.waitForBufferHeadroomLocked(DataChannelKind.RELIABLE);
           dc.send(msg.data);
         }
+        // Everything queued (including packets buffered unsent during the reconnect window) has
+        // been handed to the channel. If the loop throws instead, entries keep their unsent flag
+        // and the next replay picks them up — receivers dedupe any that did make it out.
+        this.reliableMessageBuffer.markAllSent();
       } finally {
         unlock();
       }
@@ -1756,6 +1804,32 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** Per-kind lock serializing senders that have to wait for the buffer to drain. */
   private waitForBufferHeadroomLocks = new Map<DataChannelKind, Mutex>();
 
+  /**
+   * Per-kind epoch for headroom waiters: aborted whenever a kind's channel object stops being
+   * current (replaced by createDataChannels or torn down by cleanupPeerConnections). A waiter is
+   * parked on the channel object it captured at wait entry; if that object is abandoned its
+   * events may never fire again, so the abort is what rejects the waiter and releases the
+   * headroom lock instead of stranding every future sender behind it.
+   */
+  private dataChannelEpochs = new Map<DataChannelKind, AbortController>();
+
+  private dataChannelEpochSignal(kind: DataChannelKind): AbortSignal {
+    let controller = this.dataChannelEpochs.get(kind);
+    if (!controller) {
+      controller = new AbortController();
+      this.dataChannelEpochs.set(kind, controller);
+    }
+    return controller.signal;
+  }
+
+  /** Rejects all parked headroom waiters (all kinds) and starts a fresh epoch. */
+  private invalidateDataChannelWaiters(reason: string) {
+    for (const controller of this.dataChannelEpochs.values()) {
+      controller.abort(reason);
+    }
+    this.dataChannelEpochs.clear();
+  }
+
   /** Acquires the per-kind headroom lock, resolving with the unlock function. */
   private lockBufferHeadroom(kind: DataChannelKind): Promise<() => void> {
     let lock = this.waitForBufferHeadroomLocks.get(kind);
@@ -1799,6 +1873,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (!dc) {
       throw new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`);
     }
+    const epochSignal = this.dataChannelEpochSignal(kind);
     await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
       const onBufferedAmountLow = () => {
         cleanup();
@@ -1810,13 +1885,29 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           new UnexpectedConnectionState(`DataChannel ${kind} closed while draining the buffer`),
         );
       };
+      const onEpochAbort = () => {
+        cleanup();
+        reject(
+          new UnexpectedConnectionState(
+            `DataChannel ${kind} was replaced or torn down while waiting for headroom`,
+          ),
+        );
+      };
       const cleanup = () => {
         dc.removeEventListener('bufferedamountlow', onBufferedAmountLow);
         dc.removeEventListener('close', onDCClose);
+        epochSignal.removeEventListener('abort', onEpochAbort);
       };
+      if (epochSignal.aborted) {
+        onEpochAbort();
+        return;
+      }
       dc.addEventListener('bufferedamountlow', onBufferedAmountLow);
       // Proxy along any error caused by the data channel closing while we wait.
       dc.addEventListener('close', onDCClose);
+      // The channel object we're parked on can be abandoned without ever firing another event
+      // (e.g. createDataChannels replacing it); the epoch abort is our way out.
+      epochSignal.addEventListener('abort', onEpochAbort);
     });
   }
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1643,13 +1643,13 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   async sendLossyBytes(
     bytes: NonSharedUint8Array,
     kind: Exclude<DataChannelKind, DataChannelKind.RELIABLE>,
-    bufferStatusLowBehavior: 'drop' | 'wait' = 'drop',
+    bufferStatusFullBehavior: 'drop' | 'wait' = 'drop',
   ) {
     const dc = this.dataChannelForKind(kind);
     if (dc) {
       // Depending on the exact circumstance that data is being sent, either drop or wait for the
       // buffer to drain below the high-water mark before continuing.
-      switch (bufferStatusLowBehavior) {
+      switch (bufferStatusFullBehavior) {
         case 'wait':
           if (!this.isBelowHighWaterMark(kind)) {
             await this.waitForBufferHeadroom(kind);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1657,7 +1657,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
           break;
         case 'drop':
           // we check against the actual threshold on the DC here, as it is dynamic for the lossy DC
-          if (dc.bufferedAmount > dc.bufferedAmountLowThreshold) {
+          if (!this.isBelowLowWaterMark(kind)) {
             // Drop messages to reduce latency
             this.lossyDataDropCount += 1;
             if (this.lossyDataDropCount % 100 === 0) {
@@ -1718,6 +1718,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (!dc) {
       throw new TypeError(`Could not get data channel for kind ${kind}`);
     }
+    // because RTCDatachannel has no high water mark built in we read the statically defined versions as constants
     const highMark =
       kind === DataChannelKind.RELIABLE
         ? reliableDataChannelWaterMarkHigh
@@ -1734,6 +1735,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     if (!dc) {
       throw new TypeError(`Could not get data channel for kind ${kind}`);
     }
+    // because RTCDatachannel has the threshold built in we can read it dynamically to account for changing thresholds over time
     return dc.bufferedAmount <= dc.bufferedAmountLowThreshold;
   };
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -1763,11 +1763,14 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         this.reliableMessageBuffer.alignBufferedAmount(dc.bufferedAmount);
       }
     }
-
-    const status = this.isBelowLowWaterMark(kind);
-    if (typeof status !== 'undefined' && status !== this.dcBufferStatus.get(kind)) {
-      this.dcBufferStatus.set(kind, status);
-      this.emit(EngineEvent.DCBufferStatusChanged, status, kind);
+    try {
+      const status = this.isBelowLowWaterMark(kind);
+      if (typeof status !== 'undefined' && status !== this.dcBufferStatus.get(kind)) {
+        this.dcBufferStatus.set(kind, status);
+        this.emit(EngineEvent.DCBufferStatusChanged, status, kind);
+      }
+    } catch (e) {
+      this.log.warn('could not update buffer status', { error: e });
     }
   };
 

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -44,6 +44,7 @@ import {
   type UserPacket,
 } from '@livekit/protocol';
 import { EventEmitter } from 'events';
+import type { Throws } from '@livekit/throws-transformer/throws';
 import type { MediaAttributes } from 'sdp-transform';
 import type TypedEventEmitter from 'typed-emitter';
 import type { SignalOptions } from '../api/SignalClient';
@@ -135,19 +136,6 @@ export enum DataChannelKind {
   RELIABLE = DataPacket_Kind.RELIABLE,
   LOSSY = DataPacket_Kind.LOSSY,
   DATA_TRACK_LOSSY = 2,
-}
-
-// Water marks for the two-watermark flow control
-function dataChannelLowWaterMark(kind: DataChannelKind): number {
-  return kind === DataChannelKind.RELIABLE
-    ? reliableDataChannelWaterMarkLow
-    : lossyDataChannelWaterMarkLow;
-}
-
-function dataChannelHighWaterMark(kind: DataChannelKind): number {
-  return kind === DataChannelKind.RELIABLE
-    ? reliableDataChannelWaterMarkHigh
-    : lossyDataChannelWaterMarkHigh;
 }
 
 // Default data-channel max message size (bytes), used when the remote SDP
@@ -943,11 +931,9 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.dataTrackDC.onclose = this.handleDataChannelClose(DataChannelKind.DATA_TRACK_LOSSY);
 
     // set up dc buffer threshold - if this is not set, it will default to 0
-    this.lossyDC.bufferedAmountLowThreshold = dataChannelLowWaterMark(DataChannelKind.LOSSY);
-    this.reliableDC.bufferedAmountLowThreshold = dataChannelLowWaterMark(DataChannelKind.RELIABLE);
-    this.dataTrackDC.bufferedAmountLowThreshold = dataChannelLowWaterMark(
-      DataChannelKind.DATA_TRACK_LOSSY,
-    );
+    this.lossyDC.bufferedAmountLowThreshold = lossyDataChannelWaterMarkLow;
+    this.reliableDC.bufferedAmountLowThreshold = reliableDataChannelWaterMarkLow;
+    this.dataTrackDC.bufferedAmountLowThreshold = lossyDataChannelWaterMarkLow;
 
     // handle buffer amount low events
     this.lossyDC.onbufferedamountlow = () => this.handleBufferedAmountLow(DataChannelKind.LOSSY);
@@ -1727,24 +1713,28 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
    * Whether the send buffer has room to accept more data (the send gate). Senders proceed while
    * this is true and block once it goes false.
    */
-  private isBelowHighWaterMark = (kind: DataChannelKind): boolean | undefined => {
+  private isBelowHighWaterMark = (kind: DataChannelKind): Throws<boolean, TypeError> => {
     const dc = this.dataChannelForKind(kind);
     if (!dc) {
-      return;
+      throw new TypeError(`Could not get data channel for kind ${kind}`);
     }
-    return dc.bufferedAmount <= dataChannelHighWaterMark(kind);
+    const highMark =
+      kind === DataChannelKind.RELIABLE
+        ? reliableDataChannelWaterMarkHigh
+        : lossyDataChannelWaterMarkHigh;
+    return dc.bufferedAmount <= highMark;
   };
 
   /**
    * Whether the send buffer has drained to its low-water mark. Drives the public
    * {@link EngineEvent.DCBufferStatusChanged} event.
    */
-  private isBelowLowWaterMark = (kind: DataChannelKind): boolean | undefined => {
+  private isBelowLowWaterMark = (kind: DataChannelKind): Throws<boolean, TypeError> => {
     const dc = this.dataChannelForKind(kind);
     if (!dc) {
-      return;
+      throw new TypeError(`Could not get data channel for kind ${kind}`);
     }
-    return dc.bufferedAmount <= dataChannelLowWaterMark(kind);
+    return dc.bufferedAmount <= dc.bufferedAmountLowThreshold;
   };
 
   /** Per-kind lock serializing senders that have to wait for the buffer to drain. */

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -91,7 +91,6 @@ import type { TrackPublishOptions, VideoCodec } from './track/options';
 import { getTrackPublicationInfo } from './track/utils';
 import type { LoggerOptions } from './types';
 import {
-  Future,
   isPublisherOfferWithJoinSupported,
   isReactNative,
   isVideoCodec,
@@ -1640,7 +1639,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       case DataChannelKind.RELIABLE:
         const dc = this.dataChannelForKind(kind);
         if (dc) {
-          await this.waitUntilBelowHighWaterMark(kind);
+          await this.waitForBufferHeadroom(kind);
           this.reliableMessageBuffer.push({ data: msg, sequence: packet.sequence });
 
           if (this.attemptingReconnect) {
@@ -1668,7 +1667,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       switch (bufferStatusLowBehavior) {
         case 'wait':
           if (!this.isBelowHighWaterMark(kind)) {
-            await this.waitUntilBelowHighWaterMark(kind);
+            await this.waitForBufferHeadroom(kind);
           }
           break;
         case 'drop':
@@ -1703,7 +1702,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       this.reliableMessageBuffer.popToSequence(lastMessageSeq);
       for (const msg of this.reliableMessageBuffer.getAll()) {
         // Respect flow control on resume too, so a large resend doesn't overflow the send buffer.
-        await this.waitUntilBelowHighWaterMark(DataChannelKind.RELIABLE);
+        await this.waitForBufferHeadroom(DataChannelKind.RELIABLE);
         dc.send(msg.data);
       }
     }
@@ -1750,20 +1749,21 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   };
 
   /** Per-kind lock serializing senders that have to wait for the buffer to drain. */
-  private waitUntilBelowHighWaterMarkLocks = new Map<DataChannelKind, Mutex>();
+  private waitForBufferHeadroomLocks = new Map<DataChannelKind, Mutex>();
 
   /**
-   * Resolves once the send buffer for `kind` on the RTCDataChannel is at or below its high-water mark, blocking the
-   * caller otherwise. Callers are serialized through a per-kind mutex so that, when the buffer
-   * drains, they refill it one at a time (up to the high-water mark) rather than all sending at
-   * once and overflowing the SCTP send buffer (see livekit/client-sdk-js#1995). The closed/buffer
-   * checks run inside the lock so queued callers proceed in FIFO order.
+   * Resolves once the caller may send on the `kind` channel: immediately while the send buffer is
+   * at or below its high-water mark, otherwise once the buffer has drained to the low-water mark
+   * (the `bufferedamountlow` event). Callers are serialized through a per-kind mutex so that, when
+   * the buffer drains, they refill it one at a time (up to the high-water mark) rather than all
+   * sending at once and overflowing the SCTP send buffer (see livekit/client-sdk-js#1995). The
+   * closed/buffer checks run inside the lock so queued callers proceed in FIFO order.
    */
-  async waitUntilBelowHighWaterMark(kind: DataChannelKind) {
-    let lock = this.waitUntilBelowHighWaterMarkLocks.get(kind);
+  async waitForBufferHeadroom(kind: DataChannelKind) {
+    let lock = this.waitForBufferHeadroomLocks.get(kind);
     if (!lock) {
       lock = new Mutex();
-      this.waitUntilBelowHighWaterMarkLocks.set(kind, lock);
+      this.waitForBufferHeadroomLocks.set(kind, lock);
     }
     const unlock = await lock.lock();
     try {
@@ -1785,7 +1785,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         const onDCClose = () => {
           cleanup();
           reject(
-            new UnexpectedConnectionState(`DataChannel {kind} closed while draining the buffer`),
+            new UnexpectedConnectionState(`DataChannel ${kind} closed while draining the buffer`),
           );
         };
         const cleanup = () => {

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -946,8 +946,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
 
     // set up dc buffer threshold - if this is not set, it will default to 0
     this.lossyDC.bufferedAmountLowThreshold = dataChannelLowWaterMark(DataChannelKind.LOSSY);
-    this.reliableDC.bufferedAmountLowThreshold = reliableDataChannelLowWaterMark;
-    this.dataTrackDC.bufferedAmountLowThreshold = lossyDataChannelLowWaterMark;
+    this.reliableDC.bufferedAmountLowThreshold = dataChannelLowWaterMark(DataChannelKind.RELIABLE);
+    this.dataTrackDC.bufferedAmountLowThreshold = dataChannelLowWaterMark(
+      DataChannelKind.DATA_TRACK_LOSSY,
+    );
 
     // handle buffer amount low events
     this.lossyDC.onbufferedamountlow = () => this.handleBufferedAmountLow(DataChannelKind.LOSSY);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -285,8 +285,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   /** used to indicate whether the browser is currently waiting to reconnect */
   private isWaitingForNetworkReconnect: boolean = false;
 
-  private bufferStatusLowClosingFuture = new Future<never, UnexpectedConnectionState>();
-
   constructor(private options: InternalRoomOptions) {
     super();
     this.log = getLogger(options.loggerName ?? LoggerNames.Engine, () => this.logContext);
@@ -320,13 +318,6 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     this.client.onParticipantUpdate = (updates) =>
       this.emit(EngineEvent.ParticipantUpdate, updates);
     this.client.onJoined = (joinResponse) => this.emit(EngineEvent.Joined, joinResponse);
-
-    this.on(EngineEvent.Closing, () => {
-      this.bufferStatusLowClosingFuture.reject?.(new UnexpectedConnectionState('engine closed'));
-    });
-    // Swallow the rejection at the source so it doesn't surface as an unhandled promise rejection
-    // when no waitUntilBelowHighWaterMark callers are attached.
-    this.bufferStatusLowClosingFuture.promise.catch(() => {});
   }
 
   /** @internal */
@@ -1668,19 +1659,18 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     kind: Exclude<DataChannelKind, DataChannelKind.RELIABLE>,
     bufferStatusLowBehavior: 'drop' | 'wait' = 'drop',
   ) {
-    // make sure we do have a data connection
-    await this.ensurePublisherConnected(kind);
-
     const dc = this.dataChannelForKind(kind);
     if (dc) {
-      if (!this.isBelowHighWaterMark(kind)) {
-        // Depending on the exact circumstance that data is being sent, either drop or wait for the
-        // buffer to drain below the high-water mark before continuing.
-        switch (bufferStatusLowBehavior) {
-          case 'wait':
+      // Depending on the exact circumstance that data is being sent, either drop or wait for the
+      // buffer to drain below the high-water mark before continuing.
+      switch (bufferStatusLowBehavior) {
+        case 'wait':
+          if (!this.isBelowHighWaterMark(kind)) {
             await this.waitUntilBelowHighWaterMark(kind);
-            break;
-          case 'drop':
+          }
+          break;
+        case 'drop':
+          if (!this.isBelowLowWaterMark(kind)) {
             // this.log.warn(`dropping lossy data channel message`, this.logContext);
             // Drop messages to reduce latency
             this.lossyDataDropCount += 1;
@@ -1690,7 +1680,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
               );
             }
             return;
-        }
+          }
       }
       this.lossyDataStatCurrentBytes += bytes.byteLength;
 
@@ -1761,7 +1751,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
   private waitUntilBelowHighWaterMarkLocks = new Map<DataChannelKind, Mutex>();
 
   /**
-   * Resolves once the send buffer for `kind` is at or below its high-water mark, blocking the
+   * Resolves once the send buffer for `kind` on the RTCDataChannel is at or below its high-water mark, blocking the
    * caller otherwise. Callers are serialized through a per-kind mutex so that, when the buffer
    * drains, they refill it one at a time (up to the high-water mark) rather than all sending at
    * once and overflowing the SCTP send buffer (see livekit/client-sdk-js#1995). The closed/buffer
@@ -1786,13 +1776,23 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         throw new UnexpectedConnectionState(`DataChannel not found, kind: ${kind}`);
       }
       await new TypedPromise<void, UnexpectedConnectionState>((resolve, reject) => {
-        const onBufferedAmountLow = () => resolve();
-        dc.addEventListener('bufferedamountlow', onBufferedAmountLow, { once: true });
-        // Proxy along any error caused by the engine closing while we wait.
-        this.bufferStatusLowClosingFuture.promise.catch((e) => {
+        const onBufferedAmountLow = () => {
+          cleanup();
+          resolve();
+        };
+        const onDCClose = () => {
+          cleanup();
+          reject(
+            new UnexpectedConnectionState(`DataChannel {kind} closed while draining the buffer`),
+          );
+        };
+        const cleanup = () => {
           dc.removeEventListener('bufferedamountlow', onBufferedAmountLow);
-          reject(e);
-        });
+          dc.removeEventListener('close', onDCClose);
+        };
+        dc.addEventListener('bufferedamountlow', onBufferedAmountLow);
+        // Proxy along any error caused by the data channel closing while we wait.
+        dc.addEventListener('close', onDCClose);
       });
     } finally {
       unlock();

--- a/src/utils/dataPacketBuffer.test.ts
+++ b/src/utils/dataPacketBuffer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { DataPacketBuffer } from './dataPacketBuffer';
+
+const item = (sequence: number, size: number, sent: boolean) => ({
+  data: new Uint8Array(size),
+  sequence,
+  sent,
+});
+
+describe('DataPacketBuffer', () => {
+  it('trims sent packets down to the buffered amount', () => {
+    const buffer = new DataPacketBuffer();
+    buffer.push(item(1, 100, true));
+    buffer.push(item(2, 100, true));
+    buffer.push(item(3, 100, true));
+
+    // 150 buffered bytes cover the last two packets; the first is fully delivered.
+    buffer.alignBufferedAmount(150);
+
+    expect(buffer.getAll().map((i) => i.sequence)).toEqual([2, 3]);
+  });
+
+  it('never trims unsent packets, even when the buffered amount is zero', () => {
+    const buffer = new DataPacketBuffer();
+    buffer.push(item(1, 100, false));
+    buffer.push(item(2, 100, false));
+
+    buffer.alignBufferedAmount(0);
+
+    expect(buffer.length).toBe(2);
+  });
+
+  it('does not let unsent tail bytes cause over-trimming of the sent prefix', () => {
+    const buffer = new DataPacketBuffer();
+    buffer.push(item(1, 100, true));
+    buffer.push(item(2, 100, true));
+    // Queued during a reconnect window — not part of the channel's bufferedAmount.
+    buffer.push(item(3, 100, false));
+    buffer.push(item(4, 100, false));
+
+    // Both sent packets are still in flight; nothing may be trimmed. With size accounting based
+    // on the total (400) instead of sent bytes (200), both sent packets would be popped here.
+    buffer.alignBufferedAmount(200);
+
+    expect(buffer.getAll().map((i) => i.sequence)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('markAllSent makes queued packets eligible for trimming', () => {
+    const buffer = new DataPacketBuffer();
+    buffer.push(item(1, 100, false));
+    buffer.push(item(2, 100, false));
+
+    buffer.markAllSent();
+    buffer.alignBufferedAmount(50);
+
+    expect(buffer.getAll().map((i) => i.sequence)).toEqual([2]);
+  });
+
+  it('popToSequence drops acked packets regardless of sent state', () => {
+    const buffer = new DataPacketBuffer();
+    buffer.push(item(1, 100, true));
+    buffer.push(item(2, 100, false));
+    buffer.push(item(3, 100, false));
+
+    buffer.popToSequence(2);
+
+    expect(buffer.getAll().map((i) => i.sequence)).toEqual([3]);
+  });
+});

--- a/src/utils/dataPacketBuffer.test.ts
+++ b/src/utils/dataPacketBuffer.test.ts
@@ -45,15 +45,46 @@ describe('DataPacketBuffer', () => {
     expect(buffer.getAll().map((i) => i.sequence)).toEqual([1, 2, 3, 4]);
   });
 
-  it('markAllSent makes queued packets eligible for trimming', () => {
+  it('markSent makes a single packet eligible for trimming and tracks sent size', () => {
     const buffer = new DataPacketBuffer();
-    buffer.push(item(1, 100, false));
-    buffer.push(item(2, 100, false));
+    const first = item(1, 100, false);
+    const second = item(2, 100, false);
+    buffer.push(first);
+    buffer.push(second);
 
-    buffer.markAllSent();
+    // Only the marked packet can be trimmed; the still-unsent one blocks the front.
+    buffer.markSent(first);
+    buffer.alignBufferedAmount(0);
+    expect(buffer.getAll().map((i) => i.sequence)).toEqual([1, 2]);
+
+    buffer.markSent(second);
     buffer.alignBufferedAmount(50);
-
     expect(buffer.getAll().map((i) => i.sequence)).toEqual([2]);
+  });
+
+  it('getUnsent returns only unsent packets, in order', () => {
+    const buffer = new DataPacketBuffer();
+    const a = item(1, 100, false);
+    const b = item(2, 100, false);
+    buffer.push(a);
+    buffer.push(b);
+    buffer.push(item(3, 100, false));
+    buffer.markSent(b);
+
+    expect(buffer.getUnsent().map((i) => i.sequence)).toEqual([1, 3]);
+  });
+
+  it('markAllUnsent flags every packet for re-send and resets sent size', () => {
+    const buffer = new DataPacketBuffer();
+    buffer.push(item(1, 100, true));
+    buffer.push(item(2, 100, true));
+
+    buffer.markAllUnsent();
+    expect(buffer.getUnsent().map((i) => i.sequence)).toEqual([1, 2]);
+
+    // With everything unsent, nothing can be trimmed even at a zero buffered amount.
+    buffer.alignBufferedAmount(0);
+    expect(buffer.getAll().map((i) => i.sequence)).toEqual([1, 2]);
   });
 
   it('popToSequence drops acked packets regardless of sent state', () => {

--- a/src/utils/dataPacketBuffer.ts
+++ b/src/utils/dataPacketBuffer.ts
@@ -3,6 +3,13 @@ import type { NonSharedUint8Array } from '../type-polyfills/non-shared-typed-arr
 export interface DataPacketItem {
   data: NonSharedUint8Array;
   sequence: number;
+  /**
+   * Whether the packet has been handed to the data channel. Unsent packets are queued for the
+   * resume replay (e.g. sends that landed in a reconnect window) and must never be trimmed by
+   * {@link DataPacketBuffer.alignBufferedAmount}, which reasons about the channel's buffered
+   * bytes — those only ever contain sent packets.
+   */
+  sent: boolean;
 }
 
 export class DataPacketBuffer {
@@ -10,21 +17,37 @@ export class DataPacketBuffer {
 
   private _totalSize = 0;
 
+  private _sentSize = 0;
+
   push(item: DataPacketItem) {
     this.buffer.push(item);
     this._totalSize += item.data.byteLength;
+    if (item.sent) {
+      this._sentSize += item.data.byteLength;
+    }
   }
 
   pop(): DataPacketItem | undefined {
     const item = this.buffer.shift();
     if (item) {
       this._totalSize -= item.data.byteLength;
+      if (item.sent) {
+        this._sentSize -= item.data.byteLength;
+      }
     }
     return item;
   }
 
   getAll(): DataPacketItem[] {
     return this.buffer.slice();
+  }
+
+  /** Marks every queued packet as sent — call after a replay has handed them all to the channel. */
+  markAllSent() {
+    for (const item of this.buffer) {
+      item.sent = true;
+    }
+    this._sentSize = this._totalSize;
   }
 
   popToSequence(sequence: number) {
@@ -41,7 +64,12 @@ export class DataPacketBuffer {
   alignBufferedAmount(bufferedAmount: number) {
     while (this.buffer.length > 0) {
       const first = this.buffer[0];
-      if (this._totalSize - first.data.byteLength <= bufferedAmount) {
+      // Unsent packets aren't part of the channel's bufferedAmount and are still awaiting the
+      // resume replay — trimming them would silently lose them.
+      if (!first.sent) {
+        break;
+      }
+      if (this._sentSize - first.data.byteLength <= bufferedAmount) {
         break;
       }
       this.pop();

--- a/src/utils/dataPacketBuffer.ts
+++ b/src/utils/dataPacketBuffer.ts
@@ -42,12 +42,29 @@ export class DataPacketBuffer {
     return this.buffer.slice();
   }
 
-  /** Marks every queued packet as sent — call after a replay has handed them all to the channel. */
-  markAllSent() {
-    for (const item of this.buffer) {
+  /** Every queued packet not yet handed to the channel, in sequence order. */
+  getUnsent(): DataPacketItem[] {
+    return this.buffer.filter((item) => !item.sent);
+  }
+
+  /** Marks a single queued packet as handed to the channel. */
+  markSent(item: DataPacketItem) {
+    if (!item.sent) {
       item.sent = true;
+      this._sentSize += item.data.byteLength;
     }
-    this._sentSize = this._totalSize;
+  }
+
+  /**
+   * Marks every queued packet as not-yet-sent. Used at the start of a resume replay: whatever is
+   * still buffered was sent on the previous channel (or deferred) and must be re-handed to the
+   * current one, so none of it counts as sent until the replay actually transmits it.
+   */
+  markAllUnsent() {
+    for (const item of this.buffer) {
+      item.sent = false;
+    }
+    this._sentSize = 0;
   }
 
   popToSequence(sequence: number) {


### PR DESCRIPTION
(Started by Ryan -> Lukas took over this change and wrote the below)

closes https://github.com/livekit/client-sdk-js/issues/1995

the gist of this PR is to add a kind dependent mutex around data channel sends. 
Previously the `waitForBufferStatusLow` method could be stalling lots of data requests in parallel and once it resolved all of them got flushed to the data channel at once potentially overflowing its buffer. 

To generalise this solution without any performance/throughput hits the PR additionally introduces high and low watermarks for the data channels so that there's a designated "headroom" under which data packets are allowed to be pushed to the data channel buffer immediately (avoiding a constant back and forth between high and low DC buffer status)