### PR TITLE
fix: compare typeof against 'undefined' string in supportsAdaptiveStream

### DIFF
--- a/.changeset/supports-adaptive-stream-detection.md
+++ b/.changeset/supports-adaptive-stream-detection.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Fix `supportsAdaptiveStream` always returning `true` by comparing `typeof` against the `'undefined'` string. It now returns `false` in environments without `ResizeObserver` or `IntersectionObserver`.

--- a/src/room/utils.test.ts
+++ b/src/room/utils.test.ts
@@ -1,11 +1,12 @@
 import { ClientInfo_Capability } from '@livekit/protocol';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ddExtensionURI,
   extractMaxAgeFromRequestHeaders,
   getClientInfo,
   negotiateDependencyDescriptor,
   splitUtf8,
+  supportsAdaptiveStream,
   toWebsocketUrl,
 } from './utils';
 
@@ -255,5 +256,27 @@ describe('negotiateDependencyDescriptor', () => {
     const { transceiver } = transceiverWith([{ uri: ddExtensionURI, direction: 'stopped' }], true);
 
     expect(negotiateDependencyDescriptor(transceiver)).toBe(false);
+  });
+});
+
+describe('supportsAdaptiveStream', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports support where both observers exist', () => {
+    expect(supportsAdaptiveStream()).toBe(true);
+  });
+
+  it('reports no support where ResizeObserver is missing', () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+
+    expect(supportsAdaptiveStream()).toBe(false);
+  });
+
+  it('reports no support where IntersectionObserver is missing', () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+
+    expect(supportsAdaptiveStream()).toBe(false);
   });
 });

--- a/src/room/utils.ts
+++ b/src/room/utils.ts
@@ -58,7 +58,7 @@ export function supportsAddTrack() {
 }
 
 export function supportsAdaptiveStream() {
-  return typeof ResizeObserver !== undefined && typeof IntersectionObserver !== undefined;
+  return typeof ResizeObserver !== 'undefined' && typeof IntersectionObserver !== 'undefined';
 }
 
 export function supportsDynacast() {


### PR DESCRIPTION
## Problem

`supportsAdaptiveStream()` can only return `true`.

```js
return typeof ResizeObserver !== undefined && typeof IntersectionObserver !== undefined;
```

`typeof` always evaluates to a string, and a string is never `=== undefined`, so both operands
of `&&` are always true.

Nothing in `src/` calls this. The only references are the two re-exports in `src/index.ts`, so
it exists for consumers to call and the cost lands downstream:

```ts
const room = new Room({ adaptiveStream: supportsAdaptiveStream() });
```

On a runtime with neither observer, that returns `true`, adaptive stream reaches
`RemoteVideoTrack.attach()`, and `getIntersectionObserver()` / `getResizeObserver()` construct
unguarded. What should be "adaptive stream isn't available here" becomes a `ReferenceError` at
track-attach time, far from the call that caused it.

Thanks to @wanrut for the report and the diagnosis in #2058.

## Fix

Quote both operands, so each one asks whether the global exists.

I left `getResizeObserver` and `getIntersectionObserver` alone. Guarding those is defensible,
but it changes behaviour on the attach path and is a separate discussion from this typo.

## Tests

Three cases in the existing `src/room/utils.test.ts`. The unit environment is happy-dom, which
defines both observers, so the missing-global cases use `vi.stubGlobal(..., undefined)` with
`vi.unstubAllGlobals()` teardown. `typeof` on a global set to `undefined` yields `'undefined'`,
which is what the fix keys on.

- `pnpm test`: 721/721 across 47 files, up from 718/718 on `main`, no other test changed state
- `pnpm lint`: output byte-identical to `main` (0 errors, 13 pre-existing warnings)
- `pnpm format:check` and `pnpm type:check`: clean
- Revert-tested, once on purpose and once by accident. A partial revert mid-review left
  `ResizeObserver` unquoted while `IntersectionObserver` stayed quoted, and the matching case
  failed straight away while `git diff --stat` still showed the file as `1 1`.

Changeset included as a `patch`. It notes that the function can now return `false`, since
consumers gating on it under SSR, Node or older WebViews will start taking a branch they never
took before.

Neither `tsc --strict` nor the current eslint config catches this shape, so it can recur.
`'valid-typeof': ['error', { requireStringLiterals: true }]` would prevent it. I kept it out to
leave the diff on the bug, and I'm happy to open it separately.

Fixes #2058

