### PR TITLE
fix: don't abandon an in-flight reconnect on a redundant connect() call

### DIFF
--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Return early from `Room.connect()` while reconnecting so a redundant call no longer aborts an in-flight reconnect

--- a/src/room/Room.test.ts
+++ b/src/room/Room.test.ts
@@ -8,7 +8,7 @@ import {
   TrackInfo,
   TrackType,
 } from '@livekit/protocol';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import MockMediaStreamTrack from '../test/MockMediaStreamTrack';
 import Room, { ConnectionState } from './Room';
 import { roomConnectOptionDefaults, roomOptionDefaults } from './defaults';
@@ -319,5 +319,50 @@ describe('stream state updates', () => {
 
     expect(roomEvents).not.toHaveBeenCalled();
     expect(participantEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe('connect while reconnecting', () => {
+  // isBrowserSupported() gates connect(); happy-dom has no RTCPeerConnection.
+  class StubPC {
+    addTransceiver() {}
+  }
+
+  let originalRTCPeerConnection: unknown;
+
+  beforeEach(() => {
+    originalRTCPeerConnection = (globalThis as unknown as { RTCPeerConnection?: unknown })
+      .RTCPeerConnection;
+    (globalThis as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection = StubPC;
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      originalRTCPeerConnection;
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ConnectionState.Connected,
+    ConnectionState.Reconnecting,
+    ConnectionState.SignalReconnecting,
+  ])('returns early without starting a cold connect when %s', async (state) => {
+    const room = new Room();
+    room.state = state;
+
+    const attemptConnection = vi.spyOn(
+      room as unknown as { attemptConnection: () => Promise<void> },
+      'attemptConnection',
+    );
+    const connectionStateChanged = vi.fn();
+    room.on(RoomEvent.ConnectionStateChanged, connectionStateChanged);
+
+    await room.connect('ws://localhost:7880', 'token');
+
+    // An in-flight reconnect/resume must be left alone: no transition to
+    // Connecting, and no new connection attempt to replace the engine.
+    expect(room.state).toBe(state);
+    expect(connectionStateChanged).not.toHaveBeenCalled();
+    expect(attemptConnection).not.toHaveBeenCalled();
   });
 });

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -833,9 +833,15 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     // In case a disconnect called happened right before the connect call, make sure the disconnect is completed first by awaiting its lock
     const unlockDisconnect = await this.disconnectLock.lock();
 
-    if (this.state === ConnectionState.Connected) {
+    if (
+      this.state === ConnectionState.Connected ||
+      this.state === ConnectionState.Reconnecting ||
+      this.state === ConnectionState.SignalReconnecting
+    ) {
       // when the state is reconnecting or connected, this function returns immediately
-      this.log.info(`already connected to room ${this.name}`);
+      // returning early while reconnecting keeps the in-flight reconnect/resume alive,
+      // a cold connect here would abandon it and rejoin from scratch
+      this.log.info(`already connected to room ${this.name}`, { state: this.state });
       unlockDisconnect();
       return Promise.resolve();
     }


### PR DESCRIPTION
## The guard doesn't do what its comment says

`Room.connect()` opens with an early-return guard whose comment claims it covers two states, while the condition only checks one:

```ts
if (this.state === ConnectionState.Connected) {
  // when the state is reconnecting or connected, this function returns immediately
  this.log.info(`already connected to room ${this.name}`);
  unlockDisconnect();
  return Promise.resolve();
}
```

## Consequence

Because `Reconnecting` and `SignalReconnecting` aren't matched, a `connect()` call made during a reconnect falls through to `this.setAndEmitConnectionState(ConnectionState.Connecting)` and proceeds into a full cold connect. `attemptConnection()` then takes its first branch and tears the engine down explicitly:

```ts
if (this.state === ConnectionState.Reconnecting || this.isResuming || this.engine?.pendingReconnect) {
  this.log.info('Reconnection attempt replaced by new connection attempt');
  this.recreateEngine(true);
}
```

So the in-flight reconnect/resume is discarded. Instead of recovering transparently and emitting `Reconnected`, the participant drops its media, rejoins from scratch, and the app sees a fresh `Connected`. Track subscriptions, publication SIDs and any state the app keyed on the previous session are lost.

## How this gets hit

It's reachable from ordinary React code, not just from a misbehaving caller. `useLiveKitRoom` in `@livekit/components-react` keys its connect effect on `[connect, token, connectOptions, room, onError, serverUrl]` — `onError` included. An inline arrow callback for `onError` is the common idiom, and it's a new identity on every render, so the effect re-runs and calls `room.connect()` on every render. That's harmless while `Connected` (the existing guard catches it) and destructive during a reconnect, which is exactly when renders are most likely — the app is re-rendering in response to `ConnectionStateChanged`.

## Production evidence

From 30 days of telemetry over ~1,170 signal resumes:

- Only **74.2%** recovered.
- Of the 238 that never recovered, **229 ended in a fresh `Connected` event rather than `Reconnected`** — the cold-connect signature — and this held across every browser, so it isn't a browser-specific transport bug.
- `RoomEvent.Connected` is emitted in exactly two places in 2.20.1: the tail of a successful `connect()`, and the dev-only `simulateParticipants`. Each of those 229 was therefore a real external `connect()` call landing mid-reconnect.
- 231 of 235 of those cold connects happened in the **same browser window** as the resume they interrupted, median 2s apart — ruling out users reloading the page.

## This fall-through isn't an intentional escape hatch

Worth addressing up front, since one might read the fall-through as a deliberate way to rescue a "wedged" reconnect. It isn't:

- **A reconnect always terminates.** `RTCEngine.handleDisconnect` reschedules an attempt while `reconnectPolicy.nextRetryDelayInMs()` returns a number, and gives up when it returns `null` (`emit(EngineEvent.Disconnected); close()`). The room either recovers or transitions to `Disconnected` — and in `Disconnected` the new guard doesn't apply, so a cold connect still works.
- **The one genuinely stuck case was never rescued by this path anyway.** A transport parked in `CONNECTING` (addressed in #2030) leaves the room reporting `connected`, where the pre-existing `Connected` check already returns early. `connect()` never reached the fall-through in that scenario.
- **A caller wanting a cold reset has an explicit API**: `disconnect()` then `connect()`.

## The change

Include `Reconnecting` and `SignalReconnecting` in the guard so the code matches its own comment, and add the current state to the log line so the early return is distinguishable in logs.

## Test

`src/room/Room.test.ts` gains a parameterized case asserting that `connect()` in `Connected`, `Reconnecting` and `SignalReconnecting` leaves `room.state` untouched, emits no `ConnectionStateChanged`, and never reaches `attemptConnection`. The two reconnecting cases fail on `main` and pass with the fix.

`npx tsc --noEmit`, `npx vitest run src` (690 tests) and `eslint` on the touched files all pass.
