### PR TITLE
Forward DisconnectReason to ParticipantDisconnected event

### DIFF
--- a/.changeset/forward-participant-disconnect-reason.md
+++ b/.changeset/forward-participant-disconnect-reason.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Forward `DisconnectReason` to the `ParticipantDisconnected` event

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -1913,7 +1913,13 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
       // when it's disconnected, send updates
       if (info.state === ParticipantInfo_State.DISCONNECTED) {
-        this.handleParticipantDisconnected(info.identity, remoteParticipant);
+        this.handleParticipantDisconnected(
+          info.identity,
+          remoteParticipant,
+          info.disconnectReason === DisconnectReason.UNKNOWN_REASON
+            ? undefined
+            : info.disconnectReason,
+        );
       } else {
         // create participant if doesn't exist
         this.getOrCreateParticipant(info.identity, info);
@@ -1931,7 +1937,11 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     this.incomingDataTrackManager.receiveSfuPublicationUpdates(mapped);
   };
 
-  private handleParticipantDisconnected(identity: string, participant?: RemoteParticipant) {
+  private handleParticipantDisconnected(
+    identity: string,
+    participant?: RemoteParticipant,
+    disconnectReason?: DisconnectReason,
+  ) {
     // remove and send event
     this.remoteParticipants.delete(identity);
     if (!participant) {
@@ -1944,7 +1954,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     participant.trackPublications.forEach((publication) => {
       participant.unpublishTrack(publication.trackSid, true);
     });
-    this.emit(RoomEvent.ParticipantDisconnected, participant);
+    this.emit(RoomEvent.ParticipantDisconnected, participant, disconnectReason);
     participant.setDisconnected();
     this.rpcClientManager.handleParticipantDisconnected(participant.identity);
   }
@@ -2948,7 +2958,10 @@ export type RoomEventCallbacks = {
   moved: (name: string) => void;
   mediaDevicesChanged: () => void;
   participantConnected: (participant: RemoteParticipant) => void;
-  participantDisconnected: (participant: RemoteParticipant) => void;
+  participantDisconnected: (
+    participant: RemoteParticipant,
+    disconnectReason?: DisconnectReason,
+  ) => void;
   trackPublished: (publication: RemoteTrackPublication, participant: RemoteParticipant) => void;
   trackSubscribed: (
     track: RemoteTrack,

--- a/src/room/events.ts
+++ b/src/room/events.ts
@@ -80,7 +80,7 @@ export enum RoomEvent {
    * When a [[RemoteParticipant]] leaves *after* the local
    * participant has joined.
    *
-   * args: ([[RemoteParticipant]])
+   * args: ([[RemoteParticipant]], [[DisconnectReason]] | undefined)
    */
   ParticipantDisconnected = 'participantDisconnected',
 


### PR DESCRIPTION
## Summary

Forwards the server-provided `DisconnectReason` to the `ParticipantDisconnected` event.

## Motivation

The server already distinguishes an intentional leave (client sends `LeaveRequest` → `CLIENT_INITIATED`) from a network failure (no leave → `SIGNAL_CLOSE` / `CONNECTION_TIMEOUT` / `MEDIA_FAILURE`), and ships the result in `ParticipantInfo.disconnectReason`. The JS client receives it but drops it: `handleParticipantDisconnected` only takes the identity and the participant.

There is no way to read it afterwards either — `RemoteParticipant` does not expose it and `participantInfo` is `protected`.

Other SDKs already expose this (`@livekit/rtc-node` via a `disconnectReason` getter, `server-sdk-go` in livekit/server-sdk-go#805, which treated it as a bug fix), and this SDK applied the same pattern to the local `Disconnected` event in #304 — this PR does the same for remote participants.

## Changes

- `handleParticipantDisconnected` takes an optional `disconnectReason` and passes it to the event
- Only the server-update path supplies it; the two local-cleanup call sites (reconnect unwind, room move) pass nothing since they are not real departures
- `UNKNOWN_REASON` is normalized to `undefined`, matching `rtc-node`
- Adding an optional parameter keeps existing listeners working

## Testing

`lint`, `format:check`, `type:check`, `throws:check`, `build` and `publint` pass. Full unit suite passes (715 tests / 47 files). Verified the built `dist/src/room/Room.d.ts` declares `participantDisconnected: (participant: RemoteParticipant, disconnectReason?: DisconnectReason) => void`.
