### PR TITLE
fix: only run the time sync rAF loop while it has listeners

### DIFF
--- a/.changeset/lucky-hoops-shave.md
+++ b/.changeset/lucky-hoops-shave.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Only run the `TrackEvent.TimeSyncUpdate` animation frame loop while something is subscribed to the event

--- a/.changeset/lucky-hoops-shave.md
+++ b/.changeset/lucky-hoops-shave.md
@@ -2,4 +2,4 @@
 'livekit-client': patch
 ---
 
-Only run the `TrackEvent.TimeSyncUpdate` animation frame loop while something is subscribed to the event
+Only run the `TrackEvent.TimeSyncUpdate` animation frame loop while something is subscribed to the event, and clear the frame handle when a track's monitor is stopped so the loop can be restarted

--- a/src/room/track/RemoteTrack.test.ts
+++ b/src/room/track/RemoteTrack.test.ts
@@ -5,97 +5,140 @@ import RemoteVideoTrack from './RemoteVideoTrack';
 
 describe('RemoteTrack time sync loop', () => {
   let track: RemoteVideoTrack;
-  let frames: Array<() => void>;
-  let rafSpy: ReturnType<typeof vi.fn>;
-  let rtpTimestamp: number;
-
-  /** runs every currently scheduled animation frame callback once */
-  const flushFrame = () => {
-    const pending = frames;
-    frames = [];
-    pending.forEach((cb) => cb());
-  };
+  let getSynchronizationSources: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    frames = [];
-    rtpTimestamp = 0;
-    rafSpy = vi.fn((cb: () => void) => {
-      frames.push(cb);
-      return frames.length;
-    });
-    vi.stubGlobal('requestAnimationFrame', rafSpy);
-    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    // fake timers back `requestAnimationFrame`, so cancellation behaves like it does in a browser
+    vi.useFakeTimers();
+    // `supportsSynchronizationSources()` gates the loop on this being implemented
+    vi.stubGlobal(
+      'RTCRtpReceiver',
+      class {
+        getSynchronizationSources() {}
+      },
+    );
 
-    const receiver = {
-      getSynchronizationSources: () => [{ timestamp: 1, rtpTimestamp: ++rtpTimestamp }],
-    } as unknown as RTCRtpReceiver;
+    let rtpTimestamp = 0;
+    getSynchronizationSources = vi.fn(() => [{ timestamp: 1, rtpTimestamp: ++rtpTimestamp }]);
+    const receiver = { getSynchronizationSources } as unknown as RTCRtpReceiver;
     track = new RemoteVideoTrack(new MockMediaStreamTrack(), 'sid', receiver, {});
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
-  it('does not schedule animation frames when nobody listens', () => {
-    track.registerTimeSyncUpdate();
+  it('does not sample the receiver when nobody listens', () => {
+    track.startMonitor();
+    vi.advanceTimersToNextFrame();
 
-    expect(rafSpy).not.toHaveBeenCalled();
+    expect(getSynchronizationSources).not.toHaveBeenCalled();
   });
 
   it('starts the loop when a listener subscribes', () => {
-    track.registerTimeSyncUpdate();
+    track.startMonitor();
     const listener = vi.fn();
     track.on(TrackEvent.TimeSyncUpdate, listener);
-
-    expect(rafSpy).toHaveBeenCalledTimes(1);
-    flushFrame();
+    vi.advanceTimersToNextFrame();
 
     expect(listener).toHaveBeenCalledWith({ timestamp: 1, rtpTimestamp: 1 });
   });
 
   it('starts the loop for listeners that subscribed before the monitor started', () => {
-    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
-    track.registerTimeSyncUpdate();
-
-    expect(rafSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('stops the loop once the last listener unsubscribes', () => {
     const listener = vi.fn();
-    track.registerTimeSyncUpdate();
     track.on(TrackEvent.TimeSyncUpdate, listener);
-    flushFrame();
-
-    track.off(TrackEvent.TimeSyncUpdate, listener);
-    flushFrame();
-    const callsAfterUnsubscribe = rafSpy.mock.calls.length;
-    flushFrame();
-
-    expect(frames).toHaveLength(0);
-    expect(rafSpy).toHaveBeenCalledTimes(callsAfterUnsubscribe);
-  });
-
-  it('restarts the loop when a listener subscribes again', () => {
-    const listener = vi.fn();
-    track.registerTimeSyncUpdate();
-    track.on(TrackEvent.TimeSyncUpdate, listener);
-    track.off(TrackEvent.TimeSyncUpdate, listener);
-    flushFrame();
-    listener.mockClear();
-
-    track.on(TrackEvent.TimeSyncUpdate, listener);
-    flushFrame();
+    track.startMonitor();
+    vi.advanceTimersToNextFrame();
 
     expect(listener).toHaveBeenCalled();
   });
 
-  it('does not restart the loop after the monitor has been stopped', () => {
-    track.registerTimeSyncUpdate();
-    track.stopMonitor();
-    rafSpy.mockClear();
-
+  it('does not start a second loop when a second listener subscribes', () => {
+    track.startMonitor();
+    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
     track.on(TrackEvent.TimeSyncUpdate, vi.fn());
 
-    expect(rafSpy).not.toHaveBeenCalled();
+    vi.advanceTimersToNextFrame();
+
+    // a second chain would sample twice per frame
+    expect(getSynchronizationSources).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a second loop when the monitor is started again', () => {
+    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
+    track.startMonitor();
+    track.startMonitor();
+    getSynchronizationSources.mockClear();
+
+    vi.advanceTimersToNextFrame();
+
+    expect(getSynchronizationSources).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the loop once the last listener unsubscribes', () => {
+    const listener = vi.fn();
+    track.startMonitor();
+    track.on(TrackEvent.TimeSyncUpdate, listener);
+    vi.advanceTimersToNextFrame();
+
+    track.off(TrackEvent.TimeSyncUpdate, listener);
+    vi.advanceTimersToNextFrame();
+    getSynchronizationSources.mockClear();
+    vi.advanceTimersToNextFrame();
+
+    expect(getSynchronizationSources).not.toHaveBeenCalled();
+  });
+
+  it('restarts the loop when a listener subscribes again', () => {
+    const listener = vi.fn();
+    track.startMonitor();
+    track.on(TrackEvent.TimeSyncUpdate, listener);
+    track.off(TrackEvent.TimeSyncUpdate, listener);
+    vi.advanceTimersToNextFrame();
+    listener.mockClear();
+
+    track.on(TrackEvent.TimeSyncUpdate, listener);
+    vi.advanceTimersToNextFrame();
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('cancels a running loop when the monitor is stopped', () => {
+    track.startMonitor();
+    // the listener stays subscribed, so only the cancellation can stop the loop
+    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
+    vi.advanceTimersToNextFrame();
+    expect(getSynchronizationSources).toHaveBeenCalled();
+
+    track.stopMonitor();
+    getSynchronizationSources.mockClear();
+    vi.advanceTimersToNextFrame();
+    vi.advanceTimersToNextFrame();
+
+    expect(getSynchronizationSources).not.toHaveBeenCalled();
+  });
+
+  it('resumes the loop when the monitor is started again after a stop', () => {
+    track.startMonitor();
+    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
+    vi.advanceTimersToNextFrame();
+    track.stopMonitor();
+    getSynchronizationSources.mockClear();
+
+    track.startMonitor();
+    vi.advanceTimersToNextFrame();
+
+    expect(getSynchronizationSources).toHaveBeenCalled();
+  });
+
+  it('does not restart the loop after the monitor has been stopped', () => {
+    track.startMonitor();
+    track.stopMonitor();
+
+    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
+    vi.advanceTimersToNextFrame();
+
+    expect(getSynchronizationSources).not.toHaveBeenCalled();
   });
 });

--- a/src/room/track/RemoteTrack.test.ts
+++ b/src/room/track/RemoteTrack.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MockMediaStreamTrack from '../../test/MockMediaStreamTrack';
+import { TrackEvent } from '../events';
+import RemoteVideoTrack from './RemoteVideoTrack';
+
+describe('RemoteTrack time sync loop', () => {
+  let track: RemoteVideoTrack;
+  let frames: Array<() => void>;
+  let rafSpy: ReturnType<typeof vi.fn>;
+  let rtpTimestamp: number;
+
+  /** runs every currently scheduled animation frame callback once */
+  const flushFrame = () => {
+    const pending = frames;
+    frames = [];
+    pending.forEach((cb) => cb());
+  };
+
+  beforeEach(() => {
+    frames = [];
+    rtpTimestamp = 0;
+    rafSpy = vi.fn((cb: () => void) => {
+      frames.push(cb);
+      return frames.length;
+    });
+    vi.stubGlobal('requestAnimationFrame', rafSpy);
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    const receiver = {
+      getSynchronizationSources: () => [{ timestamp: 1, rtpTimestamp: ++rtpTimestamp }],
+    } as unknown as RTCRtpReceiver;
+    track = new RemoteVideoTrack(new MockMediaStreamTrack(), 'sid', receiver, {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not schedule animation frames when nobody listens', () => {
+    track.registerTimeSyncUpdate();
+
+    expect(rafSpy).not.toHaveBeenCalled();
+  });
+
+  it('starts the loop when a listener subscribes', () => {
+    track.registerTimeSyncUpdate();
+    const listener = vi.fn();
+    track.on(TrackEvent.TimeSyncUpdate, listener);
+
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    flushFrame();
+
+    expect(listener).toHaveBeenCalledWith({ timestamp: 1, rtpTimestamp: 1 });
+  });
+
+  it('starts the loop for listeners that subscribed before the monitor started', () => {
+    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
+    track.registerTimeSyncUpdate();
+
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the loop once the last listener unsubscribes', () => {
+    const listener = vi.fn();
+    track.registerTimeSyncUpdate();
+    track.on(TrackEvent.TimeSyncUpdate, listener);
+    flushFrame();
+
+    track.off(TrackEvent.TimeSyncUpdate, listener);
+    flushFrame();
+    const callsAfterUnsubscribe = rafSpy.mock.calls.length;
+    flushFrame();
+
+    expect(frames).toHaveLength(0);
+    expect(rafSpy).toHaveBeenCalledTimes(callsAfterUnsubscribe);
+  });
+
+  it('restarts the loop when a listener subscribes again', () => {
+    const listener = vi.fn();
+    track.registerTimeSyncUpdate();
+    track.on(TrackEvent.TimeSyncUpdate, listener);
+    track.off(TrackEvent.TimeSyncUpdate, listener);
+    flushFrame();
+    listener.mockClear();
+
+    track.on(TrackEvent.TimeSyncUpdate, listener);
+    flushFrame();
+
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('does not restart the loop after the monitor has been stopped', () => {
+    track.registerTimeSyncUpdate();
+    track.stopMonitor();
+    rafSpy.mockClear();
+
+    track.on(TrackEvent.TimeSyncUpdate, vi.fn());
+
+    expect(rafSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -1,3 +1,4 @@
+import type { EventEmitter } from 'events';
 import { TrackEvent } from '../events';
 import { monitorFrequency } from '../stats';
 import type { LoggerOptions } from '../types';
@@ -123,20 +124,45 @@ export default abstract class RemoteTrack<
     }
   }
 
+  /* @internal */
+  stopMonitor() {
+    super.stopMonitor();
+    this.timeSyncHandle = undefined;
+    (this as unknown as EventEmitter).off('newListener', this.onTimeSyncListenerAdded);
+  }
+
   protected abstract monitorReceiver(): void;
 
-  registerTimeSyncUpdate() {
-    const loop = () => {
-      this.timeSyncHandle = requestAnimationFrame(() => loop());
-      const sources = this.receiver?.getSynchronizationSources()[0];
-      if (sources) {
-        const { timestamp, rtpTimestamp } = sources;
-        if (rtpTimestamp && this.rtpTimestamp !== rtpTimestamp) {
-          this.emit(TrackEvent.TimeSyncUpdate, { timestamp, rtpTimestamp });
-          this.rtpTimestamp = rtpTimestamp;
-        }
+  private timeSyncLoop = () => {
+    if (this.listenerCount(TrackEvent.TimeSyncUpdate) === 0) {
+      // nobody is listening anymore, pause the loop until a new listener subscribes
+      this.timeSyncHandle = undefined;
+      return;
+    }
+    this.timeSyncHandle = requestAnimationFrame(this.timeSyncLoop);
+    const sources = this.receiver?.getSynchronizationSources()[0];
+    if (sources) {
+      const { timestamp, rtpTimestamp } = sources;
+      if (rtpTimestamp && this.rtpTimestamp !== rtpTimestamp) {
+        this.emit(TrackEvent.TimeSyncUpdate, { timestamp, rtpTimestamp });
+        this.rtpTimestamp = rtpTimestamp;
       }
-    };
-    loop();
+    }
+  };
+
+  private onTimeSyncListenerAdded = (event: string) => {
+    if (event === TrackEvent.TimeSyncUpdate && this.timeSyncHandle === undefined) {
+      // `newListener` fires before the listener is registered, so schedule the
+      // next frame instead of entering the loop (which would see a count of 0)
+      this.timeSyncHandle = requestAnimationFrame(this.timeSyncLoop);
+    }
+  };
+
+  registerTimeSyncUpdate() {
+    // `newListener` isn't part of the typed event map, hence the cast
+    const emitter = this as unknown as EventEmitter;
+    emitter.off('newListener', this.onTimeSyncListenerAdded);
+    emitter.on('newListener', this.onTimeSyncListenerAdded);
+    this.timeSyncLoop();
   }
 }

--- a/src/room/track/RemoteTrack.ts
+++ b/src/room/track/RemoteTrack.ts
@@ -127,7 +127,6 @@ export default abstract class RemoteTrack<
   /* @internal */
   stopMonitor() {
     super.stopMonitor();
-    this.timeSyncHandle = undefined;
     (this as unknown as EventEmitter).off('newListener', this.onTimeSyncListenerAdded);
   }
 
@@ -163,6 +162,8 @@ export default abstract class RemoteTrack<
     const emitter = this as unknown as EventEmitter;
     emitter.off('newListener', this.onTimeSyncListenerAdded);
     emitter.on('newListener', this.onTimeSyncListenerAdded);
-    this.timeSyncLoop();
+    if (this.timeSyncHandle === undefined) {
+      this.timeSyncLoop();
+    }
   }
 }

--- a/src/room/track/Track.ts
+++ b/src/room/track/Track.ts
@@ -276,8 +276,9 @@ export abstract class Track<
     if (this.monitorInterval) {
       clearInterval(this.monitorInterval);
     }
-    if (this.timeSyncHandle) {
+    if (this.timeSyncHandle !== undefined) {
       cancelAnimationFrame(this.timeSyncHandle);
+      this.timeSyncHandle = undefined;
     }
   }
 


### PR DESCRIPTION
## Problem

`RemoteTrack.registerTimeSyncUpdate()` starts a `requestAnimationFrame` loop that:

- starts unconditionally from `startMonitor()` whenever `supportsSynchronizationSources()` is true,
- runs for the entire lifetime of every subscribed remote track,
- calls the native `receiver.getSynchronizationSources()` on **every** frame,

regardless of whether anything is subscribed to `TrackEvent.TimeSyncUpdate`.

Most applications never listen to that event (it's mainly consumed via `trackSyncTimeObserver` in `components-js` for transcription / frame-metadata sync). For everyone else this is ~60 wakeups/s per subscribed track of pure overhead:

- a 10-participant call with audio + video = 600–1200 callbacks/s doing nothing,
- in audio-only calls the loop alone keeps the renderer from going idle, which costs battery on laptops and mobile.

We hit this while profiling a call in our app: the rAF loop was the single largest source of periodic main-thread wakeups, and none of the emitted events had a listener.

## Change

Keep the event and its semantics exactly as they are, but make the loop lazy:

- the loop is entered when something subscribes to `TrackEvent.TimeSyncUpdate` (using the `newListener` meta event of the underlying `EventEmitter`), or immediately if a listener is already attached when `registerTimeSyncUpdate()` runs,
- the loop stops itself on the first frame after the last listener unsubscribes (so at most one extra frame is spent),
- it is only entered when no frame is already pending, so a repeated `startMonitor()` cannot leave a second, orphaned rAF chain running that `stopMonitor()` has no handle for,
- `stopMonitor()` also detaches the `newListener` hook, so a stopped track can't be restarted into a loop by a late subscriber.

For consumers of `TrackEvent.TimeSyncUpdate` nothing changes: the first update still arrives on the frame after subscribing.

`Track.stopMonitor()` additionally clears `timeSyncHandle` where it cancels the frame. It previously left a stale handle behind, which now matters because `undefined` is the "no frame pending" sentinel — without the reset, a track that is stopped and started again would never resume time sync. The same check moved from a truthiness test to `!== undefined` so the sentinel is consistent everywhere.

## Tests

Added `src/room/track/RemoteTrack.test.ts`, driving the production entry points (`startMonitor()` / `stopMonitor()`) with fake timers so `cancelAnimationFrame` behaves the way it does in a browser:

- no listeners → the receiver is never sampled
- subscribing starts the loop and delivers events
- subscribing before `startMonitor()` also starts the loop
- a second listener does not start a second chain
- a second `startMonitor()` does not start a second chain
- unsubscribing the last listener stops the loop
- resubscribing restarts it
- `stopMonitor()` cancels a loop that is still running with a live listener
- `startMonitor()` after a stop resumes the loop
- subscribing after a stop does not restart it

I mutation-checked the suite: removing any one of the guards, the cancellation, the handle reset, the `newListener` deregistration, or the `registerTimeSyncUpdate()` call in `startMonitor()` makes it fail.

`npx vitest run` passes (the only failing file is `smoke-tests/tests/smoke.spec.ts`, which fails on `main` too because `@playwright/test` isn't part of the unit-test install). `npx tsc --noEmit` is clean.