### PR TITLE
fix: track ws close with attemptId

### DIFF
--- a/.changeset/brave-days-show.md
+++ b/.changeset/brave-days-show.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: track ws close with attemptId

--- a/src/api/SignalClient.ts
+++ b/src/api/SignalClient.ts
@@ -667,6 +667,7 @@ export class SignalClient {
     if (firstMessage) {
       this.handleSignalResponse(firstMessage);
     }
+    const attemptId = this.attemptId;
     while (true) {
       if (this.signalLatency) {
         await sleep(this.signalLatency);
@@ -680,7 +681,7 @@ export class SignalClient {
         this.handleSignalResponse(resp);
       } catch (e) {
         this.log.error(`error reading from signal stream`, { error: e });
-        await this.close(false, 'error in reading loop');
+        await this.handleOnClose('error in reading loop', attemptId);
         break;
       }
     }


### PR DESCRIPTION
while unlikely, previously it could have happened that `this.close(...)` would have torn down a new signal connection. 