### PR TITLE
feat: Allow applying new constraints to a screen share

### DIFF
--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -19,10 +19,16 @@ import type { LoggerOptions } from '../types';
 import { isFireFox, isMobile, isSVCCodec, isWeb } from '../utils';
 import LocalTrack from './LocalTrack';
 import { Track, VideoQuality } from './Track';
-import type { TrackPublishOptions, VideoCaptureOptions, VideoCodec } from './options';
+import type {
+  ScreenShareCaptureOptions,
+  TrackPublishOptions,
+  VideoCaptureOptions,
+  VideoCodec,
+  VideoEncoding,
+} from './options';
 import { isBackupVideoCodec } from './options';
 import type { TrackProcessor } from './processor/types';
-import { constraintsForOptions } from './utils';
+import { constraintsForOptions, screenCaptureToDisplayMediaStreamOptions } from './utils';
 
 export class SimulcastTrackInfo {
   codec: VideoCodec;
@@ -282,6 +288,36 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
     // leave the sender's encoding parameters (scaleResolutionDownBy, maxBitrate, etc.)
     // based on the old dimensions. Recompute them so the encoded output matches the
     // new source.
+    await this.onSenderTrackSwapped();
+  }
+
+  async applyScreenShareConstraints(
+    constraints: Pick<ScreenShareCaptureOptions, 'resolution' | 'contentHint'>,
+    videoEncoding?: VideoEncoding,
+  ): Promise<void> {
+    // Only valid for screen shares
+    if (this.source !== Track.Source.ScreenShare) {
+      return;
+    }
+
+    const mediaTrackConstraints = screenCaptureToDisplayMediaStreamOptions(constraints);
+    if (typeof mediaTrackConstraints.video === 'boolean') {
+      return;
+    }
+
+    const unlock = await this.trackChangeLock.lock();
+    try {
+      await this.mediaStreamTrack.applyConstraints(mediaTrackConstraints.video);
+      if (videoEncoding && this.publishOptions) {
+        this.publishOptions.screenShareEncoding = videoEncoding;
+      }
+      if (constraints.contentHint) this.mediaStreamTrack.contentHint = constraints.contentHint;
+    } finally {
+      unlock();
+    }
+
+    // Since resolution or encoding might be different, recompute the sender's encoding
+    // parameters.
     await this.onSenderTrackSwapped();
   }
 

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -318,11 +318,11 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
 
     // Since resolution or encoding might be different, recompute the sender's encoding
     // parameters.
-    await this.onSenderTrackSwapped();
+    await this.onSenderTrackSwapped(true);
   }
 
-  protected override async onSenderTrackSwapped(): Promise<void> {
-    await this.refreshSenderEncodings();
+  protected override async onSenderTrackSwapped(ignoreDims = false): Promise<void> {
+    await this.refreshSenderEncodings(ignoreDims);
   }
 
   /**
@@ -331,7 +331,7 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
    * if the track hasn't been published yet or if the track is in performance-optimized
    * mode (which manages its own encodings).
    */
-  private async refreshSenderEncodings() {
+  private async refreshSenderEncodings(ignoreDims = false) {
     if (!this.sender || !this.publishOptions || this.optimizeForPerformance) {
       return;
     }
@@ -349,6 +349,7 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
       }
 
       if (
+        !ignoreDims &&
         this.lastEncodedDimensions &&
         this.lastEncodedDimensions.width === dims.width &&
         this.lastEncodedDimensions.height === dims.height

--- a/src/room/track/LocalVideoTrack.ts
+++ b/src/room/track/LocalVideoTrack.ts
@@ -301,15 +301,15 @@ export default class LocalVideoTrack extends LocalTrack<Track.Kind.Video> {
     }
 
     const mediaTrackConstraints = screenCaptureToDisplayMediaStreamOptions(constraints);
-    if (typeof mediaTrackConstraints.video === 'boolean') {
-      return;
+
+    if (videoEncoding && this.publishOptions) {
+      this.publishOptions.screenShareEncoding = videoEncoding;
     }
 
     const unlock = await this.trackChangeLock.lock();
     try {
-      await this.mediaStreamTrack.applyConstraints(mediaTrackConstraints.video);
-      if (videoEncoding && this.publishOptions) {
-        this.publishOptions.screenShareEncoding = videoEncoding;
+      if (typeof mediaTrackConstraints.video === 'object') {
+        await this.mediaStreamTrack.applyConstraints(mediaTrackConstraints.video);
       }
       if (constraints.contentHint) this.mediaStreamTrack.contentHint = constraints.contentHint;
     } finally {


### PR DESCRIPTION
Adds a function `applyScreenShareConstraints` to allow changing the resolution, content hint, and encoding of a screen share.

Utilizes the sender encoder refresh added in #1902 to refresh the encoding parameters after changing the encoding.