### PR TITLE
fix: treat TokenSource JWTs without exp as expired

### DIFF
--- a/.changeset/token-source-require-exp.md
+++ b/.changeset/token-source-require-exp.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Treat TokenSource JWTs without `exp` as expired, and still honor `exp` when `nbf` is absent

--- a/src/room/token-source/test-tokens.ts
+++ b/src/room/token-source/test-tokens.ts
@@ -1,3 +1,11 @@
+// Builds an unsigned (`alg: none`) JWT. These aren't signed at all, so they can only be used in
+// tests which don't care about the signature.
+function unsignedToken(payload: Record<string, unknown>) {
+  const encode = (value: Record<string, unknown>) =>
+    btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode(payload)}.`;
+}
+
 // Test JWTs created for test purposes only.
 // None of these actually auth against anything.
 export const TOKENS = {
@@ -25,4 +33,16 @@ export const TOKENS = {
   // A dummy roomConfig value is also set, with room_config.name = "test room name", room_config.extraField = "extra field value", and room_config.agents = [{"agentName": "test agent name","metadata":"test agent metadata","extraField":"extra field value"}]
   EXTRA_FIELDS:
     'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo5ODc2NTQzMjEwLCJuYmYiOjEyMzQ1Njc4OTAsImlhdCI6MTIzNDU2Nzg5MCwicm9vbUNvbmZpZyI6eyJuYW1lIjoidGVzdCByb29tIG5hbWUiLCJlbXB0eVRpbWVvdXQiOjAsImRlcGFydHVyZVRpbWVvdXQiOjAsIm1heFBhcnRpY2lwYW50cyI6MCwibWluUGxheW91dERlbGF5IjowLCJtYXhQbGF5b3V0RGVsYXkiOjAsInN5bmNTdHJlYW1zIjpmYWxzZSwiYWdlbnRzIjpbeyJhZ2VudE5hbWUiOiJ0ZXN0IGFnZW50IG5hbWUiLCJtZXRhZGF0YSI6InRlc3QgYWdlbnQgbWV0YWRhdGEiLCJleHRyYUZpZWxkIjoiZXh0cmEgZmllbGQgdmFsdWUifV0sIm1ldGFkYXRhIjoiIiwiZXh0cmFGaWVsZCI6ImV4dHJhIGZpZWxkIHZhbHVlIn19Cg.EDetpHG8cSubaApzgWJaQrpCiSy9KDBlfCfVdIydbQ-_CHiNnXOK_f_mCJbTf9A-duT1jmvPOkLrkkWFT60XPQ',
+
+  // Nbf date set at 1234567890 seconds (Fri Feb 13 2009 23:31:30 GMT+0000)
+  // No exp date set at all
+  NO_EXP: unsignedToken({ sub: '1234567890', nbf: 1234567890, iat: 1234567890 }),
+
+  // No nbf date set at all
+  // Exp date set at 1234567891 seconds (Fri Feb 13 2009 23:31:31 GMT+0000)
+  EXP_IN_PAST_NO_NBF: unsignedToken({ sub: '1234567890', exp: 1234567891, iat: 1234567890 }),
+
+  // No nbf date set at all
+  // Exp date set at 9876543210 seconds (Fri Dec 22 2282 20:13:30 GMT+0000)
+  VALID_NO_NBF: unsignedToken({ sub: '1234567890', exp: 9876543210, iat: 1234567890 }),
 };

--- a/src/room/token-source/utils.test.ts
+++ b/src/room/token-source/utils.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { TOKENS } from './test-tokens';
 import { areTokenSourceFetchOptionsEqual, decodeTokenPayload, isResponseTokenValid } from './utils';
 
+function unsignedToken(payload: Record<string, unknown>) {
+  const encode = (value: Record<string, unknown>) =>
+    btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode(payload)}.`;
+}
+
 describe('isResponseTokenValid', () => {
   it('should find a valid jwt not expired', () => {
     const isValid = isResponseTokenValid(
@@ -30,6 +36,33 @@ describe('isResponseTokenValid', () => {
       }),
     );
     expect(isValid).toBe(false);
+  });
+  it('should treat a jwt without exp as expired', () => {
+    const isValid = isResponseTokenValid(
+      TokenSourceResponse.fromJson({
+        serverUrl: 'ws://localhost:7800',
+        participantToken: unsignedToken({ sub: '1234567890', nbf: 1234567890, iat: 1234567890 }),
+      }),
+    );
+    expect(isValid).toBe(false);
+  });
+  it('should honor exp when nbf is absent', () => {
+    const isValid = isResponseTokenValid(
+      TokenSourceResponse.fromJson({
+        serverUrl: 'ws://localhost:7800',
+        participantToken: unsignedToken({ sub: '1234567890', exp: 1234567891, iat: 1234567890 }),
+      }),
+    );
+    expect(isValid).toBe(false);
+  });
+  it('should accept a non-expired jwt that omits nbf', () => {
+    const isValid = isResponseTokenValid(
+      TokenSourceResponse.fromJson({
+        serverUrl: 'ws://localhost:7800',
+        participantToken: unsignedToken({ sub: '1234567890', exp: 9876543210, iat: 1234567890 }),
+      }),
+    );
+    expect(isValid).toBe(true);
   });
 });
 

