### PR TITLE
fix: exact-token opus fmtp matching and case-insensitive opus lookup

### DIFF
--- a/.changeset/lazy-mangos-punch.md
+++ b/.changeset/lazy-mangos-punch.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: match opus fmtp parameters by exact token and look up the opus codec case-insensitively when munging SDP

--- a/src/room/PCTransport.test.ts
+++ b/src/room/PCTransport.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
   applyVideoStartBitrate,
   conformBundledCodecFmtp,
+  ensureAudioNackAndStereo,
+  extractStereoAndNackAudioFromOffer,
+  fmtpConfigHasParam,
   placeholderMidsFromTransceivers,
 } from './PCTransport';
 
@@ -179,5 +182,97 @@ a=fmtp:49 level-id=180;profile-id=1;tier-flag=0;tx-mode=SRST`);
     expect(paramSet(fmtpOf(media, '3', 49)!)).toContain('level-id=186'); // real send untouched
     expect(fmtpOf(media, '4', 49)).toBe(fmtpOf(media, '3', 49)); // stale conformed
     expect(fmtpOf(media, '5', 49)).toBe(fmtpOf(media, '3', 49)); // placeholder conformed
+  });
+});
+
+describe('fmtpConfigHasParam', () => {
+  it('matches a whole `;`-delimited parameter, not a substring', () => {
+    // `stereo=1` is a substring of `sprop-stereo=1` — an exact-token match must
+    // not treat the latter as declaring the former.
+    expect(fmtpConfigHasParam('minptime=10;stereo=1', 'stereo=1')).toBe(true);
+    expect(fmtpConfigHasParam('minptime=10;sprop-stereo=1', 'stereo=1')).toBe(false);
+    expect(fmtpConfigHasParam('minptime=10;sprop-stereo=1', 'sprop-stereo=1')).toBe(true);
+  });
+
+  it('tolerates surrounding whitespace between parameters', () => {
+    expect(fmtpConfigHasParam('minptime=10; stereo=1', 'stereo=1')).toBe(true);
+  });
+});
+
+/** Build a parsed audio media section from its `a=` lines for the munge helpers. */
+const audioSection = (rtpmap: string, fmtp: string, mid = '0') =>
+  parse(`v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=mid:${mid}
+${rtpmap}
+${fmtp}`).media[0];
+
+describe('ensureAudioNackAndStereo', () => {
+  it('adds stereo=1 even when sprop-stereo=1 is already present', () => {
+    const media = audioSection(
+      'a=rtpmap:111 opus/48000/2',
+      'a=fmtp:111 minptime=10;sprop-stereo=1',
+    );
+
+    ensureAudioNackAndStereo(media as any, ['all'], []);
+
+    const config = media.fmtp.find((f) => f.payload === 111)!.config;
+    expect(paramSet(config)).toContain('stereo=1');
+    expect(paramSet(config)).toContain('sprop-stereo=1');
+  });
+
+  it('does not add a duplicate stereo=1 when it is already present', () => {
+    const media = audioSection('a=rtpmap:111 opus/48000/2', 'a=fmtp:111 minptime=10;stereo=1');
+
+    ensureAudioNackAndStereo(media as any, ['all'], []);
+
+    const config = media.fmtp.find((f) => f.payload === 111)!.config;
+    expect(config.match(/(?:^|;)stereo=1(?:;|$)/g)).toHaveLength(1);
+  });
+
+  it('matches the opus codec case-insensitively (RFC 4855)', () => {
+    const media = audioSection('a=rtpmap:111 OPUS/48000/2', 'a=fmtp:111 minptime=10');
+
+    ensureAudioNackAndStereo(media as any, ['all'], []);
+
+    expect(paramSet(media.fmtp.find((f) => f.payload === 111)!.config)).toContain('stereo=1');
+  });
+});
+
+describe('extractStereoAndNackAudioFromOffer', () => {
+  const offerWith = (rtpmap: string, fmtp: string) => ({
+    type: 'offer' as const,
+    sdp: `v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+a=mid:0
+${rtpmap}
+${fmtp}`,
+  });
+
+  it('detects sprop-stereo=1 as a whole parameter', () => {
+    const { stereoMids } = extractStereoAndNackAudioFromOffer(
+      offerWith('a=rtpmap:111 opus/48000/2', 'a=fmtp:111 minptime=10;sprop-stereo=1'),
+    );
+    expect(stereoMids).toEqual(['0']);
+  });
+
+  it('does not treat plain stereo=1 as sprop-stereo=1', () => {
+    const { stereoMids } = extractStereoAndNackAudioFromOffer(
+      offerWith('a=rtpmap:111 opus/48000/2', 'a=fmtp:111 minptime=10;stereo=1'),
+    );
+    expect(stereoMids).toEqual([]);
+  });
+
+  it('matches the opus codec case-insensitively (RFC 4855)', () => {
+    const { stereoMids } = extractStereoAndNackAudioFromOffer(
+      offerWith('a=rtpmap:111 OPUS/48000/2', 'a=fmtp:111 minptime=10;sprop-stereo=1'),
+    );
+    expect(stereoMids).toEqual(['0']);
   });
 });

--- a/src/room/PCTransport.ts
+++ b/src/room/PCTransport.ts
@@ -744,7 +744,19 @@ export default class PCTransport extends (EventEmitter as new () => TypedEmitter
   }
 }
 
-function ensureAudioNackAndStereo(
+/**
+ * Checks whether an fmtp config declares `param` as an exact, `;`-delimited
+ * token. A plain substring check conflates distinct opus parameters — e.g.
+ * `stereo=1` is a substring of `sprop-stereo=1` — so `param` must match a whole
+ * parameter, not appear anywhere within the config string.
+ * @internal
+ */
+export function fmtpConfigHasParam(config: string, param: string): boolean {
+  return config.split(';').some((entry) => entry.trim() === param);
+}
+
+/** @internal */
+export function ensureAudioNackAndStereo(
   media: {
     type: string;
     port: number;
@@ -760,7 +772,8 @@ function ensureAudioNackAndStereo(
   // found opus codec to add nack fb
   let opusPayload = 0;
   media.rtp.some((rtp): boolean => {
-    if (rtp.codec === 'opus') {
+    // rtpmap encoding names are case-insensitive (RFC 4855)
+    if (rtp.codec.toLowerCase() === 'opus') {
       opusPayload = rtp.payload;
       return true;
     }
@@ -786,7 +799,7 @@ function ensureAudioNackAndStereo(
     if (stereoMids.includes(mid) || (stereoMids.length === 1 && stereoMids[0] === 'all')) {
       media.fmtp.some((fmtp): boolean => {
         if (fmtp.payload === opusPayload) {
-          if (!fmtp.config.includes('stereo=1')) {
+          if (!fmtpConfigHasParam(fmtp.config, 'stereo=1')) {
             fmtp.config += ';stereo=1';
           }
           return true;
@@ -877,7 +890,8 @@ export function conformBundledCodecFmtp(
   }
 }
 
-function extractStereoAndNackAudioFromOffer(offer: RTCSessionDescriptionInit): {
+/** @internal */
+export function extractStereoAndNackAudioFromOffer(offer: RTCSessionDescriptionInit): {
   stereoMids: string[];
   nackMids: string[];
 } {
@@ -889,7 +903,8 @@ function extractStereoAndNackAudioFromOffer(offer: RTCSessionDescriptionInit): {
     const mid = getMidString(media.mid!);
     if (media.type === 'audio') {
       media.rtp.some((rtp): boolean => {
-        if (rtp.codec === 'opus') {
+        // rtpmap encoding names are case-insensitive (RFC 4855)
+        if (rtp.codec.toLowerCase() === 'opus') {
           opusPayload = rtp.payload;
           return true;
         }
@@ -902,7 +917,7 @@ function extractStereoAndNackAudioFromOffer(offer: RTCSessionDescriptionInit): {
 
       media.fmtp.some((fmtp): boolean => {
         if (fmtp.payload === opusPayload) {
-          if (fmtp.config.includes('sprop-stereo=1')) {
+          if (fmtpConfigHasParam(fmtp.config, 'sprop-stereo=1')) {
             stereoMids.push(mid);
           }
           return true;


### PR DESCRIPTION
## What

Two small correctness fixes in the SDP munging code (`PCTransport.ts`), surfaced by comparing behavior against the Swift SDK's new SDP module ([client-sdk-swift#1078](https://github.com/livekit/client-sdk-swift/pull/1078)):

1. **Exact-token fmtp parameter matching.** Opus fmtp parameters were matched with a substring `.includes()` check. Because `stereo=1` is a substring of `sprop-stereo=1`, an offer that already carried `sprop-stereo=1` (but not `stereo=1`) would incorrectly be treated as already-stereo, and `stereo=1` would never be added. Introduced a `fmtpConfigHasParam(config, param)` helper that splits on `;` and compares whole tokens, and used it in both `ensureAudioNackAndStereo` and `extractStereoAndNackAudioFromOffer`.
2. **Case-insensitive opus lookup (RFC 4855).** The opus rtpmap lookup used `rtp.codec === 'opus'` (exact, case-sensitive), while every video/bitrate codec lookup in the same file already matches case-insensitively. rtpmap encoding names are case-insensitive per RFC 4855, so an `OPUS`/`Opus` codec name would be missed. Both opus lookups now lowercase before comparing.

## Why

These are latent correctness/spec-compliance bugs. Real-world impact is low today (browsers emit lowercase `opus` and typically both/neither stereo parameter together), but the matching logic was wrong and inconsistent with the rest of the file. This aligns the JS munging behavior with the Swift SDK's exact-token, uniformly-case-insensitive approach.


## Notes for reviewers

- The two internal audio munge functions (`ensureAudioNackAndStereo`, `extractStereoAndNackAudioFromOffer`) are now exported with `@internal`, consistent with the other tested helpers in this file, so the new behavior can be tested directly.
- Added 8 unit tests in `PCTransport.test.ts` covering the `sprop-stereo=1` vs `stereo=1` distinction, no-duplicate behavior, and uppercase `OPUS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)