### PR TITLE
fix: don't reset mid track map on publisher answers with empty map

### DIFF
--- a/.changeset/stale-regions-say.md
+++ b/.changeset/stale-regions-say.md
@@ -1,0 +1,5 @@
+---
+"livekit-client": patch
+---
+
+fix: don't reset mid track map on publisher answers with empty map

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -663,7 +663,11 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
         sdp: sd.sdp,
         midToTrackId,
       });
-      this.midToTrackId = midToTrackId;
+      // in dual PC mode the publisher answer carries no mapping (the server's publisher
+      // transport has no sending tracks) and must not clobber the subscriber offer mapping
+      if (Object.keys(midToTrackId).length > 0) {
+        this.midToTrackId = midToTrackId;
+      }
       await this.pcManager.setPublisherAnswer(sd, offerId);
     };
 


### PR DESCRIPTION
chrome 154 doesn't guarantee the track Id to conform to the `TR_*` name, so we need the fallback to the mid to trackId map. 
This PR ensures we're not overriding the map with an empty one in dual PC on the publisher's answer. 