### PR TITLE
Downgrade sdp transform

### DIFF
--- a/.changeset/yummy-trams-turn.md
+++ b/.changeset/yummy-trams-turn.md
@@ -1,5 +1,0 @@
----
-"livekit-client": patch
----
-
-Update dependency sdp-transform to v3

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "events": "^3.3.0",
     "jose": "^6.1.0",
     "loglevel": "^1.9.2",
-    "sdp-transform": "^3.0.0",
+    "sdp-transform": "^2.15.0",
     "tslib": "2.8.1",
     "typed-emitter": "^2.1.0",
     "webrtc-adapter": "9.0.6"
@@ -102,7 +102,7 @@
     "@stylistic/eslint-plugin": "^5.10.0",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/events": "^3.0.3",
-    "@types/sdp-transform": "3.0.0",
+    "@types/sdp-transform": "2.15.0",
     "@types/ua-parser-js": "0.7.39",
     "@typescript-eslint/eslint-plugin": "8.59.4",
     "@typescript-eslint/parser": "8.59.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.9.2
         version: 1.9.2
       sdp-transform:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^2.15.0
+        version: 2.15.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -100,8 +100,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       '@types/sdp-transform':
-        specifier: 3.0.0
-        version: 3.0.0
+        specifier: 2.15.0
+        version: 2.15.0
       '@types/ua-parser-js':
         specifier: 0.7.39
         version: 0.7.39
@@ -1541,8 +1541,8 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
-  '@types/sdp-transform@3.0.0':
-    resolution: {integrity: sha512-TLwbrRILH3mwnrXgjZLb2LXursBR/dnumGgFWKm8Jw3nTJCAN0g80pvS4KVpXHz4DpYtne762lcXin9GmShGbg==}
+  '@types/sdp-transform@2.15.0':
+    resolution: {integrity: sha512-ikIFF0EaYt/2XetIYYVeMj6SB52oVXFasJUXDzWHgzNJS5ep2Pbsu7f8f3Za+dEie8HQtt3Zr9mHYBpWT0XgxQ==}
 
   '@types/ua-parser-js@0.7.39':
     resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
@@ -3453,8 +3453,8 @@ packages:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
 
-  sdp-transform@3.0.0:
-    resolution: {integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==}
+  sdp-transform@2.15.0:
+    resolution: {integrity: sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==}
     hasBin: true
 
   sdp@3.2.2:
@@ -5457,7 +5457,7 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@types/sdp-transform@3.0.0': {}
+  '@types/sdp-transform@2.15.0': {}
 
   '@types/ua-parser-js@0.7.39': {}
 
