### PR TITLE
Add a drop-down option to choose back up codec.

### DIFF
--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -3,6 +3,7 @@ import E2EEWorker from '../../src/e2ee/worker/e2ee.worker?worker';
 //@ts-ignore
 import FrameMetadataWorker from '../../src/frameMetadata/worker/frameMetadata.worker?worker';
 import type {
+  BackupVideoCodec,
   ChatMessage,
   LocalDataTrack,
   RemoteDataTrack,
@@ -188,6 +189,7 @@ const appActions = {
     if ((<HTMLInputElement>$('multicodec-simulcast')).checked) {
       backupCodecPolicy = BackupCodecPolicy.SIMULCAST;
     }
+    const backupCodec = (<HTMLSelectElement>$('backup-codec')).value as BackupVideoCodec;
 
     updateSearchParams(url, token, cryptoKey);
 
@@ -207,6 +209,7 @@ const appActions = {
         screenShareEncoding: ScreenSharePresets.h1080fps30.encoding,
         scalabilityMode: 'L3T3_KEY',
         backupCodecPolicy: backupCodecPolicy,
+        backupCodec: { codec: backupCodec || 'vp8' },
         frameMetadata,
       },
       videoCaptureDefaults: {
@@ -1938,6 +1941,19 @@ function populateSupportedCodecs() {
     n.value = o[0];
     n.appendChild(document.createTextNode(o[1]));
     codecSelect.appendChild(n);
+  }
+
+  const backupCodecSelect = $('backup-codec');
+  const backupCodecOptions: string[][] = [
+    ['', 'Backup codec'],
+    ['h264', 'H.264'],
+    ['vp8', 'VP8'],
+  ];
+  for (const o of backupCodecOptions) {
+    const n = document.createElement('option');
+    n.value = o[0];
+    n.appendChild(document.createTextNode(o[1]));
+    backupCodecSelect.appendChild(n);
   }
 }
 

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -222,7 +222,8 @@ const appActions = {
     };
     if (
       roomOpts.publishDefaults?.videoCodec === 'av1' ||
-      roomOpts.publishDefaults?.videoCodec === 'vp9'
+      roomOpts.publishDefaults?.videoCodec === 'vp9' ||
+      roomOpts.publishDefaults?.videoCodec === 'h265'
     ) {
       if (!backupCodec) {
         roomOpts.publishDefaults.backupCodec = true;

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -224,7 +224,9 @@ const appActions = {
       roomOpts.publishDefaults?.videoCodec === 'av1' ||
       roomOpts.publishDefaults?.videoCodec === 'vp9'
     ) {
-      roomOpts.publishDefaults.backupCodec = true;
+      if (!backupCodec) {
+        roomOpts.publishDefaults.backupCodec = true;
+      }
       if (scalabilityMode !== '') {
         roomOpts.publishDefaults.scalabilityMode = scalabilityMode as ScalabilityMode;
       }

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -209,7 +209,7 @@ const appActions = {
         screenShareEncoding: ScreenSharePresets.h1080fps30.encoding,
         scalabilityMode: 'L3T3_KEY',
         backupCodecPolicy: backupCodecPolicy,
-        backupCodec: { codec: backupCodec || 'vp8' },
+        backupCodec: backupCodec ? { codec: backupCodec } : undefined,
         frameMetadata,
       },
       videoCaptureDefaults: {
@@ -225,7 +225,7 @@ const appActions = {
       roomOpts.publishDefaults?.videoCodec === 'vp9' ||
       roomOpts.publishDefaults?.videoCodec === 'h265'
     ) {
-      if (!backupCodec) {
+      if (!roomOpts.publishDefaults.backupCodec) {
         roomOpts.publishDefaults.backupCodec = true;
       }
       if (scalabilityMode !== '') {

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -110,6 +110,9 @@
                 >MultiCodec-Simulcast
               </label>
             </div>
+            <div>
+              <select id="backup-codec" class="custom-select" style="width: auto"></select>
+            </div>
           </div>
 
           <!-- actions -->


### PR DESCRIPTION
Not the prettiest (in general, feels like the options area can use a re-work to categorise, actually the buttons area too). But, adding this as I was testing this bug report for server (https://github.com/livekit/livekit/issues/4695)