### PR TITLE
fix: only apply map update in singlePC mode on answer

### DIFF
--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -665,7 +665,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       });
       // in dual PC mode the publisher answer carries no mapping (the server's publisher
       // transport has no sending tracks) and must not clobber the subscriber offer mapping
-      if (Object.keys(midToTrackId).length > 0) {
+      if (this.options.singlePeerConnection) {
         this.midToTrackId = midToTrackId;
       }
       await this.pcManager.setPublisherAnswer(sd, offerId);

--- a/src/room/RTCEngine.ts
+++ b/src/room/RTCEngine.ts
@@ -665,7 +665,7 @@ export default class RTCEngine extends (EventEmitter as new () => TypedEventEmit
       });
       // in dual PC mode the publisher answer carries no mapping (the server's publisher
       // transport has no sending tracks) and must not clobber the subscriber offer mapping
-      if (this.options.singlePeerConnection) {
+      if (this.pcManager.mode === 'publisher-only') {
         this.midToTrackId = midToTrackId;
       }
       await this.pcManager.setPublisherAnswer(sd, offerId);


### PR DESCRIPTION
follow up to #2089. the previous PR was gating on the map size which - in the singlePC - case is the wrong condition as it needs to be able to be reset to an empty state. 

Instead gate on whether or not singlePC mode is enabled.