### PR TITLE
Address example imports being incorrect

### DIFF
--- a/.changeset/wet-kiwis-flash.md
+++ b/.changeset/wet-kiwis-flash.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Convert internal exports to be external in examples/demo

--- a/examples/demo/demo.ts
+++ b/examples/demo/demo.ts
@@ -5,6 +5,7 @@ import FrameMetadataWorker from '../../src/frameMetadata/worker/frameMetadata.wo
 import type {
   BackupVideoCodec,
   ChatMessage,
+  DataTrackFrame,
   LocalDataTrack,
   RemoteDataTrack,
   RoomConnectOptions,
@@ -33,6 +34,7 @@ import {
   RpcError,
   ScreenSharePresets,
   Track,
+  TrackEvent,
   TrackPublication,
   VideoPresets,
   VideoQuality,
@@ -42,14 +44,14 @@ import {
   isLocalTrack,
   isRemoteParticipant,
   isRemoteTrack,
+  isSVCCodec,
   isVideoTrack,
   setLogLevel,
   supportsAV1,
+  supportsH265,
   supportsVP9,
 } from '../../src/index';
-import type { DataTrackFrame } from '../../src/room/data-track/frame';
-import { TrackEvent } from '../../src/room/events';
-import { isSVCCodec, sleep, supportsH265 } from '../../src/room/utils';
+import { sleep } from '../../src/room/utils';
 import { enableMachineInspector } from '../../src/utils/machineInspector';
 import { machinePanelSawRoom, openMachinePanel } from './machinePanel';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,12 +53,14 @@ import {
   isLocalTrack,
   isRemoteParticipant,
   isRemoteTrack,
+  isSVCCodec,
   isVideoCodec,
   isVideoTrack,
   supportsAV1,
   supportsAdaptiveStream,
   supportsAudioOutputSelection,
   supportsDynacast,
+  supportsH265,
   supportsVP9,
 } from './room/utils';
 import { getBrowser } from './utils/browserParser';
@@ -149,12 +151,14 @@ export {
   supportsAdaptiveStream,
   supportsAudioOutputSelection,
   supportsDynacast,
+  supportsH265,
   supportsVP9,
   Mutex,
   isAudioCodec,
   isAudioTrack,
   isLocalTrack,
   isRemoteTrack,
+  isSVCCodec,
   isVideoCodec,
   isVideoTrack,
   isLocalParticipant,
@@ -180,6 +184,7 @@ export type {
   DataTrackSubscribeOptions,
   RemoteDataTrackPipelineOptions,
 };
+export { type DataTrackFrame } from './room/data-track/frame';
 export { DataTrackPacket, type DataTrackPacketHeader } from './room/data-track/packet';
 export {
   type DataTrackExtensions,


### PR DESCRIPTION
closes https://github.com/livekit/client-sdk-js/issues/2066
The `examples/demo` demo app was importing a few types/values which `livekit-client` didn't export globally. This fixes that - `livekit-client` now exports these types/values, and the example now uses these.