### PR TITLE
fix: add code 1000 to onclose handler in WebSocketStream

### DIFF
--- a/.changeset/short-dragons-look.md
+++ b/.changeset/short-dragons-look.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: add code 1000 to onclose handler in WebSocketStream

--- a/src/api/WebSocketStream.ts
+++ b/src/api/WebSocketStream.ts
@@ -76,7 +76,7 @@ export class WebSocketStream<T extends ArrayBuffer | string = ArrayBuffer | stri
                   ),
                 );
               ws.onclose = (ev) => {
-                if (ev.wasClean) {
+                if (ev.wasClean || ev.code === 1000) {
                   controller.close();
                 } else {
                   controller.error(


### PR DESCRIPTION
React Native's WebSocket never sets wasClean (react-native:267), so livekit-client treats every close as unexpected — even the normal code-1000 close that happens on disconnect. On web wasClean is set, so it's silent; on mobile it logs WS closed unexpectedly with code 1000 + error reading from signal stream.