### PR TITLE
fix: enqueue signal requests until queue has been drained

### DIFF
--- a/.changeset/light-apes-eat.md
+++ b/.changeset/light-apes-eat.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: enqueue signal requests until queue has been drained

--- a/src/api/SignalClient.test.ts
+++ b/src/api/SignalClient.test.ts
@@ -619,6 +619,72 @@ describe('SignalClient.connect', () => {
     });
   });
 
+  describe('Held requests during a resume', () => {
+    /**
+     * Records the tracks whose mute requests reach the wire, in order. `mute` is session-scoped —
+     * it is absent from the pass-through list — so it is the class of request a resume holds.
+     * Filtered rather than counted, because keepalive traffic shares the transport.
+     */
+    function captureMutedTracks() {
+      const muted: Array<string> = [];
+      const writable = new WritableStream<ArrayBuffer | string>({
+        write(chunk) {
+          const request = SignalRequest.fromBinary(new Uint8Array(chunk as ArrayBuffer));
+          if (request.message?.case === 'mute') {
+            muted.push(request.message.value.sid);
+          }
+        },
+      });
+      return { muted, writable };
+    }
+
+    it('releases held requests before ones issued while the engine is still catching up', async () => {
+      mockWebSocketStream({
+        connection: createMockConnection(
+          createMockReadableStream([createSignalResponse('join', createJoinResponse())]),
+        ),
+      });
+      await signalClient.join('wss://test.livekit.io', 'test-token', defaultOptions);
+
+      const { muted, writable } = captureMutedTracks();
+      mockWebSocketStream({
+        connection: {
+          ...createMockConnection(
+            createMockReadableStream([
+              createSignalResponse('reconnect', new ReconnectResponse({ iceServers: [] })),
+            ]),
+          ),
+          writable,
+        },
+      });
+
+      const resuming = signalClient.reconnect('wss://test.livekit.io', 'test-token', 'sid-123');
+      expect(signalClient.currentState).toBe(SignalConnectionState.RECONNECTING);
+
+      // issued while the resume is in flight, so it waits rather than racing it
+      await signalClient.sendMuteTrack('held-during-resume', true);
+      expect(muted).toEqual([]);
+
+      await resuming;
+      expect(signalClient.currentState).toBe(SignalConnectionState.CONNECTED);
+
+      // The transport is back, but the engine has not called setReconnected yet — a resume is only
+      // complete once the media path is back too, which in a real session is seconds later. A
+      // request issued in that window must not overtake the one that has been waiting.
+      await signalClient.sendMuteTrack('issued-while-catching-up', true);
+      expect(muted).toEqual([]);
+
+      signalClient.setReconnected();
+      await signalClient.sendMuteTrack('issued-after-reconnected', true);
+
+      expect(muted).toEqual([
+        'held-during-resume',
+        'issued-while-catching-up',
+        'issued-after-reconnected',
+      ]);
+    });
+  });
+
   describe('Failure Case - Closed After Upgrade', () => {
     it('fails fast rather than waiting out the first-message timeout', async () => {
       // The upgrade succeeds and the server then closes without sending a join response. Nothing

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -917,7 +917,9 @@ export class SignalClient {
     // capture all requests while reconnecting and put them in a queue
     // unless the request originates from the queue, then don't enqueue again
     const canQueue = !fromQueue && !canPassThroughQueue(message);
-    if (canQueue && this.lifecycleState === 'reconnecting') {
+    const isHoldingRequests =
+      this.lifecycleState === 'reconnecting' || this.queuedRequests.length > 0;
+    if (canQueue && isHoldingRequests) {
       this.queuedRequests.push(async () => {
         await this.sendRequest(message, true);
       });


### PR DESCRIPTION
the gate for the signal queue is the `reconnecting` state of the signal layer. 
Queued signal requests only get flushed today when the engine calls `setReconnected` which happens _after_ also the media path has reconnected. This leaves a gap between signal reconnection and media reconnection in which new signal requests are sent directly even though there are still pending signal requests that have not been flushed yet.
