### PR TITLE
Add roomOptions.dataStream.maxPayloadByteLength

### DIFF
--- a/.changeset/puny-grapes-watch.md
+++ b/.changeset/puny-grapes-watch.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Add roomOptions.dataStream.maxPayloadByteLength to control max data stream size

--- a/src/options.ts
+++ b/src/options.ts
@@ -120,6 +120,30 @@ export interface InternalRoomOptions {
    * @default true
    */
   singlePeerConnection: boolean;
+
+  /**
+   * Options controlling data stream behavior for this room.
+   */
+  dataStream?: RoomDataStreamOptions;
+}
+
+/**
+ * Options controlling data stream behavior for a room.
+ */
+export interface RoomDataStreamOptions {
+  /**
+   * Maximum size, in bytes, of the payload this client accepts from a single incoming data stream.
+   *
+   * A compressed stream can inflate to an arbitrarily large payload, so the decompressed output is
+   * bounded rather than trusting the size declared on the wire. An incoming stream that exceeds the
+   * cap fails with a `DataStreamErrorReason.PayloadTooLarge` error on the next read instead of
+   * buffering without bound.
+   *
+   * This is enforced on the receiving side only: raising it on a sender has no effect.
+   *
+   * @default 5_000_000_000 (5 GB)
+   */
+  maxPayloadByteLength?: number;
 }
 
 /**

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -271,7 +271,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
     this.maybeCreateEngine();
 
-    this.incomingDataStreamManager = new IncomingDataStreamManager();
+    this.incomingDataStreamManager = new IncomingDataStreamManager(
+      this.options.dataStream?.maxPayloadByteLength,
+    );
     this.outgoingDataStreamManager = new OutgoingDataStreamManager(
       this.engine,
       this.log,


### PR DESCRIPTION
In the original data streams v2 pull request, it seems I forgot to wire this up as a user configurable option.