### PR TITLE
fix: emit TrackStreamStateChanged again (regression since v2.16.0)

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+fix: emit TrackStreamStateChanged again by reading the previous stream state before overwriting it

--- a/src/room/Room.test.ts
+++ b/src/room/Room.test.ts
@@ -1,13 +1,22 @@
 import {
   ClientInfo_Capability,
   JoinResponse,
+  StreamState as ProtoStreamState,
+  StreamStateUpdate,
   SubscriptionError,
   SubscriptionResponse,
+  TrackInfo,
+  TrackType,
 } from '@livekit/protocol';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import MockMediaStreamTrack from '../test/MockMediaStreamTrack';
 import Room, { ConnectionState } from './Room';
 import { roomConnectOptionDefaults, roomOptionDefaults } from './defaults';
-import { EngineEvent, RoomEvent } from './events';
+import { EngineEvent, ParticipantEvent, RoomEvent } from './events';
+import RemoteParticipant from './participant/RemoteParticipant';
+import RemoteTrackPublication from './track/RemoteTrackPublication';
+import RemoteVideoTrack from './track/RemoteVideoTrack';
+import { Track } from './track/Track';
 
 describe('Active device switch', () => {
   it('updates devices correctly', async () => {
@@ -234,5 +243,81 @@ describe('remote track subscription', () => {
     room.emit(RoomEvent.Connected);
 
     expect(replay).not.toHaveBeenCalled();
+  });
+});
+
+describe('stream state updates', () => {
+  const participantSid = 'PA_remote';
+  const participantIdentity = 'remote-user';
+  const trackSid = 'TR_video';
+
+  function setupSubscribedTrack() {
+    const room = new Room();
+    room.state = ConnectionState.Connected;
+
+    const participant = new RemoteParticipant(
+      room.engine.client,
+      participantSid,
+      participantIdentity,
+    );
+    const publication = new RemoteTrackPublication(
+      Track.Kind.Video,
+      new TrackInfo({ sid: trackSid, type: TrackType.VIDEO, name: 'camera' }),
+      true,
+    );
+    publication.setTrack(
+      new RemoteVideoTrack(new MockMediaStreamTrack(), trackSid, undefined as never, {}),
+    );
+    participant.trackPublications.set(trackSid, publication);
+
+    (
+      room as unknown as { remoteParticipants: Map<string, RemoteParticipant> }
+    ).remoteParticipants.set(participantIdentity, participant);
+    (room as unknown as { sidToIdentity: Map<string, string> }).sidToIdentity.set(
+      participantSid,
+      participantIdentity,
+    );
+
+    return { room, participant, publication };
+  }
+
+  function pushStreamState(room: Room, state: ProtoStreamState) {
+    (
+      room as unknown as { handleStreamStateUpdate: (update: StreamStateUpdate) => void }
+    ).handleStreamStateUpdate(
+      new StreamStateUpdate({
+        streamStates: [{ participantSid, trackSid, state }],
+      }),
+    );
+  }
+
+  it('emits TrackStreamStateChanged when the SFU pauses a subscribed track', () => {
+    const { room, participant, publication } = setupSubscribedTrack();
+
+    const roomEvents = vi.fn();
+    const participantEvents = vi.fn();
+    room.on(RoomEvent.TrackStreamStateChanged, roomEvents);
+    participant.on(ParticipantEvent.TrackStreamStateChanged, participantEvents);
+
+    pushStreamState(room, ProtoStreamState.PAUSED);
+
+    expect(publication.track?.streamState).toBe(Track.StreamState.Paused);
+    expect(roomEvents).toHaveBeenCalledWith(publication, Track.StreamState.Paused, participant);
+    expect(participantEvents).toHaveBeenCalledWith(publication, Track.StreamState.Paused);
+  });
+
+  it('does not emit TrackStreamStateChanged when the state is unchanged', () => {
+    const { room, participant } = setupSubscribedTrack();
+
+    const roomEvents = vi.fn();
+    const participantEvents = vi.fn();
+    room.on(RoomEvent.TrackStreamStateChanged, roomEvents);
+    participant.on(ParticipantEvent.TrackStreamStateChanged, participantEvents);
+
+    // The track starts Active; a redundant ACTIVE update must stay silent.
+    pushStreamState(room, ProtoStreamState.ACTIVE);
+
+    expect(roomEvents).not.toHaveBeenCalled();
+    expect(participantEvents).not.toHaveBeenCalled();
   });
 });

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -2028,8 +2028,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         return;
       }
       const newStreamState = Track.streamStateFromProto(streamState.state);
+      const prevStreamState = pub.track.streamState;
       pub.track.setStreamState(newStreamState);
-      if (newStreamState !== pub.track.streamState) {
+      if (newStreamState !== prevStreamState) {
         participant.emit(ParticipantEvent.TrackStreamStateChanged, pub, pub.track.streamState);
         this.emitWhenConnected(
           RoomEvent.TrackStreamStateChanged,


### PR DESCRIPTION
### Summary

`RoomEvent.TrackStreamStateChanged` and `ParticipantEvent.TrackStreamStateChanged` have not fired since v2.16.0.

`Room.handleStreamStateUpdate` writes the new stream state and *then* compares it against the field it just wrote:

```ts
const newStreamState = Track.streamStateFromProto(streamState.state);
pub.track.setStreamState(newStreamState);          // assigns Track._streamState
if (newStreamState !== pub.track.streamState) {    // getter returns what was just assigned
```

`Track.streamState` is a getter over `_streamState` and `setStreamState()` assigns that field, so the condition is always false and the body is unreachable.

### How it regressed

#1199 added the "only emit on an actual change" guard, and got the ordering right — it compared before assigning:

```ts
const newStreamState = Track.streamStateFromProto(streamState.state);
if (newStreamState !== pub.track.streamState) {
  pub.track.streamState = newStreamState;
  ...
}
```

#1625 later introduced `Track.setStreamState()` and swapped the bare field assignment for a call to it, but hoisted the call above the guard it was supposed to be inside. First released in v2.16.0 and still present on `main` (v2.21.0).

### Fix

Read the previous value before overwriting it. This restores the event while preserving #1199's intent: a redundant update (e.g. `ACTIVE` while already active) still emits nothing.

### Tests

Two cases added to `src/room/Room.test.ts`, driving `handleStreamStateUpdate` with a real `RemoteParticipant` / `RemoteTrackPublication` / `RemoteVideoTrack`:

- pausing a subscribed track emits on both the room and the participant — **fails on `main`**, passes with this change
- a redundant `ACTIVE` update emits nothing — passes either way, and guards against "fixing" this by deleting the check

`pnpm test`, `pnpm type:check` and `pnpm format:check` are clean; `pnpm lint` reports no new warnings.

### Impact

Consumers currently have no way to detect the SFU pausing a subscribed track under bandwidth pressure, which is the documented signal for diagnosing a frozen remote video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)