### PR TITLE
Reconcile the participant roster after a signal resume

### DIFF
--- a/.changeset/resume-roster-reconciliation.md
+++ b/.changeset/resume-roster-reconciliation.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Reconcile the participant roster after a signal resume, removing remote participants that left while the signal connection was down

--- a/src/e2ee/subscriberBlackScreen.test.ts
+++ b/src/e2ee/subscriberBlackScreen.test.ts
@@ -103,13 +103,7 @@ function setupRoomWithE2EE() {
     }
   ).getOrCreateParticipant('jake', new ParticipantInfo({ sid: 'PA_jake', identity: 'jake' }));
 
-  const trackInfo = new TrackInfo({
-    sid: 'TR_video',
-    type: TrackType.VIDEO,
-    name: 'camera',
-    mimeType: 'video/h264',
-    encryption: Encryption_Type.GCM,
-  });
+  const trackInfo = jakeTrackInfo();
   const publication = new RemoteTrackPublication(Track.Kind.Video, trackInfo, true);
   // addTrackPublication is what wires TrackEvent.Subscribed -> ParticipantEvent.TrackSubscribed
   (
@@ -124,6 +118,27 @@ function setupRoomWithE2EE() {
   const unsubscribe = () => publication.setTrack(undefined);
 
   return { room, worker, publication, receiver, subscribe, unsubscribe };
+}
+
+function jakeTrackInfo() {
+  return new TrackInfo({
+    sid: 'TR_video',
+    type: TrackType.VIDEO,
+    name: 'camera',
+    mimeType: 'video/h264',
+    encryption: Encryption_Type.GCM,
+  });
+}
+
+/**
+ * The server replays the full participant roster after the ReconnectResponse; Room reconciles
+ * against it to drop participants that left while the link was down, so a resume simulation has
+ * to include it or jake gets (correctly) evicted.
+ */
+function replayRosterDuringResume(room: Room) {
+  room.engine.emit(EngineEvent.ParticipantUpdate, [
+    new ParticipantInfo({ sid: 'PA_jake', identity: 'jake', tracks: [jakeTrackInfo()] }),
+  ]);
 }
 
 describe('subscriber black screen', () => {
@@ -164,6 +179,7 @@ describe('subscriber black screen', () => {
 
       // signal comes back: Room.ts:642 throws the buffered events away...
       room.engine.emit(EngineEvent.SignalResumed);
+      replayRosterDuringResume(room);
       // ...so the flush on Resumed has nothing left to flush.
       room.engine.emit(EngineEvent.Resumed);
 
@@ -188,6 +204,7 @@ describe('subscriber black screen', () => {
       subscribe();
       unsubscribe();
       room.engine.emit(EngineEvent.SignalResumed);
+      replayRosterDuringResume(room);
       room.engine.emit(EngineEvent.Resumed);
 
       // CURRENTLY FAILS with ['unsubscribed']: subscribe is buffered then

--- a/src/room/Room.test.ts
+++ b/src/room/Room.test.ts
@@ -385,6 +385,16 @@ describe('participant roster reconciliation after resume', () => {
     expect([...room.remoteParticipants.keys()]).toEqual(['alice', 'bob']);
   });
 
+  it('keeps participants that joined during the resume', () => {
+    const room = setupConnectedRoom('alice');
+
+    room.engine.emit(EngineEvent.Resuming);
+    pushUpdate(room, info('alice'), info('dave'));
+    room.engine.emit(EngineEvent.Resumed);
+
+    expect([...room.remoteParticipants.keys()]).toEqual(['alice', 'dave']);
+  });
+
   it('emits ParticipantDisconnected before Reconnected', () => {
     const room = setupConnectedRoom('alice', 'bob');
 
@@ -397,5 +407,30 @@ describe('participant roster reconciliation after resume', () => {
     room.engine.emit(EngineEvent.Resumed);
 
     expect(order).toEqual(['disconnected:bob', 'reconnected']);
+  });
+
+  it('does not reconcile against updates received outside of a resume', () => {
+    const room = setupConnectedRoom('alice', 'bob');
+
+    // a routine partial update (e.g. alice changed metadata) must not evict bob
+    pushUpdate(room, info('alice'));
+
+    expect([...room.remoteParticipants.keys()]).toEqual(['alice', 'bob']);
+  });
+
+  it('does not evict participants when the resume escalates to a full reconnect', () => {
+    const room = setupConnectedRoom('alice', 'bob');
+
+    room.engine.emit(EngineEvent.Resuming);
+    pushUpdate(room, info('alice'));
+    // resume failed; the engine falls back to a full reconnect, which rebuilds from the
+    // JoinResponse instead — the abandoned resume's roster must not be applied later
+    room.engine.emit(EngineEvent.Restarting);
+    expect(room.remoteParticipants.size).toBe(0);
+
+    pushUpdate(room, info('alice'), info('bob'));
+    room.engine.emit(EngineEvent.Resumed);
+
+    expect([...room.remoteParticipants.keys()]).toEqual(['alice', 'bob']);
   });
 });

--- a/src/room/Room.test.ts
+++ b/src/room/Room.test.ts
@@ -1,6 +1,8 @@
 import {
   ClientInfo_Capability,
   JoinResponse,
+  ParticipantInfo,
+  ParticipantInfo_State,
   StreamState as ProtoStreamState,
   StreamStateUpdate,
   SubscriptionError,
@@ -319,5 +321,81 @@ describe('stream state updates', () => {
 
     expect(roomEvents).not.toHaveBeenCalled();
     expect(participantEvents).not.toHaveBeenCalled();
+  });
+});
+
+describe('participant roster reconciliation after resume', () => {
+  const rooms: Room[] = [];
+
+  afterEach(() => {
+    while (rooms.length > 0) {
+      const room = rooms.pop()!;
+      // the Resumed handler starts a reconcile interval; don't leak it across tests
+      (room as unknown as { clearConnectionReconcile(): void }).clearConnectionReconcile();
+    }
+  });
+
+  function info(identity: string) {
+    return new ParticipantInfo({
+      sid: `PA_${identity}`,
+      identity,
+      state: ParticipantInfo_State.ACTIVE,
+    });
+  }
+
+  function pushUpdate(room: Room, ...infos: ParticipantInfo[]) {
+    room.engine.emit(EngineEvent.ParticipantUpdate, infos);
+  }
+
+  /** A connected room with the given remote participants already in the roster. */
+  function setupConnectedRoom(...identities: string[]) {
+    const room = new Room();
+    rooms.push(room);
+    room.state = ConnectionState.Connected;
+    pushUpdate(room, ...identities.map(info));
+    expect([...room.remoteParticipants.keys()]).toEqual(identities);
+    return room;
+  }
+
+  it('removes participants that left while the signal connection was down', () => {
+    const room = setupConnectedRoom('alice', 'bob');
+
+    const disconnected = vi.fn();
+    room.on(RoomEvent.ParticipantDisconnected, disconnected);
+
+    room.engine.emit(EngineEvent.Resuming);
+    // server replays the full roster after the ReconnectResponse — bob left while we were down
+    pushUpdate(room, info('alice'));
+    room.engine.emit(EngineEvent.Resumed);
+
+    expect([...room.remoteParticipants.keys()]).toEqual(['alice']);
+    expect(disconnected).toHaveBeenCalledTimes(1);
+    expect(disconnected.mock.calls[0][0].identity).toBe('bob');
+  });
+
+  it('accumulates identities across updates interleaved during the resume', () => {
+    const room = setupConnectedRoom('alice', 'bob', 'carol');
+
+    room.engine.emit(EngineEvent.Resuming);
+    // the roster snapshot can arrive split across several batched updates
+    pushUpdate(room, info('alice'));
+    pushUpdate(room, info('bob'));
+    room.engine.emit(EngineEvent.Resumed);
+
+    expect([...room.remoteParticipants.keys()]).toEqual(['alice', 'bob']);
+  });
+
+  it('emits ParticipantDisconnected before Reconnected', () => {
+    const room = setupConnectedRoom('alice', 'bob');
+
+    const order: string[] = [];
+    room.on(RoomEvent.ParticipantDisconnected, (p) => order.push(`disconnected:${p.identity}`));
+    room.on(RoomEvent.Reconnected, () => order.push('reconnected'));
+
+    room.engine.emit(EngineEvent.Resuming);
+    pushUpdate(room, info('alice'));
+    room.engine.emit(EngineEvent.Resumed);
+
+    expect(order).toEqual(['disconnected:bob', 'reconnected']);
   });
 });

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -225,6 +225,16 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
 
   private isResuming: boolean = false;
 
+  /**
+   * Identities seen in participant updates since the current resume started, or `undefined` when
+   * no resume is in progress. A resume — unlike a full reconnect — never rebuilds the roster from
+   * a `JoinResponse`, and `DISCONNECTED` updates for participants who left while the signal link
+   * was down went to a socket we no longer had. The server replays the roster after the
+   * `ReconnectResponse`, but it can interleave batched updates around it, so no single update is
+   * identifiable as the snapshot — we accumulate the union and reconcile once the resume settles.
+   */
+  private resumeSeenIdentities?: Set<string>;
+
   private pendingTrackAddedCallbacks = new Map<Track.SID, Set<() => void>>();
 
   /**
@@ -634,6 +644,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
       .on(EngineEvent.Resuming, () => {
         this.clearConnectionReconcile();
         this.isResuming = true;
+        this.resumeSeenIdentities = new Set();
         this.log.debug('Resuming signal connection');
         if (this.setAndEmitConnectionState(ConnectionState.SignalReconnecting)) {
           this.emit(RoomEvent.SignalReconnecting);
@@ -643,6 +654,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         this.registerConnectionReconcile();
         this.isResuming = false;
         this.log.debug('Resumed signal connection');
+        this.reconcileParticipantsAfterResume();
         this.updateSubscriptions();
         if (this.setAndEmitConnectionState(ConnectionState.Connected)) {
           this.emit(RoomEvent.Reconnected);
@@ -1785,6 +1797,9 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     this.clearConnectionReconcile();
     // in case we went from resuming to full-reconnect, make sure to reflect it on the isResuming flag
     this.isResuming = false;
+    // a full reconnect rebuilds the roster from the JoinResponse, so the abandoned resume's
+    // partial view of it must not be applied afterwards
+    this.resumeSeenIdentities = undefined;
 
     // also unwind existing participants & existing subscriptions
     for (const p of this.remoteParticipants.values()) {
@@ -1832,6 +1847,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
   private handleDisconnect(shouldStopTracks = true, reason?: DisconnectReason) {
     this.clearConnectionReconcile();
     this.isResuming = false;
+    this.resumeSeenIdentities = undefined;
     this.bufferedEvents = [];
     this.transcriptionReceivedTimes.clear();
     this.incomingDataStreamManager.clearControllers();
@@ -1921,6 +1937,8 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         info.identity = this.sidToIdentity.get(info.sid) ?? '';
       }
 
+      this.resumeSeenIdentities?.add(info.identity);
+
       let remoteParticipant = this.remoteParticipants.get(info.identity);
 
       // when it's disconnected, send updates
@@ -1948,6 +1966,30 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
     );
     this.incomingDataTrackManager.receiveSfuPublicationUpdates(mapped);
   };
+
+  /**
+   * Synthesizes disconnects for remote participants that the server didn't mention in any
+   * participant update during a resume — they left while the signal connection was down, so their
+   * `DISCONNECTED` update never reached us. Called before `RoomEvent.Reconnected` is emitted so
+   * consumers never observe a reconnected room with a stale roster.
+   */
+  private reconcileParticipantsAfterResume() {
+    const seenIdentities = this.resumeSeenIdentities;
+    this.resumeSeenIdentities = undefined;
+    if (!seenIdentities) {
+      return;
+    }
+
+    for (const [identity, participant] of [...this.remoteParticipants]) {
+      if (!seenIdentities.has(identity)) {
+        this.log.debug(
+          `removing participant ${identity} absent from the roster replayed after resume`,
+          this.logContext,
+        );
+        this.handleParticipantDisconnected(identity, participant);
+      }
+    }
+  }
 
   private handleParticipantDisconnected(
     identity: string,


### PR DESCRIPTION
> [!WARNING]
> This pull request was LLM generated and has only been lightly reviewed by Ryan. @xianshijing-lk had asked I port this fix to the web sdk but I haven't done a deep dive on the specific issue, and beyond running the LLM generated tests have not actually exercised this yet.
> 
> A more thorough review of this needs to occur before it could be merged.

## The problem

The SDK keeps remote participants that are no longer in the room. This occurs after a signal resume. A node migration or a short signal failure causes a resume.

The server sends a `DISCONNECTED` update for each participant that leaves. The SDK does not get this update if the signal connection is down at that time. A full reconnect corrects this, because the SDK builds the roster again from the `JoinResponse`. A resume does not build the roster again. Therefore the participants stay in `room.remoteParticipants` for an unlimited time.

CLT-3322 changed the migration procedure. A migration now does a resume and not a full reconnect. Before that change, the full reconnect removed all participants and thus hid this defect.

## The change

`Room` keeps a record of each identity in the participant updates during a resume. At the end of the resume, `Room` removes each remote participant that is not in that record. `Room` sends a `ParticipantDisconnected` event for each participant that it removes.

The record is a union of all of the updates in the resume. The server sends the full participant list after the `ReconnectResponse`. But the server can also send other updates immediately before and after that list. Therefore one update alone is not sufficient.

`Room` does this procedure before it calls `updateSubscriptions()` and before it sends the `Reconnected` event. Thus the SDK does not subscribe again to the tracks of a participant that left. Thus an application also does not see a stale roster in a reconnected room.

`Room` discards the record if the resume becomes a full reconnect, and also at a disconnect.

This change is equivalent to the mechanism in the Rust SDK (`rtc_session.rs::finish_resume` and `room/mod.rs::reconcile_absent_participants`).

## The tests

`Room.test.ts` has six new tests. Three of these tests fail before the change:

- The SDK removes a participant that left while the signal connection was down.
- The SDK collects the identities from updates that the server sends at different times in the resume.
- The SDK sends `ParticipantDisconnected` before `Reconnected`.

Three more tests pass before and after the change. These tests show the limits of the new procedure:

- The SDK keeps a participant that joins during the resume.
- The SDK removes no participant if there is no resume.
- The SDK does not use the roster of a resume that became a full reconnect.

`subscriberBlackScreen.test.ts` simulates a resume in two tests. These simulations did not include a participant update. A server always sends the participant list after a resume. The first commit corrects these two simulations. The assertions stay the same.

## Attention for the reviewer

The new procedure has no gate on the server version. If a server does not send the participant list after a resume, the SDK removes all remote participants. The Rust SDK has the same behavior. CLT-3323 records this behavior of the server.

## The commits

Read the commits in this sequence:

1. `test(e2ee)` — correct the two resume simulations. Read this commit quickly.
2. `fix(room)` — 42 lines. This is the full change in behavior. **Give your full attention to this commit.**
3. `test(room)` — the three tests that fail before commit 2.
4. `test(room)` — the three tests that show the limits.
5. `chore` — the changeset.

## Verification

- `npx tsc --noEmit` gives no error.
- `npx vitest run --exclude 'smoke-tests/**'` gives 818 tests that pass and 1 test that the runner skips. The `smoke-tests/` suite does not run, because `@playwright/test` is not available. This suite also does not run on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