--- a/src/room/token-source/utils.test.ts
+++ b/src/room/token-source/utils.test.ts
@@ -3,12 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { TOKENS } from './test-tokens';
 import { areTokenSourceFetchOptionsEqual, decodeTokenPayload, isResponseTokenValid } from './utils';
 
-function unsignedToken(payload: Record<string, unknown>) {
-  const encode = (value: Record<string, unknown>) =>
-    btoa(JSON.stringify(value)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode(payload)}.`;
-}
-
 describe('isResponseTokenValid', () => {
   it('should find a valid jwt not expired', () => {
     const isValid = isResponseTokenValid(
@@ -41,7 +35,7 @@ describe('isResponseTokenValid', () => {
     const isValid = isResponseTokenValid(
       TokenSourceResponse.fromJson({
         serverUrl: 'ws://localhost:7800',
-        participantToken: unsignedToken({ sub: '1234567890', nbf: 1234567890, iat: 1234567890 }),
+        participantToken: TOKENS.NO_EXP,
       }),
     );
     expect(isValid).toBe(false);
@@ -50,7 +44,7 @@ describe('isResponseTokenValid', () => {
     const isValid = isResponseTokenValid(
       TokenSourceResponse.fromJson({
         serverUrl: 'ws://localhost:7800',
-        participantToken: unsignedToken({ sub: '1234567890', exp: 1234567891, iat: 1234567890 }),
+        participantToken: TOKENS.EXP_IN_PAST_NO_NBF,
       }),
     );
     expect(isValid).toBe(false);
@@ -59,7 +53,7 @@ describe('isResponseTokenValid', () => {
     const isValid = isResponseTokenValid(
       TokenSourceResponse.fromJson({
         serverUrl: 'ws://localhost:7800',
-        participantToken: unsignedToken({ sub: '1234567890', exp: 9876543210, iat: 1234567890 }),
+        participantToken: TOKENS.VALID_NO_NBF,
       }),
     );
     expect(isValid).toBe(true);

--- a/src/room/token-source/utils.ts
+++ b/src/room/token-source/utils.ts
@@ -7,19 +7,26 @@ const ONE_MINUTE_IN_MILLISECONDS = 60 * ONE_SECOND_IN_MILLISECONDS;
 
 export function isResponseTokenValid(response: TokenSourceResponse) {
   const jwtPayload = decodeTokenPayload(response.participantToken);
-  if (!jwtPayload?.nbf || !jwtPayload?.exp) {
-    return true;
+  // Missing exp: TokenSourceCached would otherwise return this response forever.
+  // nbf is optional (RFC 7519); do not skip the exp check when it is absent.
+  if (!jwtPayload?.exp) {
+    return false;
   }
 
   const now = new Date();
 
-  const nbfInMilliseconds = jwtPayload.nbf * ONE_SECOND_IN_MILLISECONDS;
-  const nbfDate = new Date(nbfInMilliseconds);
+  if (jwtPayload.nbf) {
+    const nbfInMilliseconds = jwtPayload.nbf * ONE_SECOND_IN_MILLISECONDS;
+    const nbfDate = new Date(nbfInMilliseconds);
+    if (nbfDate > now) {
+      return false;
+    }
+  }
 
   const expInMilliseconds = jwtPayload.exp * ONE_SECOND_IN_MILLISECONDS;
   const expDate = new Date(expInMilliseconds - ONE_MINUTE_IN_MILLISECONDS);
 
-  return nbfDate <= now && expDate > now;
+  return expDate > now;
 }
 
 /** Given a LiveKit generated participant token, decodes and returns the associated {@link TokenPayload} data. */


### PR DESCRIPTION
## Problem

`isResponseTokenValid` used `if (!nbf || !exp) return true`. Missing either claim skipped the rest of the check, so `TokenSourceCached` kept returning the cached response.

`nbf` is optional in RFC 7519. A JWT with `exp` in the past and no `nbf` was treated as still valid. A JWT with no `exp` was treated as never expired.

This is the client cache counterpart of livekit/protocol#1706, livekit/python-sdks#779, livekit/node-sdks#710, livekit/server-sdk-ruby#97, and livekit/server-sdk-kotlin#170. Those require `exp` on verify. This helper decides whether to refetch.

## Fix

Require `exp`. Check `nbf` only when it is present. Still apply the existing one-minute `exp` skew.

Threat-model: the cached participant token is already in the client. The attacker does not need host or TokenSource authority. An expired token that omits `nbf` (common) never triggers a refetch. A token that omits `exp` is cached forever. The server may still reject the JWT; the client never goes back to the token source.

## Test plan

- `pnpm exec vitest run src/room/token-source/utils.test.ts` (13/13)
- `pnpm test` (718/718)
- lint, format, typecheck, throws-check, build, compat, publint green locally
- Revert-tested: restoring `if (!nbf || !exp) return true` fails `should treat a jwt without exp as expired` and `should honor exp when nbf is absent`


Made with [Cursor](https://cursor.com)