### PR TITLE
fix: fail over to other regions when Cloud rejects a connection with 403

### DIFF
--- a/.changeset/region-pinning-403-failover.md
+++ b/.changeset/region-pinning-403-failover.md
@@ -1,0 +1,5 @@
+---
+'livekit-client': patch
+---
+
+Retry against other LiveKit Cloud regions when the initial connection is rejected with 403. Cloud signals project-level region pinning with a 403 on the RTC paths, which was previously treated as terminal, so a client that geo-routed to a disallowed region never reached `/settings/regions` and failed to connect. 401 and the 404 "room does not exist" case remain terminal.

--- a/src/room/Room.ts
+++ b/src/room/Room.ts
@@ -77,6 +77,7 @@ import {
   ConnectionErrorReason,
   UnexpectedConnectionState,
   UnsupportedServer,
+  canFailOverToAnotherRegion,
 } from './errors';
 import { EngineEvent, ParticipantEvent, RoomEvent, TrackEvent } from './events';
 import LocalParticipant from './participant/LocalParticipant';
@@ -908,8 +909,7 @@ class Room extends (EventEmitter as new () => TypedEmitter<RoomEventCallbacks>) 
         if (
           this.regionUrlProvider &&
           error instanceof ConnectionError &&
-          error.reason !== ConnectionErrorReason.Cancelled &&
-          error.reason !== ConnectionErrorReason.NotAllowed
+          canFailOverToAnotherRegion(error)
         ) {
           let nextUrl: string | null = null;
           try {

--- a/src/room/errors.test.ts
+++ b/src/room/errors.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { ConnectionError, canFailOverToAnotherRegion } from './errors';
+
+describe('canFailOverToAnotherRegion', () => {
+  it('allows failover on 403, which LiveKit Cloud uses to signal region pinning', () => {
+    // The RTC paths 403 when the project is not allowed in the region the client geo-routed to.
+    // `/settings/regions` stays reachable so the client can discover where it is allowed.
+    expect(
+      canFailOverToAnotherRegion(
+        ConnectionError.notAllowed('project not allowed in this region.', 403),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not allow failover on 401 — no other region will accept the same token', () => {
+    expect(canFailOverToAnotherRegion(ConnectionError.notAllowed('unauthorized', 401))).toBe(false);
+  });
+
+  it('does not allow failover when the room does not exist, reported as NotAllowed with 404', () => {
+    expect(
+      canFailOverToAnotherRegion(ConnectionError.notAllowed('requested room does not exist', 404)),
+    ).toBe(false);
+  });
+
+  it('does not allow failover on a cancelled attempt', () => {
+    expect(canFailOverToAnotherRegion(ConnectionError.cancelled('aborted'))).toBe(false);
+  });
+
+  it.each([
+    ['server unreachable', ConnectionError.serverUnreachable('unreachable')],
+    ['timeout', ConnectionError.timeout('timed out')],
+    ['internal', ConnectionError.internal('internal')],
+  ])('allows failover on a %s error', (_name, error) => {
+    expect(canFailOverToAnotherRegion(error)).toBe(true);
+  });
+});

--- a/src/room/errors.ts
+++ b/src/room/errors.ts
@@ -188,6 +188,33 @@ export class ConnectionError<
   }
 }
 
+/**
+ * Whether a failed connection attempt may be retried against a different LiveKit Cloud region.
+ *
+ * LiveKit Cloud signals project-level region pinning by returning 403 on the RTC paths when the
+ * project is not allowed in the region the client geo-routed to. `/settings/regions` is
+ * deliberately left reachable so the client can discover its allowed regions and connect there, so
+ * a 403 must not be treated as terminal.
+ *
+ * A 401 stays terminal: no other region will accept a token this one rejected. So does the 404
+ * "requested room does not exist" case, which is also reported as `NotAllowed`.
+ *
+ * We key on the status rather than the server's error message because that message is an
+ * unversioned human-readable string; matching it would let a copy edit break already-shipped
+ * clients. If a 403 really was a permissions failure rather than region pinning, every region
+ * attempt fails the same way and the original error still surfaces — at the cost of one extra
+ * region lookup.
+ */
+export function canFailOverToAnotherRegion(error: ConnectionError): boolean {
+  if (error.reason === ConnectionErrorReason.Cancelled) {
+    return false;
+  }
+  if (error.reason === ConnectionErrorReason.NotAllowed) {
+    return error.status === 403;
+  }
+  return true;
+}
+
 export class DeviceUnsupportedError extends LivekitError {
   readonly name = 'DeviceUnsupportedError';
 


### PR DESCRIPTION
Part of CLT-3325. Companion PRs: [client-sdk-flutter](https://github.com/livekit/client-sdk-flutter), [client-sdk-swift](https://github.com/livekit/client-sdk-swift).

## Problem

LiveKit Cloud enforces project-level region pinning by returning **403 on the RTC paths** (`/rtc`, `/rtc/validate`) when a project is not allowed in the region the client geo-routed to. `/settings/regions` is deliberately excluded from that gate so the client can discover its allowed regions and connect there — per the server-side comment, *"allow other APIs to pass because clients will permanently give up if they fail."*

`Room.connect` excluded **every** `NotAllowed` error from region failover:

```ts
error.reason !== ConnectionErrorReason.NotAllowed
```

and `handleConnectionError` maps both 401 **and** 403 to `notAllowed` (`SignalClient.ts:1290-1292`). So a pinned project that geo-routed to a disallowed region gave up before ever fetching the region list, and never reached the region it was allowed in.

## Fix

Extract the decision into `canFailOverToAnotherRegion` and key it on the HTTP status:

- **403 → retry other regions.** This is the region-pinning signal.
- **401 → terminal.** No other region will accept a token this one rejected.
- **404 "requested room does not exist" → terminal.** Also reported as `NotAllowed`.
- Cancelled → terminal, unchanged. Everything else → retry, unchanged.

### Why status and not the error message

The server's body for this case is `"project not allowed in this region."`, but that is an unversioned human-readable string. Matching it would mean five SDKs carrying identical literals forever, and a server-side copy edit — dropping the period, rewording — would silently break already-shipped clients. Browser clients can be refreshed; mobile ones cannot.

The cost of not discriminating is bounded: if a 403 really was a permissions failure, every region attempt fails the same way and the original error still surfaces, one region lookup later. A genuinely bad token is capped tighter still — `/settings/regions` returns 401 for it, and the existing handler already bails on that (`Room.ts:908-916`).

## Cross-SDK status

This bug is not universal. Rust and Android already fail over on any non-cancellation error and are unaffected; JS, Flutter and Swift all bail. Agents SDKs route through the Rust core, so **agents are unaffected**.

## Testing

`src/room/errors.test.ts` covers the predicate directly (7 assertions, passing). Typecheck is clean for the touched files — the two pre-existing `tsc` errors in `SignalClient.ts` / `SignalClientStateMachine.ts` come from the missing `machina` dependency on `main` and are untouched by this change.

## Open question

How often the RTC 403 actually fires for pinned projects has **not** been confirmed with the Cloud team — geo-routing may normally land clients in-region, making this an edge case (bad GeoDNS, anycast flap, VPN). The opt-in `prepareConnection()` warm-up also does region selection up front and would mask it for apps that call it. The fix is correct either way and works against today's servers, but severity is unconfirmed.

Separately worth pursuing server-side: a structured discriminator — ideally a header carrying the allowed region URL — would both remove the ambiguity and let clients skip the `/settings/regions` round trip entirely. It must stay advisory so clients can keep this status-based fallback for older servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)