### PR TITLE
Add publish-side frame metadata user_data support

### DIFF
--- a/.changeset/publish-frame-user-data.md
+++ b/.changeset/publish-frame-user-data.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+Add publish-side frame metadata user_data support: enable it with `FrameMetadataPublishOptions.userData` and attach per-frame data via `LocalVideoTrack.attachUserDataToNextFrame()`

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -106,8 +106,9 @@ function getFrameMetadataPublishOptions() {
   const enabled = (<HTMLInputElement>$('frame-metadata')).checked;
   const timestamp = enabled && (<HTMLInputElement>$('frame-metadata-timestamp')).checked;
   const frameId = enabled && (<HTMLInputElement>$('frame-metadata-frame-id')).checked;
+  const userData = enabled && (<HTMLInputElement>$('frame-metadata-user-data')).checked;
 
-  return timestamp || frameId ? { timestamp, frameId } : undefined;
+  return timestamp || frameId || userData ? { timestamp, frameId, userData } : undefined;
 }
 
 function syncFrameMetadataPublishOptions(room = currentRoom) {
@@ -134,14 +135,18 @@ function syncFrameMetadataFeatureControls() {
   const featureControls = $('frame-metadata-features');
   const timestamp = <HTMLInputElement>$('frame-metadata-timestamp');
   const frameId = <HTMLInputElement>$('frame-metadata-frame-id');
+  const userData = <HTMLInputElement>$('frame-metadata-user-data');
 
   featureControls.style.display = enabled ? 'block' : 'none';
   timestamp.disabled = !enabled;
   frameId.disabled = !enabled;
+  userData.disabled = !enabled;
   if (!enabled) {
     timestamp.checked = false;
     frameId.checked = false;
+    userData.checked = false;
   }
+  $('frame-user-data-controls').style.display = userData.checked ? 'flex' : 'none';
   syncFrameMetadataPublishOptions();
 }
 
@@ -155,10 +160,24 @@ function syncFrameMetadataFeatureControls() {
 (<HTMLInputElement>$('frame-metadata-frame-id')).addEventListener('change', () =>
   syncFrameMetadataPublishOptions(),
 );
+(<HTMLInputElement>$('frame-metadata-user-data')).addEventListener(
+  'change',
+  syncFrameMetadataFeatureControls,
+);
 syncFrameMetadataFeatureControls();
 
 // handles actions from the HTML
 const appActions = {
+  sendFrameUserData: () => {
+    const videoPub = currentRoom?.localParticipant.getTrackPublication(Track.Source.Camera);
+    if (!videoPub?.videoTrack) {
+      appendLog('cannot attach frame user data, camera is not published');
+      return;
+    }
+    const value = (<HTMLInputElement>$('frame-user-data-input')).value;
+    videoPub.videoTrack.attachUserDataToNextFrame(new TextEncoder().encode(value));
+    appendLog('attached user data to next frame', value);
+  },
   sendFile: async () => {
     console.log('start sending');
     const file = ($('file') as HTMLInputElement).files?.[0]!;

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -92,6 +92,30 @@
                   Attach Frame ID
                 </label>
               </div>
+              <div class="ml-3">
+                <input type="checkbox" class="form-check-input" id="frame-metadata-user-data" />
+                <label for="frame-metadata-user-data" class="form-check-label">
+                  Attach User Data
+                </label>
+              </div>
+              <div class="ml-3 input-group" id="frame-user-data-controls" style="display: none">
+                <input
+                  type="text"
+                  class="form-control"
+                  id="frame-user-data-input"
+                  placeholder="User data for next frame"
+                />
+                <div class="input-group-append">
+                  <button
+                    id="send-frame-user-data-button"
+                    class="btn btn-secondary"
+                    type="button"
+                    onclick="appActions.sendFrameUserData()"
+                  >
+                    Send
+                  </button>
+                </div>
+              </div>
             </div>
             <div>
               <select id="preferred-codec" class="custom-select" style="width: auto"></select>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@livekit/mutex": "1.1.1",
-    "@livekit/protocol": "1.46.6",
+    "@livekit/protocol": "1.49.0",
     "events": "^3.3.0",
     "jose": "^6.1.0",
     "loglevel": "^1.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       '@livekit/protocol':
-        specifier: 1.46.6
-        version: 1.46.6
+        specifier: 1.49.0
+        version: 1.49.0
       '@types/dom-mediacapture-record':
         specifier: ^1
         version: 1.0.22
@@ -1224,8 +1224,8 @@ packages:
   '@livekit/mutex@1.1.1':
     resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
 
-  '@livekit/protocol@1.46.6':
-    resolution: {integrity: sha512-upzlHP1vi/kZ/QqALZTFskQ0ifqc2f15RKucHYOsIHJsaXvEYanG75mAb7o+Yomfs4XhQ4BaRsdY+TFHXpaqrg==}
+  '@livekit/protocol@1.49.0':
+    resolution: {integrity: sha512-TCmihwjHBWAUdNrqvmrN/K59r7vDnPIy3OEaE3p0g4FvdcQTiLynmFC3igR25Q2fnifahhAJjnnfSCtWUK7kYg==}
 
   '@livekit/throws-transformer@0.1.3':
     resolution: {integrity: sha512-PBttE6W6g/2ALGu6kWOunZ5qdrXwP9Ge1An2/62OfE6Rhc0Abd4yp6ex2pWhwUfGxDsSZvFgoB1Ia/5mWAMuKQ==}
@@ -5121,7 +5121,7 @@ snapshots:
 
   '@livekit/mutex@1.1.1': {}
 
-  '@livekit/protocol@1.46.6':
+  '@livekit/protocol@1.49.0':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 

--- a/src/e2ee/E2eeManager.ts
+++ b/src/e2ee/E2eeManager.ts
@@ -17,6 +17,7 @@ import { mimeTypeToVideoCodecString } from '../room/track/utils';
 import {
   Future,
   isLocalTrack,
+  isLocalVideoTrack,
   isSafariBased,
   isScriptTransformSupportedForWorker,
   isVideoTrack,
@@ -40,6 +41,7 @@ import type {
   RatchetRequestMessage,
   RemoveTransformMessage,
   ScriptTransformOptions,
+  SetFrameUserDataMessage,
   SetKeyMessage,
   SifTrailerMessage,
   UpdateCodecMessage,
@@ -507,14 +509,30 @@ export class E2EEManager
       if (!sender) log.warn('early return because sender is not ready');
       return;
     }
-    this.handleSender(
-      sender,
-      track.mediaStreamID,
-      undefined,
-      isVideoTrack(track)
-        ? (track.publishOptions?.frameMetadata ?? track.publishOptions?.packetTrailer)
-        : undefined,
-    );
+    const frameMetadata = isLocalVideoTrack(track)
+      ? (track.publishOptions?.frameMetadata ?? track.publishOptions?.packetTrailer)
+      : undefined;
+    this.handleSender(sender, track.mediaStreamID, undefined, frameMetadata);
+
+    // registered outside handleSender so a reused sender (E2EE_FLAG set)
+    // still gets a fresh poster
+    if (frameMetadata?.userData && isLocalVideoTrack(track)) {
+      const trackId = track.mediaStreamID;
+      track.frameUserDataPoster = (userData) => {
+        if (!this.worker || !this.room?.localParticipant.identity) {
+          return;
+        }
+        const msg: SetFrameUserDataMessage = {
+          kind: 'setFrameUserData',
+          data: {
+            participantIdentity: this.room.localParticipant.identity,
+            trackId,
+            userData: userData as NonSharedUint8Array | undefined,
+          },
+        };
+        this.worker.postMessage(msg);
+      };
+    }
   }
 
   /**

--- a/src/e2ee/types.ts
+++ b/src/e2ee/types.ts
@@ -67,6 +67,19 @@ export interface EncodeMessage extends BaseMessage {
   };
 }
 
+export interface SetFrameUserDataMessage extends BaseMessage {
+  kind: 'setFrameUserData';
+  data: {
+    participantIdentity: string;
+    trackId: string;
+    /**
+     * User data to attach to the next published video frame; undefined
+     * clears any pending value.
+     */
+    userData?: NonSharedUint8Array;
+  };
+}
+
 export interface RemoveTransformMessage extends BaseMessage {
   kind: 'removeTransform';
   data: {
@@ -173,6 +186,7 @@ export type E2EEWorkerMessage =
   | InitMessage
   | SetKeyMessage
   | EncodeMessage
+  | SetFrameUserDataMessage
   | ErrorMessage
   | EnableMessage
   | RemoveTransformMessage

--- a/src/e2ee/worker/FrameCryptor.test.ts
+++ b/src/e2ee/worker/FrameCryptor.test.ts
@@ -354,6 +354,133 @@ describe('FrameCryptor', () => {
         frameId: 1,
       });
     });
+
+    it('appends pending user data to the next frame only', async () => {
+      const { keys, cryptor, input, output } = prepareParticipantTestEncoder(
+        participantIdentity,
+        {},
+        { frameId: true, userData: true },
+      );
+
+      await keys.setKey(await createKeyMaterialFromString('key1'), 1);
+
+      const userData = Uint8Array.from([7, 8, 9]);
+      cryptor.setPendingFrameUserData(userData);
+
+      const firstFrame = mockRTCEncodedVideoFrame(
+        new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+      );
+      input.write(firstFrame);
+      await vitest.waitFor(() => expect(output.chunks).toHaveLength(1));
+
+      const firstMetadata = extractPacketTrailer(firstFrame.data).metadata;
+      expect(firstMetadata?.frameId).toBe(1);
+      expect(firstMetadata?.userData).toEqual(userData);
+
+      const secondFrame = mockRTCEncodedVideoFrame(
+        new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+      );
+      input.write(secondFrame);
+      await vitest.waitFor(() => expect(output.chunks).toHaveLength(2));
+
+      const secondMetadata = extractPacketTrailer(secondFrame.data).metadata;
+      expect(secondMetadata?.frameId).toBe(2);
+      expect(secondMetadata?.userData).toBeUndefined();
+    });
+
+    it('does not append pending user data when the publish options do not enable it', async () => {
+      const { keys, cryptor, input, output } = prepareParticipantTestEncoder(
+        participantIdentity,
+        {},
+        { frameId: true },
+      );
+
+      await keys.setKey(await createKeyMaterialFromString('key1'), 1);
+
+      cryptor.setPendingFrameUserData(Uint8Array.from([7, 8, 9]));
+
+      const frame = mockRTCEncodedVideoFrame(
+        new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+      );
+      input.write(frame);
+      await vitest.waitFor(() => expect(output.chunks).toHaveLength(1));
+
+      expect(extractPacketTrailer(frame.data).metadata).toEqual({
+        userTimestamp: BigInt(0),
+        frameId: 1,
+      });
+    });
+
+    it('keeps pending user data set before the encode transform registers', async () => {
+      vitest.useFakeTimers();
+      try {
+        const keyProviderOptions = { ...KEY_PROVIDER_DEFAULTS };
+        const keys = new ParticipantKeyHandler(participantIdentity, keyProviderOptions);
+        encryptionEnabledMap.set(participantIdentity, true);
+
+        const cryptor = new FrameCryptor({
+          participantIdentity,
+          keys,
+          keyProviderOptions,
+          sifTrailer: new Uint8Array(),
+        });
+
+        // user data posted before setupTransform runs must survive it
+        const userData = Uint8Array.from([7, 8, 9]);
+        cryptor.setPendingFrameUserData(userData);
+
+        const input = new TestUnderlyingSource<RTCEncodedVideoFrame>();
+        const output = new TestUnderlyingSink<RTCEncodedVideoFrame>();
+        cryptor.setupTransform(
+          'encode',
+          new ReadableStream(input),
+          new WritableStream(output),
+          'testTrack',
+          false,
+          undefined,
+          { userData: true },
+        );
+
+        await keys.setKey(await createKeyMaterialFromString('key1'), 1);
+
+        const frame = mockRTCEncodedVideoFrame(
+          new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+        );
+        input.write(frame);
+        await vitest.waitFor(() => expect(output.chunks).toHaveLength(1));
+
+        expect(extractPacketTrailer(frame.data).metadata?.userData).toEqual(userData);
+      } finally {
+        vitest.useRealTimers();
+      }
+    });
+
+    it('appends pending user data on the encryption-disabled passthrough path', async () => {
+      vitest.useFakeTimers();
+      try {
+        const { cryptor, input, output } = prepareParticipantTestEncoder(
+          participantIdentity,
+          {},
+          {
+            userData: true,
+          },
+        );
+
+        encryptionEnabledMap.set(participantIdentity, false);
+
+        const userData = Uint8Array.from([7, 8, 9]);
+        cryptor.setPendingFrameUserData(userData);
+
+        const frame = mockRTCEncodedVideoFrame(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]));
+        input.write(frame);
+        await vitest.advanceTimersToNextTimerAsync();
+
+        expect(output.chunks).toHaveLength(1);
+        expect(extractPacketTrailer(frame.data).metadata?.userData).toEqual(userData);
+      } finally {
+        vitest.useRealTimers();
+      }
+    });
   });
 
   describe('decode', () => {

--- a/src/e2ee/worker/FrameCryptor.ts
+++ b/src/e2ee/worker/FrameCryptor.ts
@@ -95,6 +95,9 @@ export class FrameCryptor extends BaseFrameCryptor {
 
   private frameMetadataFrameId = 0;
 
+  /** User data to attach to the next encoded video frame, cleared once written. */
+  private pendingFrameUserData?: Uint8Array;
+
   /**
    * Throttling mechanism for decryption errors to prevent memory leaks
    */
@@ -220,6 +223,16 @@ export class FrameCryptor extends BaseFrameCryptor {
   setFrameMetadataOpts(frameMetadata?: FrameMetadataPublishOptions) {
     this.frameMetadataOpts = frameMetadata;
     this.frameMetadataFrameId = 0;
+    // pendingFrameUserData is intentionally left untouched: it may have been
+    // set before the encode transform registered on this cryptor.
+  }
+
+  /**
+   * Sets the user data to attach to the next published video frame. An
+   * undefined or empty value clears any pending user data instead.
+   */
+  setPendingFrameUserData(userData?: Uint8Array) {
+    this.pendingFrameUserData = userData && userData.length > 0 ? userData : undefined;
   }
 
   setupTransform(
@@ -504,10 +517,18 @@ export class FrameCryptor extends BaseFrameCryptor {
       this.frameMetadataFrameId =
         this.frameMetadataFrameId === 0xffffffff ? 1 : this.frameMetadataFrameId + 1;
     }
+    let userData: Uint8Array | undefined;
+    // Empty (DTX-like) frames never carry a trailer; don't let them consume
+    // the one-shot user data.
+    if (this.frameMetadataOpts?.userData && encodedFrame.data.byteLength > 0) {
+      userData = this.pendingFrameUserData;
+      this.pendingFrameUserData = undefined;
+    }
     appendPacketTrailerToEncodedFrame(
       encodedFrame,
       this.frameMetadataOpts,
       this.frameMetadataFrameId,
+      userData,
     );
   }
 

--- a/src/e2ee/worker/e2ee.worker.ts
+++ b/src/e2ee/worker/e2ee.worker.ts
@@ -159,6 +159,13 @@ onmessage = (ev) => {
           workerLogger.error('no participant Id was provided and shared key usage is disabled');
         }
         break;
+      case 'setFrameUserData':
+        // getTrackCryptor creates the cryptor when missing, so user data
+        // posted before the encode transform registers is kept as pending
+        getTrackCryptor(data.participantIdentity, data.trackId).setPendingFrameUserData(
+          data.userData,
+        );
+        break;
       case 'removeTransform':
         unsetCryptorParticipant(data.trackId, data.participantIdentity);
         break;

--- a/src/frameMetadata/frameMetadata.test.ts
+++ b/src/frameMetadata/frameMetadata.test.ts
@@ -8,13 +8,14 @@ import {
   appendPacketTrailer,
   appendPacketTrailerToEncodedFrame,
   extractPacketTrailer,
+  getMaxFrameUserDataLength,
   processPacketTrailer,
 } from './frameMetadata';
 
 /**
- * Builds a packet trailer (XORed TLVs + envelope) for the given fields. The
- * SDK only writes timestamp/frameId, so this mirrors the native sender's TLV
- * encoding to exercise user_data extraction.
+ * Builds a packet trailer (XORed TLVs + envelope) for the given fields,
+ * mirroring the native sender's TLV encoding independently of
+ * appendPacketTrailer so both directions can be checked against it.
  */
 function buildTrailer(
   payload: Uint8Array,
@@ -137,6 +138,105 @@ describe('packetTrailer', () => {
     expect(Array.from(result)).toEqual(Array.from(payload));
   });
 
+  it('writes a user_data-only trailer byte-identical to the reference encoding', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const userData = Uint8Array.from([0x00, 0x01, 0xfe, 0xff, 0x42]);
+
+    const result = appendPacketTrailer(payload, 0n, 0, userData);
+
+    expect(Array.from(result)).toEqual(Array.from(buildTrailer(payload, { userData })));
+  });
+
+  it('writes user_data alongside timestamp and frameId byte-identical to the reference encoding', () => {
+    const payload = Uint8Array.from([9, 8, 7, 6, 5]);
+    const userData = Uint8Array.from([10, 20, 30, 40]);
+
+    const result = appendPacketTrailer(payload, 1_744_249_600_123_456n, 42, userData);
+
+    expect(Array.from(result)).toEqual(
+      Array.from(
+        buildTrailer(payload, { userTimestamp: 1_744_249_600_123_456n, frameId: 42, userData }),
+      ),
+    );
+  });
+
+  it('round-trips user_data through append and extract', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const userData = Uint8Array.from([0x00, 0x7f, 0x80, 0xff]);
+
+    const extracted = extractPacketTrailer(
+      appendPacketTrailer(payload, 1_744_249_600_123_456n, 42, userData),
+    );
+
+    expect(Array.from(extracted.data)).toEqual(Array.from(payload));
+    expect(extracted.metadata?.userTimestamp).toBe(1_744_249_600_123_456n);
+    expect(extracted.metadata?.frameId).toBe(42);
+    expect(Array.from(extracted.metadata!.userData!)).toEqual(Array.from(userData));
+  });
+
+  it('returns data unchanged for empty user_data when timestamp and frameId are 0', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const result = appendPacketTrailer(payload, 0n, 0, new Uint8Array(0));
+
+    expect(Array.from(result)).toEqual(Array.from(payload));
+  });
+
+  it('omits the user_data TLV for empty user_data when other fields are present', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const result = appendPacketTrailer(payload, 0n, 42, new Uint8Array(0));
+
+    expect(extractPacketTrailer(result).metadata).toEqual({
+      userTimestamp: 0n,
+      frameId: 42,
+    });
+  });
+
+  it('computes the maximum user_data length per publish option combination', () => {
+    expect(getMaxFrameUserDataLength()).toBe(248);
+    expect(getMaxFrameUserDataLength({ userData: true })).toBe(248);
+    expect(getMaxFrameUserDataLength({ frameId: true })).toBe(242);
+    expect(getMaxFrameUserDataLength({ timestamp: true })).toBe(238);
+    expect(getMaxFrameUserDataLength({ timestamp: true, frameId: true })).toBe(232);
+  });
+
+  it('round-trips user_data at the maximum length', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const userData = new Uint8Array(getMaxFrameUserDataLength({ timestamp: true, frameId: true }));
+    userData.fill(0xab);
+
+    const extracted = extractPacketTrailer(
+      appendPacketTrailer(payload, 1_744_249_600_123_456n, 42, userData),
+    );
+
+    expect(Array.from(extracted.data)).toEqual(Array.from(payload));
+    expect(Array.from(extracted.metadata!.userData!)).toEqual(Array.from(userData));
+  });
+
+  it('drops oversized user_data while keeping timestamp and frameId', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const userData = new Uint8Array(
+      getMaxFrameUserDataLength({ timestamp: true, frameId: true }) + 1,
+    );
+
+    const extracted = extractPacketTrailer(
+      appendPacketTrailer(payload, 1_744_249_600_123_456n, 42, userData),
+    );
+
+    expect(extracted.metadata).toEqual({
+      userTimestamp: 1_744_249_600_123_456n,
+      frameId: 42,
+    });
+  });
+
+  it('drops oversized user_data entirely when it is the only field', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const userData = new Uint8Array(getMaxFrameUserDataLength() + 1);
+
+    const result = appendPacketTrailer(payload, 0n, 0, userData);
+
+    expect(Array.from(result)).toEqual(Array.from(payload));
+  });
+
   it('passes frames through when there is no valid trailer', () => {
     const payload = Uint8Array.from([1, 2, 3, 4, 5]);
     const extracted = extractPacketTrailer(payload);
@@ -218,6 +318,59 @@ describe('packetTrailer', () => {
       userTimestamp: BigInt(Date.now()) * BigInt(1000),
       frameId: 7,
     });
+  });
+
+  it('appends a user_data-only trailer to encoded frames', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const frame = { data: payload.buffer } as RTCEncodedVideoFrame;
+    const userData = Uint8Array.from([7, 8, 9]);
+
+    const changed = appendPacketTrailerToEncodedFrame(frame, { userData: true }, 0, userData);
+
+    expect(changed).toBe(true);
+    const extracted = extractPacketTrailer(frame.data);
+    expect(Array.from(extracted.data)).toEqual(Array.from(payload));
+    expect(extracted.metadata).toEqual({
+      userTimestamp: 0n,
+      frameId: 0,
+      userData,
+    });
+  });
+
+  it('passes encoded frames through when user_data is enabled but none is pending', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const frame = { data: payload.buffer } as RTCEncodedVideoFrame;
+
+    const changed = appendPacketTrailerToEncodedFrame(frame, { userData: true }, 0);
+
+    expect(changed).toBe(false);
+    expect(frame.data).toBe(payload.buffer);
+  });
+
+  it('ignores user_data when the publish options do not enable it', () => {
+    const payload = Uint8Array.from([1, 2, 3, 4]);
+    const frame = { data: payload.buffer } as RTCEncodedVideoFrame;
+
+    appendPacketTrailerToEncodedFrame(frame, { frameId: true }, 1, Uint8Array.from([7, 8, 9]));
+
+    expect(extractPacketTrailer(frame.data).metadata).toEqual({
+      userTimestamp: 0n,
+      frameId: 1,
+    });
+  });
+
+  it('passes empty encoded frames through even with pending user_data', () => {
+    const frame = { data: new ArrayBuffer(0) } as RTCEncodedVideoFrame;
+
+    const changed = appendPacketTrailerToEncodedFrame(
+      frame,
+      { userData: true },
+      0,
+      Uint8Array.from([7, 8, 9]),
+    );
+
+    expect(changed).toBe(false);
+    expect(frame.data.byteLength).toBe(0);
   });
 
   it.each([{}, { timestamp: false, frameId: false }])(

--- a/src/frameMetadata/frameMetadata.ts
+++ b/src/frameMetadata/frameMetadata.ts
@@ -15,6 +15,24 @@ export const PACKET_TRAILER_ENVELOPE_SIZE = 5;
 
 const TIMESTAMP_TLV_SIZE = 10;
 const FRAME_ID_TLV_SIZE = 6;
+const USER_DATA_TLV_HEADER_SIZE = 2;
+const MAX_TRAILER_LENGTH = 0xff;
+
+/**
+ * Maximum number of user data bytes that fit in a single frame's packet
+ * trailer alongside the TLVs implied by the given publish options. The
+ * trailer length is encoded in a single byte, capping the entire trailer
+ * (all TLVs plus the 5-byte envelope) at 255 bytes.
+ */
+export function getMaxFrameUserDataLength(options?: FrameMetadataPublishOptions): number {
+  return (
+    MAX_TRAILER_LENGTH -
+    PACKET_TRAILER_ENVELOPE_SIZE -
+    USER_DATA_TLV_HEADER_SIZE -
+    (options?.timestamp ? TIMESTAMP_TLV_SIZE : 0) -
+    (options?.frameId ? FRAME_ID_TLV_SIZE : 0)
+  );
+}
 
 export interface ExtractPacketTrailerResult {
   data: Uint8Array;
@@ -25,17 +43,26 @@ export function appendPacketTrailer(
   data: Uint8Array,
   userTimestamp: bigint,
   frameId: number,
+  userData?: Uint8Array,
 ): Uint8Array {
   const hasTimestamp = userTimestamp !== BigInt(0);
   const hasFrameId = frameId !== 0;
+  // The trailer length is a single byte; drop user data that would overflow it
+  // rather than throwing inside a frame pipeline (the public API validates the
+  // size up front).
+  const hasUserData =
+    !!userData &&
+    userData.length > 0 &&
+    userData.length <= getMaxFrameUserDataLength({ timestamp: hasTimestamp, frameId: hasFrameId });
 
-  if (!hasTimestamp && !hasFrameId) {
+  if (!hasTimestamp && !hasFrameId && !hasUserData) {
     return data;
   }
 
   const trailerLength =
     (hasTimestamp ? TIMESTAMP_TLV_SIZE : 0) +
     (hasFrameId ? FRAME_ID_TLV_SIZE : 0) +
+    (hasUserData ? USER_DATA_TLV_HEADER_SIZE + userData.length : 0) +
     PACKET_TRAILER_ENVELOPE_SIZE;
   const result = new Uint8Array(data.length + trailerLength);
   let offset = 0;
@@ -57,6 +84,15 @@ export function appendPacketTrailer(
     offset += 4;
   }
 
+  if (hasUserData) {
+    result[offset++] = PACKET_TRAILER_USER_DATA_TAG ^ 0xff;
+    result[offset++] = userData.length ^ 0xff;
+    for (let index = 0; index < userData.length; index += 1) {
+      result[offset + index] = userData[index] ^ 0xff;
+    }
+    offset += userData.length;
+  }
+
   result[offset++] = trailerLength ^ 0xff;
   result.set(PACKET_TRAILER_MAGIC, offset);
 
@@ -67,6 +103,7 @@ export function appendPacketTrailerToEncodedFrame(
   frame: RTCEncodedVideoFrame,
   options: FrameMetadataPublishOptions | undefined,
   frameId: number,
+  userData?: Uint8Array,
 ): boolean {
   if (!hasFrameMetadataPublishOptions(options) || frame.data.byteLength === 0) {
     return false;
@@ -74,8 +111,14 @@ export function appendPacketTrailerToEncodedFrame(
 
   const userTimestamp = options?.timestamp ? BigInt(Date.now()) * BigInt(1000) : BigInt(0);
   const packetTrailerFrameId = options?.frameId ? frameId : 0;
+  const packetTrailerUserData = options?.userData ? userData : undefined;
   const data = new Uint8Array(frame.data);
-  const result = appendPacketTrailer(data, userTimestamp, packetTrailerFrameId);
+  const result = appendPacketTrailer(
+    data,
+    userTimestamp,
+    packetTrailerFrameId,
+    packetTrailerUserData,
+  );
 
   if (result.byteLength === data.byteLength) {
     return false;

--- a/src/frameMetadata/types.ts
+++ b/src/frameMetadata/types.ts
@@ -12,6 +12,12 @@ export type PacketTrailerMetadata = FrameMetadata;
 export interface FrameMetadataPublishOptions {
   timestamp?: boolean;
   frameId?: boolean;
+  /**
+   * Advertises the user data feature on the published track and enables
+   * writing per-frame user data supplied via
+   * {@link LocalVideoTrack.attachUserDataToNextFrame}.
+   */
+  userData?: boolean;
 }
 
 /** @deprecated Use {@link FrameMetadataPublishOptions} instead. */
@@ -45,7 +51,16 @@ export interface PTEncodeMessage extends PTBaseMessage {
   data: {
     readableStream: ReadableStream;
     writableStream: WritableStream;
+    trackId: string;
     packetTrailer?: FrameMetadataPublishOptions;
+  };
+}
+
+export interface PTSetFrameUserDataMessage extends PTBaseMessage {
+  kind: 'setFrameUserData';
+  data: {
+    trackId: string;
+    userData?: Uint8Array;
   };
 }
 
@@ -56,6 +71,7 @@ export type PTScriptTransformOptions =
     }
   | {
       kind: 'encode';
+      trackId: string;
       packetTrailer?: FrameMetadataPublishOptions;
     };
 
@@ -78,5 +94,6 @@ export type PTWorkerMessage =
   | PTInitAck
   | PTDecodeMessage
   | PTEncodeMessage
+  | PTSetFrameUserDataMessage
   | PTUpdateTrackIdMessage
   | PTMetadataMessage;

--- a/src/frameMetadata/utils.test.ts
+++ b/src/frameMetadata/utils.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   getFrameMetadataFeatures,
   getFrameMetadataPublishOptions,
+  hasFrameMetadataPublishOptions,
   isFrameMetadataSupported,
 } from './utils';
 
@@ -83,6 +84,14 @@ describe('frame metadata publish features', () => {
     expect(getFrameMetadataFeatures({ frameId: true })).toEqual([
       PacketTrailerFeature.PTF_FRAME_ID,
     ]);
+    expect(getFrameMetadataFeatures({ userData: true })).toEqual([
+      PacketTrailerFeature.PTF_USER_DATA,
+    ]);
+    expect(getFrameMetadataFeatures({ timestamp: true, frameId: true, userData: true })).toEqual([
+      PacketTrailerFeature.PTF_USER_TIMESTAMP,
+      PacketTrailerFeature.PTF_FRAME_ID,
+      PacketTrailerFeature.PTF_USER_DATA,
+    ]);
     expect(getFrameMetadataFeatures()).toEqual([]);
   });
 
@@ -99,7 +108,26 @@ describe('frame metadata publish features', () => {
     expect(getFrameMetadataPublishOptions([PacketTrailerFeature.PTF_FRAME_ID])).toEqual({
       frameId: true,
     });
+    expect(getFrameMetadataPublishOptions([PacketTrailerFeature.PTF_USER_DATA])).toEqual({
+      userData: true,
+    });
+    expect(
+      getFrameMetadataPublishOptions([
+        PacketTrailerFeature.PTF_USER_TIMESTAMP,
+        PacketTrailerFeature.PTF_FRAME_ID,
+        PacketTrailerFeature.PTF_USER_DATA,
+      ]),
+    ).toEqual({ timestamp: true, frameId: true, userData: true });
     expect(getFrameMetadataPublishOptions()).toBeUndefined();
     expect(getFrameMetadataPublishOptions([])).toBeUndefined();
+  });
+
+  it('detects publish options with any feature enabled', () => {
+    expect(hasFrameMetadataPublishOptions({ timestamp: true })).toBe(true);
+    expect(hasFrameMetadataPublishOptions({ frameId: true })).toBe(true);
+    expect(hasFrameMetadataPublishOptions({ userData: true })).toBe(true);
+    expect(hasFrameMetadataPublishOptions({ userData: false })).toBe(false);
+    expect(hasFrameMetadataPublishOptions({})).toBe(false);
+    expect(hasFrameMetadataPublishOptions()).toBe(false);
   });
 });

--- a/src/frameMetadata/utils.ts
+++ b/src/frameMetadata/utils.ts
@@ -15,7 +15,7 @@ export function isFrameMetadataSupported(options?: FrameMetadataOptions) {
 }
 
 export function hasFrameMetadataPublishOptions(options?: FrameMetadataPublishOptions): boolean {
-  return !!(options?.timestamp || options?.frameId);
+  return !!(options?.timestamp || options?.frameId || options?.userData);
 }
 
 export function getFrameMetadataFeatures(
@@ -27,6 +27,9 @@ export function getFrameMetadataFeatures(
   }
   if (options?.frameId) {
     features.push(PacketTrailerFeature.PTF_FRAME_ID);
+  }
+  if (options?.userData) {
+    features.push(PacketTrailerFeature.PTF_USER_DATA);
   }
   return features;
 }
@@ -45,6 +48,9 @@ export function getFrameMetadataPublishOptions(
   if (features.includes(PacketTrailerFeature.PTF_FRAME_ID)) {
     options.frameId = true;
   }
+  if (features.includes(PacketTrailerFeature.PTF_USER_DATA)) {
+    options.userData = true;
+  }
 
-  return options.timestamp || options.frameId ? options : undefined;
+  return hasFrameMetadataPublishOptions(options) ? options : undefined;
 }

--- a/src/frameMetadata/worker/encodePipelineRegistry.test.ts
+++ b/src/frameMetadata/worker/encodePipelineRegistry.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vitest } from 'vitest';
+import { extractPacketTrailer } from '../frameMetadata';
+import { EncodePipelineRegistry } from './encodePipelineRegistry';
+
+class TestUnderlyingSource<T> implements UnderlyingSource<T> {
+  controller!: ReadableStreamController<T>;
+
+  start(controller: ReadableStreamController<T>): void {
+    this.controller = controller;
+  }
+
+  write(chunk: T): void {
+    this.controller.enqueue(chunk as any);
+  }
+
+  error(reason?: unknown): void {
+    this.controller.error(reason);
+  }
+
+  close(): void {
+    this.controller.close();
+  }
+}
+
+class TestUnderlyingSink<T> implements UnderlyingSink<T> {
+  public chunks: T[] = [];
+
+  write(chunk: T): void {
+    this.chunks.push(chunk);
+  }
+}
+
+function mockFrame(data: Uint8Array): RTCEncodedVideoFrame {
+  return { data: data.buffer } as RTCEncodedVideoFrame;
+}
+
+function setupPipeline(
+  registry: EncodePipelineRegistry,
+  packetTrailer?: Parameters<EncodePipelineRegistry['setupEncodeTransform']>[2],
+  trackId?: string,
+) {
+  const input = new TestUnderlyingSource<RTCEncodedVideoFrame>();
+  const output = new TestUnderlyingSink<RTCEncodedVideoFrame>();
+  registry.setupEncodeTransform(
+    new ReadableStream(input),
+    new WritableStream(output),
+    packetTrailer,
+    trackId,
+  );
+  return { input, output };
+}
+
+async function writeFrame(
+  input: TestUnderlyingSource<RTCEncodedVideoFrame>,
+  output: TestUnderlyingSink<RTCEncodedVideoFrame>,
+  data: Uint8Array,
+) {
+  const countBefore = output.chunks.length;
+  input.write(mockFrame(data));
+  await vitest.waitFor(() => expect(output.chunks.length).toBe(countBefore + 1));
+  return output.chunks[countBefore];
+}
+
+describe('EncodePipelineRegistry', () => {
+  const payload = Uint8Array.from([1, 2, 3, 4]);
+  const userData = Uint8Array.from([7, 8, 9]);
+
+  it('attaches pending user data to the next frame only', async () => {
+    const registry = new EncodePipelineRegistry();
+    const { input, output } = setupPipeline(registry, { userData: true }, 'track');
+
+    registry.setFrameUserData('track', userData);
+
+    const first = await writeFrame(input, output, payload);
+    expect(extractPacketTrailer(first.data).metadata?.userData).toEqual(userData);
+
+    const second = await writeFrame(input, output, payload);
+    expect(extractPacketTrailer(second.data).metadata).toBeUndefined();
+  });
+
+  it('replaces pending user data on subsequent calls (last write wins)', async () => {
+    const registry = new EncodePipelineRegistry();
+    const { input, output } = setupPipeline(registry, { userData: true }, 'track');
+
+    registry.setFrameUserData('track', Uint8Array.from([1]));
+    registry.setFrameUserData('track', userData);
+
+    const frame = await writeFrame(input, output, payload);
+    expect(extractPacketTrailer(frame.data).metadata?.userData).toEqual(userData);
+  });
+
+  it('fans out pending user data to every pipeline registered under the trackId', async () => {
+    const registry = new EncodePipelineRegistry();
+    const primary = setupPipeline(registry, { userData: true }, 'track');
+    const backup = setupPipeline(registry, { userData: true }, 'track');
+
+    registry.setFrameUserData('track', userData);
+
+    const primaryFrame = await writeFrame(primary.input, primary.output, payload);
+    const backupFrame = await writeFrame(backup.input, backup.output, payload);
+    expect(extractPacketTrailer(primaryFrame.data).metadata?.userData).toEqual(userData);
+    expect(extractPacketTrailer(backupFrame.data).metadata?.userData).toEqual(userData);
+  });
+
+  it('does not deliver user data to pipelines of other tracks', async () => {
+    const registry = new EncodePipelineRegistry();
+    const other = setupPipeline(registry, { userData: true }, 'other-track');
+
+    registry.setFrameUserData('track', userData);
+
+    const frame = await writeFrame(other.input, other.output, payload);
+    expect(extractPacketTrailer(frame.data).metadata).toBeUndefined();
+  });
+
+  it('stashes user data posted before pipeline registration and lets the first registrant adopt it', async () => {
+    const registry = new EncodePipelineRegistry();
+
+    registry.setFrameUserData('track', userData);
+
+    const { input, output } = setupPipeline(registry, { userData: true }, 'track');
+    const first = await writeFrame(input, output, payload);
+    expect(extractPacketTrailer(first.data).metadata?.userData).toEqual(userData);
+
+    // the stash is consumed by the first registrant
+    const late = setupPipeline(registry, { userData: true }, 'track');
+    const lateFrame = await writeFrame(late.input, late.output, payload);
+    expect(extractPacketTrailer(lateFrame.data).metadata).toBeUndefined();
+  });
+
+  it('clears pending user data and stash when called with undefined or empty data', async () => {
+    const registry = new EncodePipelineRegistry();
+    const { input, output } = setupPipeline(registry, { userData: true }, 'track');
+
+    registry.setFrameUserData('track', userData);
+    registry.setFrameUserData('track', undefined);
+
+    const first = await writeFrame(input, output, payload);
+    expect(extractPacketTrailer(first.data).metadata).toBeUndefined();
+
+    registry.setFrameUserData('track', userData);
+    registry.setFrameUserData('track', new Uint8Array(0));
+
+    const second = await writeFrame(input, output, payload);
+    expect(extractPacketTrailer(second.data).metadata).toBeUndefined();
+
+    // clearing a not-yet-adopted stash
+    const registry2 = new EncodePipelineRegistry();
+    registry2.setFrameUserData('track', userData);
+    registry2.setFrameUserData('track', undefined);
+    const pipeline2 = setupPipeline(registry2, { userData: true }, 'track');
+    const frame2 = await writeFrame(pipeline2.input, pipeline2.output, payload);
+    expect(extractPacketTrailer(frame2.data).metadata).toBeUndefined();
+  });
+
+  it('does not consume pending user data on empty frames', async () => {
+    const registry = new EncodePipelineRegistry();
+    const { input, output } = setupPipeline(registry, { userData: true }, 'track');
+
+    registry.setFrameUserData('track', userData);
+
+    const empty = await writeFrame(input, output, new Uint8Array(0));
+    expect(empty.data.byteLength).toBe(0);
+
+    const next = await writeFrame(input, output, payload);
+    expect(extractPacketTrailer(next.data).metadata?.userData).toEqual(userData);
+  });
+
+  it('keeps writing frame ids while user data is one-shot', async () => {
+    const registry = new EncodePipelineRegistry();
+    const { input, output } = setupPipeline(registry, { userData: true, frameId: true }, 'track');
+
+    registry.setFrameUserData('track', userData);
+
+    const first = await writeFrame(input, output, payload);
+    const firstMetadata = extractPacketTrailer(first.data).metadata;
+    expect(firstMetadata?.frameId).toBe(1);
+    expect(firstMetadata?.userData).toEqual(userData);
+
+    const second = await writeFrame(input, output, payload);
+    const secondMetadata = extractPacketTrailer(second.data).metadata;
+    expect(secondMetadata?.frameId).toBe(2);
+    expect(secondMetadata?.userData).toBeUndefined();
+  });
+
+  it('unregisters a pipeline when its stream terminates', async () => {
+    const registry = new EncodePipelineRegistry();
+    const internals = registry as unknown as {
+      pipelines: Map<string, Set<unknown>>;
+      pendingByKey: Map<string, Uint8Array>;
+    };
+    const { input, output } = setupPipeline(registry, { userData: true }, 'track');
+
+    input.error(new Error('stream closed'));
+    // wait for the pipe rejection to unregister the pipeline
+    await vitest.waitFor(() => {
+      expect(internals.pipelines.size).toBe(0);
+    });
+
+    // with no registered pipelines the value is stashed again
+    registry.setFrameUserData('track', userData);
+    expect(internals.pendingByKey.get('track')).toEqual(userData);
+    expect(output.chunks.length).toBe(0);
+  });
+});

--- a/src/frameMetadata/worker/encodePipelineRegistry.ts
+++ b/src/frameMetadata/worker/encodePipelineRegistry.ts
@@ -1,0 +1,117 @@
+import { appendPacketTrailerToEncodedFrame } from '../frameMetadata';
+import type { FrameMetadataPublishOptions } from '../types';
+import { hasFrameMetadataPublishOptions } from '../utils';
+
+interface EncodePipelineState {
+  /** User data to attach to the next non-empty frame, cleared once written. */
+  pendingUserData?: Uint8Array;
+}
+
+/**
+ * Tracks encode pipelines by trackId so per-frame user data posted from the
+ * main thread can be routed to every encode pipeline of a track (a track can
+ * have several pipelines when publishing backup codecs).
+ */
+export class EncodePipelineRegistry {
+  private pipelines = new Map<string, Set<EncodePipelineState>>();
+
+  /**
+   * User data received before any pipeline registered under its trackId.
+   * RTCRtpScriptTransform registration arrives via a channel separate from
+   * postMessage, so a setFrameUserData message can race ahead of it; the
+   * first pipeline registering under the key adopts the stashed value.
+   */
+  private pendingByKey = new Map<string, Uint8Array>();
+
+  setupEncodeTransform(
+    readable: ReadableStream,
+    writable: WritableStream,
+    packetTrailer?: FrameMetadataPublishOptions,
+    trackId?: string,
+  ) {
+    if (!hasFrameMetadataPublishOptions(packetTrailer)) {
+      readable.pipeTo(writable).catch(() => {});
+      return;
+    }
+
+    const state: EncodePipelineState = {};
+    if (trackId !== undefined) {
+      let states = this.pipelines.get(trackId);
+      if (!states) {
+        states = new Set();
+        this.pipelines.set(trackId, states);
+      }
+      states.add(state);
+
+      const stashed = this.pendingByKey.get(trackId);
+      if (stashed) {
+        state.pendingUserData = stashed;
+        this.pendingByKey.delete(trackId);
+      }
+    }
+
+    let frameId = 0;
+    const transform = new TransformStream({
+      transform(
+        frame: RTCEncodedVideoFrame,
+        controller: TransformStreamDefaultController<RTCEncodedVideoFrame>,
+      ) {
+        try {
+          if (packetTrailer?.frameId) {
+            frameId = frameId === 0xffffffff ? 1 : frameId + 1;
+          }
+          let userData: Uint8Array | undefined;
+          // Empty (DTX-like) frames never carry a trailer; don't let them
+          // consume the one-shot user data.
+          if (packetTrailer?.userData && frame.data.byteLength > 0) {
+            userData = state.pendingUserData;
+            state.pendingUserData = undefined;
+          }
+          appendPacketTrailerToEncodedFrame(frame, packetTrailer, frameId, userData);
+        } catch {
+          // Never drop frames on trailer-write failure.
+        }
+        controller.enqueue(frame);
+      },
+    });
+
+    readable
+      .pipeThrough(transform)
+      .pipeTo(writable)
+      .catch(() => {})
+      .finally(() => {
+        if (trackId !== undefined) {
+          const states = this.pipelines.get(trackId);
+          if (states) {
+            states.delete(state);
+            if (states.size === 0) {
+              this.pipelines.delete(trackId);
+            }
+          }
+        }
+      });
+  }
+
+  /**
+   * Sets the user data to attach to the next frame of each encode pipeline
+   * registered under the trackId. An undefined or empty value clears any
+   * pending user data instead.
+   */
+  setFrameUserData(trackId: string, userData?: Uint8Array) {
+    const normalized = userData && userData.length > 0 ? userData : undefined;
+    const states = this.pipelines.get(trackId);
+    if (states && states.size > 0) {
+      for (const state of states) {
+        state.pendingUserData = normalized;
+      }
+      this.pendingByKey.delete(trackId);
+      return;
+    }
+
+    if (normalized) {
+      this.pendingByKey.set(trackId, normalized);
+    } else {
+      this.pendingByKey.delete(trackId);
+    }
+  }
+}

--- a/src/frameMetadata/worker/frameMetadata.worker.ts
+++ b/src/frameMetadata/worker/frameMetadata.worker.ts
@@ -1,11 +1,6 @@
-import { appendPacketTrailerToEncodedFrame, processPacketTrailer } from '../frameMetadata';
-import type {
-  FrameMetadataPublishOptions,
-  PTMetadataMessage,
-  PTScriptTransformOptions,
-  PTWorkerMessage,
-} from '../types';
-import { hasFrameMetadataPublishOptions } from '../utils';
+import { processPacketTrailer } from '../frameMetadata';
+import type { PTMetadataMessage, PTScriptTransformOptions, PTWorkerMessage } from '../types';
+import { EncodePipelineRegistry } from './encodePipelineRegistry';
 
 /**
  * Holds the trackId currently associated with a pipeline. A mutable
@@ -18,6 +13,8 @@ interface PipelineState {
 }
 
 const pipelines = new Map<string, PipelineState>();
+
+const encodePipelines = new EncodePipelineRegistry();
 
 onmessage = (ev: MessageEvent<PTWorkerMessage>) => {
   const msg = ev.data;
@@ -37,11 +34,16 @@ onmessage = (ev: MessageEvent<PTWorkerMessage>) => {
       break;
 
     case 'encode':
-      setupEncodeTransform(
+      encodePipelines.setupEncodeTransform(
         msg.data.readableStream,
         msg.data.writableStream,
         msg.data.packetTrailer,
+        msg.data.trackId,
       );
+      break;
+
+    case 'setFrameUserData':
+      encodePipelines.setFrameUserData(msg.data.trackId, msg.data.userData);
       break;
 
     case 'updateTrackId':
@@ -94,40 +96,6 @@ function setupDecodeTransform(
     });
 }
 
-function setupEncodeTransform(
-  readable: ReadableStream,
-  writable: WritableStream,
-  packetTrailer?: FrameMetadataPublishOptions,
-) {
-  if (!hasFrameMetadataPublishOptions(packetTrailer)) {
-    readable.pipeTo(writable).catch(() => {});
-    return;
-  }
-
-  let frameId = 0;
-  const transform = new TransformStream({
-    transform(
-      frame: RTCEncodedVideoFrame,
-      controller: TransformStreamDefaultController<RTCEncodedVideoFrame>,
-    ) {
-      try {
-        if (packetTrailer?.frameId) {
-          frameId = frameId === 0xffffffff ? 1 : frameId + 1;
-        }
-        appendPacketTrailerToEncodedFrame(frame, packetTrailer, frameId);
-      } catch {
-        // Never drop frames on trailer-write failure.
-      }
-      controller.enqueue(frame);
-    },
-  });
-
-  readable
-    .pipeThrough(transform)
-    .pipeTo(writable)
-    .catch(() => {});
-}
-
 function updateTrackId(oldTrackId: string, newTrackId: string, hasPacketTrailer: boolean) {
   const state = pipelines.get(oldTrackId);
   if (state) {
@@ -147,7 +115,12 @@ if (self.RTCTransformEvent) {
     const transformer = event.transformer;
     const options = transformer.options as PTScriptTransformOptions;
     if (options.kind === 'encode') {
-      setupEncodeTransform(transformer.readable, transformer.writable, options.packetTrailer);
+      encodePipelines.setupEncodeTransform(
+        transformer.readable,
+        transformer.writable,
+        options.packetTrailer,
+        options.trackId,
+      );
     } else {
       setupDecodeTransform(transformer.readable, transformer.writable, options.trackId, true);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export {
   /** @deprecated Use {@link FrameMetadataOptions} instead. */
   type PacketTrailerOptions,
 } from './frameMetadata/FrameMetadataManager';
+export { getMaxFrameUserDataLength } from './frameMetadata/frameMetadata';
 
 export * from './connectionHelper/ConnectionCheck';
 export * from './connectionHelper/checks/Checker';

--- a/src/room/RTCEngine.test.ts
+++ b/src/room/RTCEngine.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import RTCEngine, { DataChannelKind } from './RTCEngine';
 import { roomOptionDefaults } from './defaults';
 import { PublishDataError } from './errors';
+import type LocalTrack from './track/LocalTrack';
+import LocalVideoTrack from './track/LocalVideoTrack';
 
 describe('RTCEngine', () => {
   const originalRTCRtpSender = window.RTCRtpSender;
@@ -58,12 +60,26 @@ describe('RTCEngine', () => {
     ).makeRTCConfiguration();
   }
 
-  function setupFrameMetadataSender(engine: RTCEngine, sender: RTCRtpSender, opts = {}) {
+  function mockLocalVideoTrack(mediaStreamID = 'stream-id') {
+    // constructing a LocalVideoTrack requires more browser APIs than happy-dom
+    // provides, so build a minimal instance with just the state the engine uses
+    const track = Object.create(LocalVideoTrack.prototype) as LocalVideoTrack;
+    Object.assign(track, { _mediaStreamID: mediaStreamID });
+    return track;
+  }
+
+  function setupFrameMetadataSender(
+    engine: RTCEngine,
+    sender: RTCRtpSender,
+    opts = {},
+    track: LocalTrack = mockLocalVideoTrack(),
+  ) {
     (
       engine as unknown as {
-        setupFrameMetadataSender: (sender: RTCRtpSender, opts?: unknown) => void;
+        setupFrameMetadataSender: (sender: RTCRtpSender, track: LocalTrack, opts?: unknown) => void;
       }
-    ).setupFrameMetadataSender(sender, opts);
+    ).setupFrameMetadataSender(sender, track, opts);
+    return track;
   }
 
   it('does not enable encoded insertable streams without E2EE or a packet trailer worker', () => {
@@ -176,11 +192,66 @@ describe('RTCEngine', () => {
         data: {
           readableStream: readable,
           writableStream: writable,
+          trackId: 'stream-id',
           packetTrailer: { timestamp: true, frameId: true },
         },
       },
       [readable, writable],
     );
+  });
+
+  it('registers a frame user data poster when userData is enabled', () => {
+    stubInsertableStreamsSupport();
+
+    const worker = { postMessage: vi.fn() } as unknown as Worker;
+    const engine = new RTCEngine({
+      ...roomOptionDefaults,
+      packetTrailer: { worker },
+    });
+    const createEncodedStreams = vi.fn(() => ({
+      readable: {} as ReadableStream,
+      writable: {} as WritableStream,
+    }));
+    const sender = {
+      createEncodedStreams,
+    } as unknown as RTCRtpSender;
+
+    const track = setupFrameMetadataSender(engine, sender, {
+      packetTrailer: { userData: true },
+    }) as LocalVideoTrack;
+
+    expect(track.frameUserDataPoster).toBeDefined();
+
+    const userData = Uint8Array.from([1, 2, 3]);
+    track.frameUserDataPoster!(userData);
+
+    expect(worker.postMessage).toHaveBeenLastCalledWith({
+      kind: 'setFrameUserData',
+      data: { trackId: 'stream-id', userData },
+    });
+  });
+
+  it('does not register a frame user data poster when userData is disabled', () => {
+    stubInsertableStreamsSupport();
+
+    const worker = { postMessage: vi.fn() } as unknown as Worker;
+    const engine = new RTCEngine({
+      ...roomOptionDefaults,
+      packetTrailer: { worker },
+    });
+    const createEncodedStreams = vi.fn(() => ({
+      readable: {} as ReadableStream,
+      writable: {} as WritableStream,
+    }));
+    const sender = {
+      createEncodedStreams,
+    } as unknown as RTCRtpSender;
+
+    const track = setupFrameMetadataSender(engine, sender, {
+      packetTrailer: { timestamp: true },
+    }) as LocalVideoTrack;
+
+    expect(track.frameUserDataPoster).toBeUndefined();
   });
 
   it('uses RTCRtpScriptTransform for sender packet trailer writes when supported', () => {
@@ -215,6 +286,7 @@ describe('RTCEngine', () => {
 
     expect(RTCRtpScriptTransform).toHaveBeenCalledWith(worker, {
       kind: 'encode',
+      trackId: 'stream-id',
       packetTrailer: { timestamp: true },
     });
     expect((sender as unknown as { transform: unknown }).transform).toBe(transform);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -54,6 +54,11 @@ import {
 } from '../api/SignalClient';
 import type { BaseE2EEManager } from '../e2ee/E2eeManager';
 import { asEncryptablePacket, isInsertableStreamSupported } from '../e2ee/utils';
+import type {
+  FrameMetadataPublishOptions,
+  PTEncodeMessage,
+  PTSetFrameUserDataMessage,
+} from '../frameMetadata/types';
 import {
   hasFrameMetadataPublishOptions,
   isFrameMetadataSupported,
@@ -1111,7 +1116,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     } else {
       throw new UnexpectedConnectionState('Required webRTC APIs not supported on this device');
     }
-    this.setupFrameMetadataSender(sender, opts);
+    this.setupFrameMetadataSender(sender, track, opts);
     return sender;
   }
 
@@ -1131,7 +1136,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       throw new UnexpectedConnectionState('Cannot stream on this device');
     }
     if (sender) {
-      this.setupFrameMetadataSender(sender, opts);
+      this.setupFrameMetadataSender(sender, track, opts);
     }
     return sender;
   }
@@ -1140,7 +1145,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     return (this.options.frameMetadata ?? this.options.packetTrailer)?.worker;
   }
 
-  private setupFrameMetadataSender(sender: RTCRtpSender, opts: TrackPublishOptions = {}) {
+  private setupFrameMetadataSender(
+    sender: RTCRtpSender,
+    track: LocalTrack,
+    opts: TrackPublishOptions = {},
+  ) {
     const worker = this.frameMetadataWorker;
     if (!worker || this.signalOpts?.e2eeEnabled) {
       return;
@@ -1154,8 +1163,10 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         // @ts-ignore
         sender.transform = new RTCRtpScriptTransform(worker, {
           kind: 'encode',
+          trackId: track.mediaStreamID,
           packetTrailer: frameMetadata,
         });
+        this.setupFrameUserDataPoster(worker, track, frameMetadata);
       }
       return;
     }
@@ -1173,20 +1184,38 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
     // @ts-ignore
     const { readable, writable } = sender.createEncodedStreams();
     if (hasMetadata) {
-      worker.postMessage(
-        {
-          kind: 'encode',
-          data: {
-            readableStream: readable,
-            writableStream: writable,
-            packetTrailer: frameMetadata,
-          },
+      const msg: PTEncodeMessage = {
+        kind: 'encode',
+        data: {
+          readableStream: readable,
+          writableStream: writable,
+          trackId: track.mediaStreamID,
+          packetTrailer: frameMetadata,
         },
-        [readable, writable],
-      );
+      };
+      worker.postMessage(msg, [readable, writable]);
+      this.setupFrameUserDataPoster(worker, track, frameMetadata);
     } else {
       readable.pipeTo(writable);
     }
+  }
+
+  private setupFrameUserDataPoster(
+    worker: Worker,
+    track: LocalTrack,
+    frameMetadata?: FrameMetadataPublishOptions,
+  ) {
+    if (!frameMetadata?.userData || !(track instanceof LocalVideoTrack)) {
+      return;
+    }
+    const trackId = track.mediaStreamID;
+    track.frameUserDataPoster = (userData) => {
+      const msg: PTSetFrameUserDataMessage = {
+        kind: 'setFrameUserData',
+        data: { trackId, userData },
+      };
+      worker.postMessage(msg);
+    };
   }
 
   private async createTransceiverRTCRtpSender(

--- a/src/room/participant/LocalParticipant.ts
+++ b/src/room/participant/LocalParticipant.ts
@@ -1589,6 +1589,9 @@ export default class LocalParticipant extends Participant {
     let negotiationNeeded = false;
     const trackSender = track.sender;
     track.sender = undefined;
+    if (isLocalVideoTrack(track)) {
+      track.frameUserDataPoster = undefined;
+    }
     if (
       this.engine.pcManager &&
       this.engine.pcManager.currentState < PCTransportState.FAILED &&

--- a/src/room/track/LocalVideoTrack.test.ts
+++ b/src/room/track/LocalVideoTrack.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { videoLayersFromEncodings } from './LocalVideoTrack';
+import { describe, expect, it, vi } from 'vitest';
+import { getMaxFrameUserDataLength } from '../../frameMetadata/frameMetadata';
+import MockMediaStreamTrack from '../../test/MockMediaStreamTrack';
+import LocalVideoTrack, { videoLayersFromEncodings } from './LocalVideoTrack';
 import { VideoQuality } from './Track';
+import type { TrackPublishOptions } from './options';
 
 describe('videoLayersFromEncodings', () => {
   it('returns single layer for no encoding', () => {
@@ -129,5 +132,84 @@ describe('videoLayersFromEncodings', () => {
     expect(layers[0].height).toBe(320);
     expect(layers[2].quality).toBe(VideoQuality.HIGH);
     expect(layers[2].width).toBe(720);
+  });
+});
+
+describe('attachUserDataToNextFrame', () => {
+  // constructing a LocalVideoTrack requires more browser APIs than happy-dom
+  // provides, so build a minimal instance with just the state the method uses
+  function createTrack(publishOptions?: TrackPublishOptions) {
+    const track = Object.create(LocalVideoTrack.prototype) as LocalVideoTrack;
+    const warn = vi.fn();
+    Object.assign(track, {
+      _mediaStreamTrack: new MockMediaStreamTrack(),
+      log: { warn },
+      publishOptions,
+    });
+    const poster = vi.fn();
+    track.frameUserDataPoster = poster;
+    return { track, poster, warn };
+  }
+
+  it('posts user data to the encode pipeline', () => {
+    const { track, poster, warn } = createTrack({ frameMetadata: { userData: true } });
+    const userData = Uint8Array.from([1, 2, 3]);
+
+    track.attachUserDataToNextFrame(userData);
+
+    expect(poster).toHaveBeenCalledWith(userData);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('normalizes undefined and empty user data to a clear', () => {
+    const { track, poster } = createTrack({ frameMetadata: { userData: true } });
+
+    track.attachUserDataToNextFrame(undefined);
+    track.attachUserDataToNextFrame(new Uint8Array(0));
+
+    expect(poster).toHaveBeenNthCalledWith(1, undefined);
+    expect(poster).toHaveBeenNthCalledWith(2, undefined);
+  });
+
+  it('warns and ignores user data when the publish options do not enable it', () => {
+    const { track, poster, warn } = createTrack({ frameMetadata: { timestamp: true } });
+
+    track.attachUserDataToNextFrame(Uint8Array.from([1, 2, 3]));
+
+    expect(poster).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('warns and ignores user data when no encode pipeline is active', () => {
+    const { track, poster, warn } = createTrack({ frameMetadata: { userData: true } });
+    track.frameUserDataPoster = undefined;
+
+    track.attachUserDataToNextFrame(Uint8Array.from([1, 2, 3]));
+
+    expect(poster).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('accepts the deprecated packetTrailer publish options alias', () => {
+    const { track, poster } = createTrack({ packetTrailer: { userData: true } });
+    const userData = Uint8Array.from([1, 2, 3]);
+
+    track.attachUserDataToNextFrame(userData);
+
+    expect(poster).toHaveBeenCalledWith(userData);
+  });
+
+  it('throws a RangeError when user data exceeds the trailer capacity', () => {
+    const options = { userData: true, timestamp: true, frameId: true };
+    const { track, poster } = createTrack({ frameMetadata: options });
+
+    const maxLength = getMaxFrameUserDataLength(options);
+    expect(() => track.attachUserDataToNextFrame(new Uint8Array(maxLength + 1))).toThrowError(
+      RangeError,
+    );
+    expect(poster).not.toHaveBeenCalled();
+
+    track.attachUserDataToNextFrame(new Uint8Array(maxLength).fill(1));
+    expect(poster).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -6,6 +6,7 @@ import {
   VideoLayer,
 } from '@livekit/protocol';
 import type { SignalClient } from '../../api/SignalClient';
+import { getMaxFrameUserDataLength } from '../../frameMetadata/frameMetadata';
 import type { StructuredLogger } from '../../logger';
 import { TrackEvent } from '../events';
 import {
@@ -71,6 +72,13 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
   /* @internal */
   lastEncodedDimensions?: Track.Dimensions;
+
+  /**
+   * Forwards frame user data to the worker running this track's encode
+   * transforms. Registered when the sender transform is set up.
+   * @internal
+   */
+  frameUserDataPoster?: (userData?: Uint8Array) => void;
 
   get sender(): RTCRtpSender | undefined {
     return this._sender;
@@ -416,6 +424,42 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
         this.log.warn(`failed to set degradationPreference`, { error: e, ...this.logContext });
       }
     }
+  }
+
+  /**
+   * Attaches user data to the next encoded frame of this track as frame
+   * metadata. The data is written once to the next frame of each active
+   * encode pipeline (primary and backup-codec senders) and cleared
+   * afterwards. Calling again before a frame is encoded replaces the pending
+   * value (last write wins); passing `undefined` or an empty array clears it.
+   *
+   * Requires the track to be published with
+   * `frameMetadata: { userData: true }` and a frame metadata worker (or E2EE)
+   * configured on the room.
+   *
+   * @throws RangeError when userData does not fit in the frame trailer; use
+   * {@link getMaxFrameUserDataLength} to size payloads ahead of time
+   * @experimental
+   */
+  attachUserDataToNextFrame(userData?: Uint8Array) {
+    const fmOpts = this.publishOptions?.frameMetadata ?? this.publishOptions?.packetTrailer;
+    if (!fmOpts?.userData) {
+      this.log.warn(
+        'ignoring frame user data; track was not published with frameMetadata userData enabled',
+        this.logContext,
+      );
+      return;
+    }
+    if (!this.frameUserDataPoster) {
+      this.log.warn('ignoring frame user data; no active encode pipeline', this.logContext);
+      return;
+    }
+    if (userData && userData.byteLength > getMaxFrameUserDataLength(fmOpts)) {
+      throw new RangeError(
+        `frame user data exceeds the maximum of ${getMaxFrameUserDataLength(fmOpts)} bytes for the current frame metadata options`,
+      );
+    }
+    this.frameUserDataPoster(userData && userData.byteLength > 0 ? userData : undefined);
   }
 
   addSimulcastTrack(

--- a/src/room/track/options.ts
+++ b/src/room/track/options.ts
@@ -136,6 +136,9 @@ export interface TrackPublishDefaults {
    * Requires either room-level frame metadata worker configuration or E2EE,
    * because encoded frame transforms are used to write the metadata.
    *
+   * With `userData` enabled, per-frame user data can be attached via
+   * {@link LocalVideoTrack.attachUserDataToNextFrame}.
+   *
    * @experimental
    */
   frameMetadata?: FrameMetadataPublishOptions;


### PR DESCRIPTION
Fixes #2012

## What

Adds the missing publish-side counterpart to the receive-side `user_data` parsing introduced in #1983:

- **`FrameMetadataPublishOptions.userData?: boolean`** — opt-in flag that advertises `PTF_USER_DATA` on the published track.
- **`LocalVideoTrack.attachUserDataToNextFrame(userData?: Uint8Array)`** — attaches the bytes to the next encoded frame as a `0x03` user_data TLV in the `LKTS` frame trailer.
- **`getMaxFrameUserDataLength(options)`** (exported) — computes the payload cap implied by the single-byte trailer length (248 bytes for user_data alone, 232 alongside timestamp + frameId).

## Semantics

`attachUserDataToNextFrame` is **one-shot**: the value is written once to the next encoded frame of *each* active encode pipeline of the track (primary and backup-codec senders), then cleared. Calling again before a frame is encoded replaces the pending value (last write wins); `undefined`/empty clears it. Oversized payloads throw a `RangeError` at the API; the wire encoder additionally drops an overflowing TLV defensively since frame pipelines must never throw. Empty (DTX-like) frames never consume the pending value.

## How

- `appendPacketTrailer` gained a `userData` parameter emitting the `0x03` TLV byte-exactly matching the existing parser (tag/len/value all XOR `0xFF`).
- **Non-E2EE**: encode pipelines in the frame metadata worker were previously anonymous; they are now keyed by `track.mediaStreamID` in a new `EncodePipelineRegistry`, and a new `setFrameUserData` worker message routes pending bytes to every pipeline of the track. A small stash covers the `RTCRtpScriptTransform` registration race (`onrtctransform` arrives on a different channel than `postMessage`). `RTCEngine.setupFrameMetadataSender` registers a poster on the track that forwards the bytes.
- **E2EE**: `FrameCryptor` stores the pending value and writes it after encryption (trailer stays outside the ciphertext, matching extract-before-decrypt on receive). The `setFrameUserData` message uses `getTrackCryptor`'s create-if-missing semantics, so data posted before the encode transform registers is kept — and `setFrameMetadataOpts` deliberately does not clear it.
- `@livekit/protocol` bumped 1.46.6 → 1.49.0, the first 1.x release with `PTF_USER_DATA`.
- Demo: new "Attach User Data" checkbox + send box; the receive side already renders user_data since #1983.

## Notes for reviewers

- Older receivers gate extraction on `packetTrailerFeatures.length > 0`, which a userData-only track satisfies (proto3 open enums preserve the unknown value), and SDKs ≥ 2.20.1 already parse tag `0x03`. Forwarding of the new enum value by older SFU builds is worth a sanity check; combining `userData` with `timestamp`/`frameId` is the safe fallback.
- 35 new tests: encoder round-trips against the reference trailer builder, feature mapping, registry one-shot/fan-out/race/teardown behavior, FrameCryptor E2EE paths (including the passthrough path and pending-survives-setup regression), `LocalVideoTrack` validation, and `RTCEngine` poster wiring.
- Also smoke-tested the built `livekit-client.fm.worker.mjs` in a browser by transferring streams into it and driving the message protocol end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)