### PR TITLE
fix: enable Terser `mangle.safari10` to fix RN scoping issues

### DIFF
--- a/.changeset/sour-peas-own.md
+++ b/.changeset/sour-peas-own.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+fix: enable Terser `mangle.safari10` to fix scoping issues for variables in react-native

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,7 +48,9 @@ export default {
       strict: true,
       sourcemap: true,
       name: kebabCaseToPascalCase(packageJson.name),
-      plugins: [terser()],
+      // mangle.safari10: avoid catch/finally identifier reuse that React Native 
+      // Hermes mis-resolves after catch return (client-sdk-js#1952).
+      plugins: [terser({ mangle: { safari10: true } })],
     },
   ],
   plugins: [typescript({ tsconfig: './tsconfig.json' }), ...commonPlugins],


### PR DESCRIPTION
Fixes #1952.

Turning on `mangle.safari10` enables some extra handling around try/catch clauses which clears up the similar issue found on older Hermes versions (used by < RN0.84).