@@ -7621,7 +7621,7 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
-  sdp-transform@3.0.0: {}
+  sdp-transform@2.15.0: {}
 
   sdp@3.2.2: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
   "minimumReleaseAge": "2 weeks",
   "packageRules": [
     {
+      "description": "Keep sdp-transform on v2: v3 corrupts valid MSIDs containing `|` (clux/sdp-transform#106).",
+      "matchPackageNames": ["sdp-transform", "@types/sdp-transform"],
+      "enabled": false
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "devDependencies (non-major)"

--- a/src/room/PCTransport.test.ts
+++ b/src/room/PCTransport.test.ts
@@ -1,6 +1,10 @@
 import { type MediaDescription, parse } from 'sdp-transform';
 import { describe, expect, it } from 'vitest';
-import { conformBundledCodecFmtp, placeholderMidsFromTransceivers } from './PCTransport';
+import {
+  applyVideoStartBitrate,
+  conformBundledCodecFmtp,
+  placeholderMidsFromTransceivers,
+} from './PCTransport';
 
 /** Parse the `key[=value]` pairs of an fmtp config into a comparable set. */
 const paramSet = (config: string) => new Set(config.split(';').filter(Boolean));
@@ -51,6 +55,35 @@ a=mid:3
 a=recvonly
 a=rtpmap:49 H265/90000
 a=fmtp:49 level-id=180;profile-id=1;tier-flag=0;tx-mode=SRST`;
+
+describe('video start bitrate', () => {
+  it('applies the bitrate only to the section whose msid track ID matches the cid', () => {
+    const { media } = parse(`v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0 1
+m=video 9 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 0.0.0.0
+a=mid:0
+a=sendonly
+a=msid:PA_remote|camera other-track
+a=rtpmap:96 VP8/90000
+m=video 9 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 0.0.0.0
+a=mid:1
+a=sendonly
+a=msid:PA_remote|camera camera-cid
+a=rtpmap:96 VP8/90000`);
+
+    for (const section of media) {
+      applyVideoStartBitrate(section, 'camera-cid', 'VP8', 1_000);
+    }
+
+    expect(fmtpOf(media, '0', 96)).toBeUndefined();
+    expect(paramSet(fmtpOf(media, '1', 96)!)).toContain('x-google-start-bitrate=900');
+  });
+});
 
 describe('placeholderMidsFromTransceivers', () => {
   const tr = (mid: string | null, track: unknown) =>

--- a/src/room/PCTransport.test.ts
+++ b/src/room/PCTransport.test.ts
@@ -1,10 +1,6 @@
 import { type MediaDescription, parse } from 'sdp-transform';
 import { describe, expect, it } from 'vitest';
-import {
-  applyVideoStartBitrate,
-  conformBundledCodecFmtp,
-  placeholderMidsFromTransceivers,
-} from './PCTransport';
+import { conformBundledCodecFmtp, placeholderMidsFromTransceivers } from './PCTransport';
 
 /** Parse the `key[=value]` pairs of an fmtp config into a comparable set. */
 const paramSet = (config: string) => new Set(config.split(';').filter(Boolean));
@@ -55,36 +51,6 @@ a=mid:3
 a=recvonly
 a=rtpmap:49 H265/90000
 a=fmtp:49 level-id=180;profile-id=1;tier-flag=0;tx-mode=SRST`;
-
-describe('video start bitrate', () => {
-  it('matches the track cid in an sdp-transform v3 msid array', () => {
-    const { media } = parse(`v=0
-o=- 0 0 IN IP4 127.0.0.1
-s=-
-t=0 0
-a=group:BUNDLE 0 1
-m=video 9 UDP/TLS/RTP/SAVPF 96
-c=IN IP4 0.0.0.0
-a=mid:0
-a=sendonly
-a=msid:stream-a other-track
-a=rtpmap:96 VP8/90000
-m=video 9 UDP/TLS/RTP/SAVPF 96
-c=IN IP4 0.0.0.0
-a=mid:1
-a=sendonly
-a=msid:stream-b another-track
-a=msid:stream-c camera-cid
-a=rtpmap:96 VP8/90000`);
-
-    for (const section of media) {
-      applyVideoStartBitrate(section, 'camera-cid', 'VP8', 1_000);
-    }
-
-    expect(fmtpOf(media, '0', 96)).toBeUndefined();
-    expect(paramSet(fmtpOf(media, '1', 96)!)).toContain('x-google-start-bitrate=900');
-  });
-});
 
 describe('placeholderMidsFromTransceivers', () => {
   const tr = (mid: string | null, track: unknown) =>

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -36,6 +36,64 @@ const maxStartBitrateKbps = 1000;
 
 const debounceInterval = 20;
 
+/**
+ * Applies the configured start bitrate when this media section belongs to `cid`.
+ * This SDP munging is used for a bitrate setting that cannot be applied through
+ * `RTCRtpEncodingParameters`.
+ *
+ * Returns `undefined` when the section does not belong to the track, `0` when
+ * it does but does not offer the requested codec, and the codec payload when the
+ * requested codec is present (whether the bitrate was added or already set).
+ *
+ * @internal
+ */
+export function applyVideoStartBitrate(
+  media: MediaDescription,
+  cid: string,
+  codec: string,
+  maxbr: number,
+  isScreenShare = false,
+): number | undefined {
+  const trackId = media.msid?.split(' ')[1];
+  if (trackId !== cid) {
+    return undefined;
+  }
+
+  const codecPayload =
+    media.rtp.find((rtp) => rtp.codec.toUpperCase() === codec.toUpperCase())?.payload ?? 0;
+  if (codecPayload === 0) {
+    return 0;
+  }
+
+  // Use 90% of target bitrate, capped at 1 Mbps for camera to prevent BWE
+  // from starting too aggressively. Screen share is not capped since text/UI
+  // clarity requires high bitrate from the start.
+  // TODO: dynamically adjust start bitrate based on network conditions (e.g., previous BWE estimate)
+  const calculatedStartBitrate = Math.round(maxbr * startBitrateMultiplier);
+  const startBitrate = isScreenShare
+    ? calculatedStartBitrate
+    : Math.min(calculatedStartBitrate, maxStartBitrateKbps);
+
+  const fmtp = media.fmtp.find((entry) => entry.payload === codecPayload);
+  if (fmtp) {
+    // If another track's fmtp already has a start bitrate, it cannot be
+    // overridden here because the payload type is shared across the bundle.
+    // This forces every track sharing that payload to use the initial track's
+    // start bitrate.
+    if (!fmtp.config.includes('x-google-start-bitrate')) {
+      fmtp.config += `;x-google-start-bitrate=${startBitrate}`;
+    }
+  } else {
+    // VP8 and some codecs may not have an existing fmtp line.
+    media.fmtp.push({
+      payload: codecPayload,
+      config: `x-google-start-bitrate=${startBitrate}`,
+    });
+  }
+
+  return codecPayload;
+}
+
 export const PCEvents = {
   NegotiationStarted: 'negotiationStarted',
   NegotiationComplete: 'negotiationComplete',
@@ -396,56 +454,25 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
           ensureAudioNackAndStereo(media, ['all'], []);
         } else if (media.type === 'video') {
           this.trackBitrates.some((trackbr): boolean => {
-            if (!media.msid || !trackbr.cid || !media.msid.includes(trackbr.cid)) {
+            if (!trackbr.cid) {
               return false;
             }
 
-            let codecPayload = 0;
-            media.rtp.some((rtp): boolean => {
-              if (rtp.codec.toUpperCase() === trackbr.codec.toUpperCase()) {
-                codecPayload = rtp.payload;
-                return true;
-              }
+            const codecPayload = applyVideoStartBitrate(
+              media,
+              trackbr.cid,
+              trackbr.codec,
+              trackbr.maxbr,
+              trackbr.isScreenShare,
+            );
+            if (codecPayload === undefined) {
               return false;
-            });
-
-            if (codecPayload === 0) {
-              return true;
             }
 
-            if (isSVCCodec(trackbr.codec) && !isSafari()) {
+            if (codecPayload > 0 && isSVCCodec(trackbr.codec) && !isSafari()) {
               this.ensureVideoDDExtensionForSVC(media, sdpParsed);
             }
 
-            // mung sdp for bitrate setting that can't apply by sendEncoding
-            // Use 90% of target bitrate, capped at 1 Mbps for camera to prevent BWE from starting too aggressively
-            // Screen share is not capped since text/UI clarity requires high bitrate from the start
-            // TODO: dynamically adjust start bitrate based on network conditions (e.g., use previous BWE estimate)
-            const calculatedStartBitrate = Math.round(trackbr.maxbr * startBitrateMultiplier);
-            const startBitrate = trackbr.isScreenShare
-              ? calculatedStartBitrate
-              : Math.min(calculatedStartBitrate, maxStartBitrateKbps);
-
-            let fmtpFound = false;
-            for (const fmtp of media.fmtp) {
-              if (fmtp.payload === codecPayload) {
-                fmtpFound = true;
-                // if another track's fmtp already is set, we cannot override the bitrate
-                // this has the unfortunate consequence of being forced to use the
-                // initial track's bitrate for all tracks
-                if (!fmtp.config.includes('x-google-start-bitrate')) {
-                  fmtp.config += `;x-google-start-bitrate=${startBitrate}`;
-                }
-                break;
-              }
-            }
-            // VP8 and some codecs may not have an existing fmtp line - create one
-            if (!fmtpFound) {
-              media.fmtp.push({
-                payload: codecPayload,
-                config: `x-google-start-bitrate=${startBitrate}`,
-              });
-            }
             return true;
           });
         }

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -36,63 +36,6 @@ const maxStartBitrateKbps = 1000;
 
 const debounceInterval = 20;
 
-/**
- * Applies the configured start bitrate when this media section belongs to `cid`.
- * This SDP munging is used for a bitrate setting that cannot be applied through
- * `RTCRtpEncodingParameters`.
- *
- * Returns `undefined` when the section does not belong to the track, `0` when
- * it does but does not offer the requested codec, and the codec payload when the
- * requested codec is present (whether the bitrate was added or already set).
- *
- * @internal
- */
-export function applyVideoStartBitrate(
-  media: MediaDescription,
-  cid: string,
-  codec: string,
-  maxbr: number,
-  isScreenShare = false,
-): number | undefined {
-  if (!media.msid?.some(({ appdata: trackId }) => trackId === cid)) {
-    return undefined;
-  }
-
-  const codecPayload =
-    media.rtp.find((rtp) => rtp.codec.toUpperCase() === codec.toUpperCase())?.payload ?? 0;
-  if (codecPayload === 0) {
-    return 0;
-  }
-
-  // Use 90% of target bitrate, capped at 1 Mbps for camera to prevent BWE
-  // from starting too aggressively. Screen share is not capped since text/UI
-  // clarity requires high bitrate from the start.
-  // TODO: dynamically adjust start bitrate based on network conditions (e.g., previous BWE estimate)
-  const calculatedStartBitrate = Math.round(maxbr * startBitrateMultiplier);
-  const startBitrate = isScreenShare
-    ? calculatedStartBitrate
-    : Math.min(calculatedStartBitrate, maxStartBitrateKbps);
-
-  const fmtp = media.fmtp.find((entry) => entry.payload === codecPayload);
-  if (fmtp) {
-    // If another track's fmtp already has a start bitrate, it cannot be
-    // overridden here because the payload type is shared across the bundle.
-    // This forces every track sharing that payload to use the initial track's
-    // start bitrate.
-    if (!fmtp.config.includes('x-google-start-bitrate')) {
-      fmtp.config += `;x-google-start-bitrate=${startBitrate}`;
-    }
-  } else {
-    // VP8 and some codecs may not have an existing fmtp line.
-    media.fmtp.push({
-      payload: codecPayload,
-      config: `x-google-start-bitrate=${startBitrate}`,
-    });
-  }
-
-  return codecPayload;
-}
-
 export const PCEvents = {
   NegotiationStarted: 'negotiationStarted',
   NegotiationComplete: 'negotiationComplete',
@@ -453,25 +396,56 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
           ensureAudioNackAndStereo(media, ['all'], []);
         } else if (media.type === 'video') {
           this.trackBitrates.some((trackbr): boolean => {
-            if (!trackbr.cid) {
+            if (!media.msid || !trackbr.cid || !media.msid.includes(trackbr.cid)) {
               return false;
             }
 
-            const codecPayload = applyVideoStartBitrate(
-              media,
-              trackbr.cid,
-              trackbr.codec,
-              trackbr.maxbr,
-              trackbr.isScreenShare,
-            );
-            if (codecPayload === undefined) {
+            let codecPayload = 0;
+            media.rtp.some((rtp): boolean => {
+              if (rtp.codec.toUpperCase() === trackbr.codec.toUpperCase()) {
+                codecPayload = rtp.payload;
+                return true;
+              }
               return false;
+            });
+
+            if (codecPayload === 0) {
+              return true;
             }
 
-            if (codecPayload > 0 && isSVCCodec(trackbr.codec) && !isSafari()) {
+            if (isSVCCodec(trackbr.codec) && !isSafari()) {
               this.ensureVideoDDExtensionForSVC(media, sdpParsed);
             }
 
+            // mung sdp for bitrate setting that can't apply by sendEncoding
+            // Use 90% of target bitrate, capped at 1 Mbps for camera to prevent BWE from starting too aggressively
+            // Screen share is not capped since text/UI clarity requires high bitrate from the start
+            // TODO: dynamically adjust start bitrate based on network conditions (e.g., use previous BWE estimate)
+            const calculatedStartBitrate = Math.round(trackbr.maxbr * startBitrateMultiplier);
+            const startBitrate = trackbr.isScreenShare
+              ? calculatedStartBitrate
+              : Math.min(calculatedStartBitrate, maxStartBitrateKbps);
+
+            let fmtpFound = false;
+            for (const fmtp of media.fmtp) {
+              if (fmtp.payload === codecPayload) {
+                fmtpFound = true;
+                // if another track's fmtp already is set, we cannot override the bitrate
+                // this has the unfortunate consequence of being forced to use the
+                // initial track's bitrate for all tracks
+                if (!fmtp.config.includes('x-google-start-bitrate')) {
+                  fmtp.config += `;x-google-start-bitrate=${startBitrate}`;
+                }
+                break;
+              }
+            }
+            // VP8 and some codecs may not have an existing fmtp line - create one
+            if (!fmtpFound) {
+              media.fmtp.push({
+                payload: codecPayload,
+                config: `x-google-start-bitrate=${startBitrate}`,
+              });
+            }
             return true;
           });
         }

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -54,8 +54,7 @@ export function applyVideoStartBitrate(
   maxbr: number,
   isScreenShare = false,
 ): number | undefined {
-  const trackId = media.msid?.split(' ')[1];
-  if (trackId !== cid) {
+  if (!media.msid?.includes(cid)) {
     return undefined;
   }
 


### PR DESCRIPTION
reverts #2023 due to a regex bug that stops parsing msids at `|` (which we use as a separator). 

Also adds a rule to the renovate config to not update sdp-transform